### PR TITLE
Use custom (de)serialization for `points`/`selection`

### DIFF
--- a/js/src/codecs.js
+++ b/js/src/codecs.js
@@ -19,7 +19,6 @@ class NumpyCodec {
   }
 }
 
-
 class Numpy2D extends NumpyCodec {
 
   /**
@@ -54,7 +53,6 @@ class Numpy2D extends NumpyCodec {
   }
 }
 
-  
 class Numpy1D extends NumpyCodec {
 
   /**

--- a/js/src/codecs.js
+++ b/js/src/codecs.js
@@ -1,0 +1,80 @@
+const DTYPES = {
+  uint8: Uint8Array,
+  int8: Int8Array,
+  uint16: Uint16Array,
+  int16: Int16Array,
+  uint32: Uint32Array,
+  int32: Int32Array,
+  float32: Float32Array,
+  float64: Float64Array,
+};
+
+class NumpyCodec {
+  /** @param {keyof typeof DTYPES} dtype */
+  constructor(dtype) {
+    if (!(dtype in DTYPES)) {
+      throw Error(`Dtype not supported, got ${JSON.stringify(dtype)}.`);
+    }
+    this.dtype = dtype;
+  }
+}
+
+
+class Numpy2D extends NumpyCodec {
+
+  /**
+   * @param {{buffer: DataView, dtype: keyof typeof DTYPES, shape: [number, number]}} data
+   * @returns {number[][]}
+   */
+  deserialize(data) {
+    if (data == null) return null;
+    // Take full view of data buffer
+    const arr = new DTYPES[this.dtype](data.buffer.buffer);
+    // Chunk single TypedArray into nested Array of points
+    const [height, width] = data.shape;
+    // Float32Array(width * height) -> [Array(width), Array(width), ...]
+    const points = Array
+      .from({ length: height })
+      .map((_, i) => Array.from(arr.subarray(i * width, (i + 1) * width)));
+    return points;
+  }
+
+  /**
+   * @param {number[][]} data
+   * @returns {{data: ArrayBuffer, dtype: keyof typeof DTYPES, shape: [number, number]}}
+   */
+  serialize(data) {
+    const height = data.length;
+    const width = data[0].length;
+    const arr = new DTYPES[this.dtype](height * width);
+    for (let i = 0; i < data.length; i++) {
+      arr.set(data[i], i * height);
+    }
+    return { data: arr.buffer, dtype: this.dtype, shape: [height, width] };
+  }
+}
+
+  
+class Numpy1D extends NumpyCodec {
+
+  /**
+   * @param {{buffer: DataView, dtype: keyof typeof DTYPES, shape: [number]}} data
+   * @returns {number[]}
+   */
+  deserialize(data) {
+    if (data == null) return null;
+    // for some reason can't be a typed array
+    return Array.from(new DTYPES[this.dtype](data.buffer.buffer));
+  }
+
+  /**
+   * @param {number[]} data
+   * @returns {{data: ArrayBuffer, dtype: keyof typeof DTYPES, shape: [number]}}
+   */
+  serialize(data) {
+    const arr = new DTYPES[this.dtype](data)
+    return { data: arr.buffer, dtype: this.dtype, shape: [data.length] };
+  }
+}
+
+module.exports = { Numpy1D, Numpy2D };

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -6,8 +6,15 @@ const packageJson = require('../package.json');
 const createScatterplot = reglScatterplot.default;
 
 const pointsCodec = {
+  /**
+   * @param {{buffer: DataView, dtype: string, shape: number[]}} data
+   * @returns {number[][]}
+   */
   deserialize(data) {
     if (data == null) return null;
+    if (data.dtype !== 'float32' || data.shape.length !== 2) {
+      throw Error('Must be 2D Float32 array.');
+    }
     // Take full view of data buffer
     const arr = new Float32Array(data.buffer.buffer);
     // Chunk single TypedArray into nested Array of points
@@ -18,6 +25,10 @@ const pointsCodec = {
       .map((_, i) => Array.from(arr.subarray(i * width, (i + 1) * width)));
      return points;
   },
+  /**
+   * @param {number[][]} data
+   * @returns {{data: ArrayBuffer, dtype: 'float32', shape: [number, number]}}
+   */
   serialize(data) {
     const height = data.length;
     const width = data[0].length;
@@ -30,11 +41,22 @@ const pointsCodec = {
 }
 
 const selectionCodec = {
+  /**
+   * @param {{data: DataView, dtype: string, shape: number[]}} data
+   * @returns {number[]}
+   */
   deserialize(data) {
     if (data == null) return null;
+    if (data.dtype !== 'int32' || data.shape.length !== 1) {
+      throw Error('Must be 1D Int32 array.');
+    }
     // for some reason can't be a typed array
     return Array.from(new Int32Array(data.buffer.buffer));
   },
+  /**
+   * @param {number[]} data
+   * @returns {{data: ArrayBuffer, dtype: 'int32', shape: [number]}}
+   */
   serialize(data) {
     data = new Int32Array(data)
     return { data: data.buffer, dtype: 'int32', shape: [data.length] };

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -12,10 +12,10 @@ const pointsCodec = {
     const arr = new Float32Array(data.buffer.buffer);
     // Chunk single TypedArray into nested Array of points
     const [height, width] = data.shape;
-    // Float32Array(width * height) -> [Float32Array(width), Float32Array(width), ...]
+    // Float32Array(width * height) -> [Array(width), Array(width), ...]
     const points = Array
       .from({ length: height })
-      .map((_, i) => arr.subarray(i * width, (i + 1) * width));
+      .map((_, i) => Array.from(arr.subarray(i * width, (i + 1) * width)));
      return points;
   },
   serialize(data) {

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -5,30 +5,20 @@ const packageJson = require('../package.json');
 
 const createScatterplot = reglScatterplot.default;
 
-const numpy2D = {
-
+const pointsCodec = {
   deserialize(data) {
-    console.log('2D - deserialize', data);
     if (data == null) return null;
-    if (data.shape.length !== 2) {
-      console.error('Array must be 2D.')
-    }
-
     // Take full view of data buffer
     const arr = new Float32Array(data.buffer.buffer);
-
     // Chunk single TypedArray into nested Array of points
     const [height, width] = data.shape;
     // Float32Array(width * height) -> [Float32Array(width), Float32Array(width), ...]
     const points = Array
       .from({ length: height })
       .map((_, i) => arr.subarray(i * width, (i + 1) * width));
-
      return points;
   },
-
   serialize(data) {
-    console.log('2D - serialize', data);
     const height = data.length;
     const width = data[0].length;
     const arr = new Float32Array(height * width);
@@ -39,26 +29,16 @@ const numpy2D = {
   }
 }
 
-const numpy1D = {
-
+const selectionCodec = {
   deserialize(data) {
-    console.log('1D - deserialize', data);
     if (data == null) return null;
-
-    if (data.shape.length !== 1) {
-      console.error('Array must be 1D.')
-      return [];
-    }
-
+    // for some reason can't be a typed array
     return Array.from(new Int32Array(data.buffer.buffer));
   },
-
   serialize(data) {
     data = new Int32Array(data)
-    console.log('1D - serialize', data);
     return { data: data.buffer, dtype: 'int32', shape: [data.length] };
   }
-
 }
 
 const JupyterScatterModel = widgets.DOMWidgetModel.extend(
@@ -76,8 +56,8 @@ const JupyterScatterModel = widgets.DOMWidgetModel.extend(
   {
     serializers: {
       ...widgets.DOMWidgetModel.serializers,
-      points: numpy2D,
-      selection: numpy1D,
+      points: pointsCodec,
+      selection: selectionCodec,
     }
   },
 );

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -6,6 +6,7 @@ const packageJson = require('../package.json');
 const createScatterplot = reglScatterplot.default;
 
 const numpy2D = {
+
   deserialize(data) {
     console.log('2D - deserialize', data);
     if (data == null) return null;
@@ -14,14 +15,16 @@ const numpy2D = {
     }
 
     // Take full view of data buffer
-    const arr = new Float32Array(data.data.buffer);
+    const arr = new Float32Array(data.buffer.buffer);
 
     // Chunk single TypedArray into nested Array of points
     const [height, width] = data.shape;
     // Float32Array(width * height) -> [Float32Array(width), Float32Array(width), ...]
-    return Array
+    const points = Array
       .from({ length: height })
       .map((_, i) => arr.subarray(i * width, (i + 1) * width));
+
+     return points;
   },
 
   serialize(data) {
@@ -32,11 +35,12 @@ const numpy2D = {
     for (let i = 0; i < data.length; i++) {
       arr.set(data[i], i * height);
     }
-    return { data: arr, shape: [height, width] };
+    return { data: arr.buffer, dtype: 'float32', shape: [height, width] };
   }
 }
 
 const numpy1D = {
+
   deserialize(data) {
     console.log('1D - deserialize', data);
     if (data == null) return null;
@@ -46,12 +50,13 @@ const numpy1D = {
       return [];
     }
 
-    return new Float32Array(data.data.buffer);
+    return Array.from(new Int32Array(data.buffer.buffer));
   },
 
   serialize(data) {
+    data = new Int32Array(data)
     console.log('1D - serialize', data);
-    return { data: new Float32Array(data), shape: [data.length] };
+    return { data: data.buffer, dtype: 'int32', shape: [data.length] };
   }
 
 }

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -5,14 +5,24 @@ const packageJson = require('../package.json');
 
 const createScatterplot = reglScatterplot.default;
 
-const numpy2DCodec = {
+const numpyCodec = {
   deserialize(data) {
+    console.log('deserialize', data);
     if (data == null) return null;
-    if (data.shape.length !== 2) {
-      throw new Error('Array must be 2D.')
-    }
     // Take full view of data buffer
     const arr = new Float32Array(data.data.buffer);
+
+    // 1-D
+    if (data.shape.length === 1) {
+      return arr;
+    }
+
+    if (data.shape.length !== 2) {
+      console.error('Array must be 1D or 2D.')
+      return [];
+    }
+
+    // 2-D 
     // Chunk single TypedArray into nested Array of points
     const [height, width] = data.shape;
     // Float32Array(width * height) -> [Float32Array(width), Float32Array(width), ...]
@@ -21,10 +31,10 @@ const numpy2DCodec = {
       .map((_, i) => arr.subarray(i * width, (i + 1) * width));
     return points;
   },
-  serialize(data) {
-    console.log(data);
-    // TODO: Need to unnest data into single TypedArray.
-    const arr = new Float32Array(data.length + data[0].length);
+
+  serialize(data, obj) {
+    console.log('serialize', data, obj);
+    const arr = new Float32Array([]);
     return arr;
   }
 }
@@ -44,8 +54,8 @@ const JupyterScatterModel = widgets.DOMWidgetModel.extend(
   {
     serializers: {
       ...widgets.DOMWidgetModel.serializers,
-      points: numpy2DCodec,
-      selection: numpy2DCodec,
+      points: numpyCodec,
+      selection: numpyCodec,
     }
   },
 );

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -148,8 +148,6 @@ const JupyterScatterView = widgets.DOMWidgetView.extend({
 
       self.scatterplot = createScatterplot(initialOptions);
 
-      console.log('initialOptions', initialOptions);
-
       // eslint-disable-next-line
       console.log(
         'jscatter v' + packageJson.version +

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -22,7 +22,7 @@ const JupyterScatterModel = widgets.DOMWidgetModel.extend(
     serializers: {
       ...widgets.DOMWidgetModel.serializers,
       points: new codecs.Numpy2D('float32'),
-      selection: new codecs.Numpy1D('int32'),
+      selection: new codecs.Numpy1D('uint32'),
     }
   },
 );
@@ -416,45 +416,6 @@ const JupyterScatterView = widgets.DOMWidgetView.extend({
 
   otherOptionsHandler: function otherOptionsHandler(newOptions) {
     this.scatterplot.set(newOptions);
-  },
-
-  viewDownloadHandler: function viewDownloadHandler(target) {
-    if (!target) return;
-
-    const data = this.scatterplot.export();
-
-    if (target === 'property') {
-      this.model.set('view_pixels', Array.from(data.pixels));
-      this.model.set('view_shape', [data.width, data.height]);
-      this.model.set('view_download', null);
-      this.model.save_changes();
-      return;
-    }
-
-    const c = document.createElement('canvas');
-    c.width = data.width;
-    c.height = data.height;
-
-    const ctx = c.getContext('2d');
-    ctx.putImageData(new ImageData(data.pixels, data.width, data.height), 0, 0);
-
-    // The following is only needed to flip the image vertically. Since `ctx.scale`
-    // only affects `draw*()` calls and not `put*()` calls we have to draw the
-    // image twice...
-    const imageObject = new Image();
-    imageObject.onload = () => {
-      ctx.clearRect(0, 0, data.width, data.height);
-      ctx.scale(1, -1);
-      ctx.drawImage(imageObject, 0, -data.height);
-      c.toBlob((blob) => {
-        downloadBlob(blob, 'scatter.png');
-        setTimeout(() => {
-          this.model.set('view_download', null);
-          this.model.save_changes();
-        }, 0);
-      });
-    };
-    imageObject.src = c.toDataURL();
   },
 
   viewDownloadHandler: function viewDownloadHandler(target) {

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -22,6 +22,7 @@ const numpy2DCodec = {
     return points;
   },
   serialize(data) {
+    console.log(data);
     // TODO: Need to unnest data into single TypedArray.
     const arr = new Float32Array(data.length + data[0].length);
     return arr;
@@ -44,7 +45,7 @@ const JupyterScatterModel = widgets.DOMWidgetModel.extend(
     serializers: {
       ...widgets.DOMWidgetModel.serializers,
       points: numpy2DCodec,
-      serialize: numpy2DCodec,
+      selection: numpy2DCodec,
     }
   },
 );

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -148,6 +148,8 @@ const JupyterScatterView = widgets.DOMWidgetView.extend({
 
       self.scatterplot = createScatterplot(initialOptions);
 
+      console.log('initialOptions', initialOptions);
+
       // eslint-disable-next-line
       console.log(
         'jscatter v' + packageJson.version +
@@ -409,6 +411,45 @@ const JupyterScatterView = widgets.DOMWidgetView.extend({
 
   otherOptionsHandler: function otherOptionsHandler(newOptions) {
     this.scatterplot.set(newOptions);
+  },
+
+  viewDownloadHandler: function viewDownloadHandler(target) {
+    if (!target) return;
+
+    const data = this.scatterplot.export();
+
+    if (target === 'property') {
+      this.model.set('view_pixels', Array.from(data.pixels));
+      this.model.set('view_shape', [data.width, data.height]);
+      this.model.set('view_download', null);
+      this.model.save_changes();
+      return;
+    }
+
+    const c = document.createElement('canvas');
+    c.width = data.width;
+    c.height = data.height;
+
+    const ctx = c.getContext('2d');
+    ctx.putImageData(new ImageData(data.pixels, data.width, data.height), 0, 0);
+
+    // The following is only needed to flip the image vertically. Since `ctx.scale`
+    // only affects `draw*()` calls and not `put*()` calls we have to draw the
+    // image twice...
+    const imageObject = new Image();
+    imageObject.onload = () => {
+      ctx.clearRect(0, 0, data.width, data.height);
+      ctx.scale(1, -1);
+      ctx.drawImage(imageObject, 0, -data.height);
+      c.toBlob((blob) => {
+        downloadBlob(blob, 'scatter.png');
+        setTimeout(() => {
+          this.model.set('view_download', null);
+          this.model.save_changes();
+        }, 0);
+      });
+    };
+    imageObject.src = c.toDataURL();
   },
 
   viewDownloadHandler: function viewDownloadHandler(target) {

--- a/jscatter/jscatter.py
+++ b/jscatter/jscatter.py
@@ -269,7 +269,6 @@ class Scatter():
 
         if 'skip_widget_update' not in kwargs:
             self.update_widget('points', self._points)
-
     def selection(self, selection = Undefined):
         if selection is not Undefined:
             try:
@@ -1374,13 +1373,8 @@ class Scatter():
             return self._widget
 
         self._widget = JupyterScatter(
-<<<<<<< HEAD
             points=self.get_point_list(),
-            selection=self._selection.tolist(),
-=======
-            points=self._points,
             selection=self._selection,
->>>>>>> a8a183d (wip)
             width=self._width,
             height=self._height,
             background_color=self._background_color,

--- a/jscatter/jscatter.py
+++ b/jscatter/jscatter.py
@@ -7,7 +7,7 @@ import pandas as pd
 from matplotlib.colors import to_rgba
 
 from .encodings import Encodings
-from .widget import JupyterScatter
+from .widget import JupyterScatter, SELECTION_DTYPE
 from .color_maps import okabe_ito, glasbey_light, glasbey_dark
 from .utils import any_not, minmax_scale, tolist, uri_validator
 
@@ -63,7 +63,7 @@ class Scatter():
         self._widget = None
         self._pixels = None
         self._encodings = Encodings()
-        self._selection = np.asarray([])
+        self._selection = np.asarray([], dtype=SELECTION_DTYPE)
         self._background_color = to_rgba(default_background_color)
         self._background_color_luminance = 1
         self._background_image = None
@@ -269,20 +269,21 @@ class Scatter():
 
         if 'skip_widget_update' not in kwargs:
             self.update_widget('points', self._points)
+
     def selection(self, selection = Undefined):
         if selection is not Undefined:
             try:
-                self._selection = np.asarray(selection)
+                self._selection = np.asarray(selection, dtype=self._selection.dtype)
                 self.update_widget('selection', self._selection)
             except:
                 if selection is None:
-                    self._selection = np.asarray([])
+                    self._selection = np.asarray([], dtype=self._selection.dtype)
                 pass
 
             return self
 
         if self._widget is not None:
-            return np.asarray(self._widget.selection)
+            return self._widget.selection.astype(self._selection.dtype)
 
         return self._selection
 

--- a/jscatter/jscatter.py
+++ b/jscatter/jscatter.py
@@ -29,8 +29,6 @@ def check_encoding_dtype(series):
     if not any([check(series.dtype) for check in VALID_ENCODING_TYPES]):
         raise ValueError(f'{series.name} is of an unsupported data type: {series.dtype}. Must be one of category, float*, or int*.')
 
-from .utils import any_not_none
-
 def component_idx_to_name(idx):
     if idx == 2:
         return 'valueA'
@@ -275,17 +273,17 @@ class Scatter():
     def selection(self, selection = Undefined):
         if selection is not Undefined:
             try:
-                self._selection = np.asarray(selection, dtype=self._selection.dtype)
+                self._selection = np.asarray(selection).astype(SELECTION_DTYPE)
                 self.update_widget('selection', self._selection)
             except:
                 if selection is None:
-                    self._selection = np.asarray([], dtype=self._selection.dtype)
+                    self._selection = np.asarray([], dtype=SELECTION_DTYPE)
                 pass
 
             return self
 
         if self._widget is not None:
-            return self._widget.selection.astype(self._selection.dtype)
+            return self._widget.selection.astype(SELECTION_DTYPE)
 
         return self._selection
 
@@ -433,7 +431,6 @@ class Scatter():
             norm = self._color_norm,
             order = self._color_order,
         )
-        self.options(kwargs.get('options'))
 
     def opacity(
         self,
@@ -1423,6 +1420,7 @@ class Scatter():
 
     def show(self):
         return self.widget.show()
+
 
 def plot(x, y, data = None, **kwargs):
     return Scatter(x, y, data, **kwargs).show()

--- a/jscatter/jscatter.py
+++ b/jscatter/jscatter.py
@@ -209,13 +209,13 @@ class Scatter():
 
         if not connect_by:
             # To avoid having to serialize unused data
-            return self._points[:,:4].tolist()
+            return self._points[:,:4]
 
         if not connect_order:
             # To avoid having to serialize unused data
-            return self._points[:,:5].tolist()
+            return self._points[:,:5]
 
-        return self._points.tolist()
+        return self._points
 
     def x(self, x = Undefined, **kwargs):
         if x is not Undefined:
@@ -234,7 +234,7 @@ class Scatter():
             self._points[:, 0] = minmax_scale(self._points[:, 0], (-1,1))
 
             if 'skip_widget_update' not in kwargs:
-                self.update_widget('points', self._points.tolist())
+                self.update_widget('points', self._points)
 
             return self
 
@@ -257,7 +257,7 @@ class Scatter():
             self._points[:, 1] = minmax_scale(self._points[:, 1], (-1,1))
 
             if 'skip_widget_update' not in kwargs:
-                self.update_widget('points', self._points.tolist())
+                self.update_widget('points', self._points)
 
             return self
 
@@ -268,13 +268,13 @@ class Scatter():
         self.y(y, skip_widget_update=True)
 
         if 'skip_widget_update' not in kwargs:
-            self.update_widget('points', self._points.tolist())
+            self.update_widget('points', self._points)
 
     def selection(self, selection = Undefined):
         if selection is not Undefined:
             try:
                 self._selection = np.asarray(selection)
-                self.update_widget('selection', self._selection.tolist())
+                self.update_widget('selection', self._selection)
             except:
                 if selection is None:
                     self._selection = np.asarray([])
@@ -1374,8 +1374,13 @@ class Scatter():
             return self._widget
 
         self._widget = JupyterScatter(
+<<<<<<< HEAD
             points=self.get_point_list(),
             selection=self._selection.tolist(),
+=======
+            points=self._points,
+            selection=self._selection,
+>>>>>>> a8a183d (wip)
             width=self._width,
             height=self._height,
             background_color=self._background_color,

--- a/jscatter/jscatter.py
+++ b/jscatter/jscatter.py
@@ -207,15 +207,17 @@ class Scatter():
         connect_by = bool(self._connect_by)
         connect_order = bool(self._connect_order)
 
+        view = self._points
+
         if not connect_by:
             # To avoid having to serialize unused data
-            return self._points[:,:4]
+            view = view[:,:4]
 
         if not connect_order:
             # To avoid having to serialize unused data
-            return self._points[:,:5]
+            view = view[:,:5]
 
-        return self._points
+        return view.copy()
 
     def x(self, x = Undefined, **kwargs):
         if x is not Undefined:

--- a/jscatter/jscatter.py
+++ b/jscatter/jscatter.py
@@ -699,7 +699,6 @@ class Scatter():
             order = self._connect_order,
         )
 
-<<<<<<< HEAD
     def connection_color(
         self,
         color = Undefined,
@@ -716,41 +715,6 @@ class Scatter():
                 self._connection_color = to_rgba(color)
             except ValueError:
                 pass
-=======
-    def use_cmap(self, cmap_name: str, reverse: bool = False):
-        """Use a Matplotlib colormap for the point color.
-
-        Parameters
-        ----------
-        cmap_name : str
-            The name of the Matplotlib color map.
-        reverse : bool, optional
-            Reverse the colormap when set to ``True``.
-        """
-        self.color = plt.get_cmap(cmap_name)(range(256)).tolist()[::(1 + (-2 * reverse))]
-
-    def reset_view(self):
-        self.view_reset = True
-
-    def select(self, points):
-        """Select points
-
-        Parameters
-        ----------
-        points : 1D array_like
-            List of point indices to select
-        """
-
-        self.selection = np.asarray(points).tolist()
-
-    def get_panzoom_mode_widget(self, icon_only=False, width=None):
-        button = widgets.Button(
-            description='' if icon_only else 'Pan & Zoom',
-            icon='arrows',
-            tooltip='Activate pan & zoom',
-            button_style = 'primary' if self.mouse_mode == 'panZoom' else '',
-        )
->>>>>>> 42278d8 (Add convenience function)
 
         if color_active is not Undefined:
             try:

--- a/jscatter/jscatter.py
+++ b/jscatter/jscatter.py
@@ -29,6 +29,8 @@ def check_encoding_dtype(series):
     if not any([check(series.dtype) for check in VALID_ENCODING_TYPES]):
         raise ValueError(f'{series.name} is of an unsupported data type: {series.dtype}. Must be one of category, float*, or int*.')
 
+from .utils import any_not_none
+
 def component_idx_to_name(idx):
     if idx == 2:
         return 'valueA'
@@ -429,6 +431,7 @@ class Scatter():
             norm = self._color_norm,
             order = self._color_order,
         )
+        self.options(kwargs.get('options'))
 
     def opacity(
         self,

--- a/jscatter/jscatter.py
+++ b/jscatter/jscatter.py
@@ -699,6 +699,7 @@ class Scatter():
             order = self._connect_order,
         )
 
+<<<<<<< HEAD
     def connection_color(
         self,
         color = Undefined,
@@ -715,6 +716,41 @@ class Scatter():
                 self._connection_color = to_rgba(color)
             except ValueError:
                 pass
+=======
+    def use_cmap(self, cmap_name: str, reverse: bool = False):
+        """Use a Matplotlib colormap for the point color.
+
+        Parameters
+        ----------
+        cmap_name : str
+            The name of the Matplotlib color map.
+        reverse : bool, optional
+            Reverse the colormap when set to ``True``.
+        """
+        self.color = plt.get_cmap(cmap_name)(range(256)).tolist()[::(1 + (-2 * reverse))]
+
+    def reset_view(self):
+        self.view_reset = True
+
+    def select(self, points):
+        """Select points
+
+        Parameters
+        ----------
+        points : 1D array_like
+            List of point indices to select
+        """
+
+        self.selection = np.asarray(points).tolist()
+
+    def get_panzoom_mode_widget(self, icon_only=False, width=None):
+        button = widgets.Button(
+            description='' if icon_only else 'Pan & Zoom',
+            icon='arrows',
+            tooltip='Activate pan & zoom',
+            button_style = 'primary' if self.mouse_mode == 'panZoom' else '',
+        )
+>>>>>>> 42278d8 (Add convenience function)
 
         if color_active is not Undefined:
             try:

--- a/jscatter/jscatter.py
+++ b/jscatter/jscatter.py
@@ -234,7 +234,7 @@ class Scatter():
             self._points[:, 0] = minmax_scale(self._points[:, 0], (-1,1))
 
             if 'skip_widget_update' not in kwargs:
-                self.update_widget('points', self._points)
+                self.update_widget('points', self.get_point_list())
 
             return self
 
@@ -257,7 +257,7 @@ class Scatter():
             self._points[:, 1] = minmax_scale(self._points[:, 1], (-1,1))
 
             if 'skip_widget_update' not in kwargs:
-                self.update_widget('points', self._points)
+                self.update_widget('points', self.get_point_list())
 
             return self
 
@@ -268,7 +268,7 @@ class Scatter():
         self.y(y, skip_widget_update=True)
 
         if 'skip_widget_update' not in kwargs:
-            self.update_widget('points', self._points)
+            self.update_widget('points', self.get_point_list())
 
     def selection(self, selection = Undefined):
         if selection is not Undefined:

--- a/jscatter/widget.py
+++ b/jscatter/widget.py
@@ -35,8 +35,8 @@ def array_to_binary(arr, obj=None):
         return None
 
 def binary_to_array(value, obj=None):
-    # TODO: Need to deserialize into 2D data
-    return np.frombuffer(value['data'], dtype=np.float32)
+    print(value)
+    return np.frombuffer(value['data'], dtype=np.float32).reshape(value['shape'])
 
 array_binary_serialization = dict(to_json=array_to_binary, from_json=binary_to_array)
 

--- a/jscatter/widget.py
+++ b/jscatter/widget.py
@@ -10,7 +10,7 @@ from traittypes import Array
 from ._version import __version__
 from .utils import to_hex, with_left_label
 
-SELECTION_DTYPE = 'int32'
+SELECTION_DTYPE = 'uint32'
 
 def component_idx_to_name(idx):
     if idx == 2:
@@ -578,7 +578,7 @@ class JupyterScatter(widgets.DOMWidget):
             List of point indices to select
         """
 
-        self.selection = np.asarray(points, dtype=SELECTION_DTYPE)
+        self.selection = np.asarray(points).astype(SELECTION_DTYPE)
 
     def get_panzoom_mode_widget(self, icon_only=False, width=None):
         button = widgets.Button(

--- a/jscatter/widget.py
+++ b/jscatter/widget.py
@@ -29,6 +29,7 @@ def array_to_binary(arr, obj=None):
     if arr is not None:
         arr = arr.astype(np.float32)
         mv = memoryview(arr)
+        assert arr.flags["C_CONTIGUOUS"], "must be row-major array."
         return {'data': mv, 'shape': arr.shape}
     else:
         return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ jupyterlab_widgets>=1.0.0
 matplotlib
 numpy
 pandas
+traittypes>=0.2.1


### PR DESCRIPTION
Changes `points` and `selection` to use different serde (rather than traitlets `List`). Currently assumes that `points` and `selection` will be 2D numpy arrays.

TODO:

- [x] implement custom JS deserialization
- [x] implement custom JS serialization 

_NOTE_: `regl-scatterplot` requires data to be in a nested/interleaved structure: `[[x0, y0, ...], [x1, y1, ...]]`. I'm not sure how feasible it would be, but we could likely improve the overhead of data-transfer further if we could pass columnar data to `scatterplot.draw()`, e.g.:

```javascript
scatterplot.draw({
    x: new Float32Array(...),
    y: new Float32Array(...),
    category: new Float32Array(...),
    value: new Float32Array(...),
});
```

In python, the underlying `points`/`selection` arrays could be column-major order (`order="F"`), which means that we could de-serialize the `memoryview` on the client into individual columnar typed arrays.