### PR TITLE
Upgrade packaging for automatic install

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,7 +2,6 @@ graft jscatter/nbextension
 graft jscatter/labextension
 
 graft js
-graft tests
 prune **/node_modules
 
 include jscatter.json

--- a/README.md
+++ b/README.md
@@ -41,15 +41,13 @@
 ## Install
 
 ```bash
-# Install extension
 pip install jupyter-scatter
+```
 
-# Activate extension in Jupyter Lab
-jupyter labextension install jupyter-scatter
+If you are using JupyterLab <=2:
 
-# Activate extension in Jupyter Notebook
-jupyter nbextension install --py --sys-prefix jscatter
-jupyter nbextension enable --py --sys-prefix jscatter
+```bash
+jupyter labextension install @jupyter-widgets/jupyterlab-manager jupyter-scatter
 ```
 
 For a minimal working example, take a look at [test-environment](test-environment).
@@ -183,10 +181,13 @@ jupyter nbextension install --py --symlink --sys-prefix jscatter
 jupyter nbextension enable --py --sys-prefix jscatter
 ```
 
+Note for developers: the `--symlink` argument on Linux or OS X allows one to modify
+the JavaScript code in-place. This feature is not available with Windows.
+
 **Enable the Lab Extension:**
 
 ```bash
-jupyter labextension develop --overwrite jscatter
+jupyter labextension develop . --overwrite
 ```
 
 **After Changing Python code:** simply restart the kernel.

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ jupyter nbextension install --py --symlink --sys-prefix jscatter
 jupyter nbextension enable --py --sys-prefix jscatter
 ```
 
-Note for developers: the `--symlink` argument on Linux or OS X allows one to modify
+Note for developers: the `--symlink` argument on Linux or macOS allows one to modify
 the JavaScript code in-place. This feature is not available with Windows.
 
 **Enable the Lab Extension:**

--- a/install.json
+++ b/install.json
@@ -1,5 +1,0 @@
-{
-  "packageManager": "python",
-  "packageName": "jscatter",
-  "uninstallInstructions": "Use your Python package manager (pip, conda, etc.) to uninstall the package jscatter"
-}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["jupyter_packaging~=0.7.9", "jupyterlab>=3.0.0,==3.*", "setuptools>=40.8.0", "wheel"]
+requires = ["jupyter_packaging>=0.10,<2", "jupyterlab==3.*", "setuptools>=40.8.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,34 @@
-[bdist_wheel]
-universal=1
-
 [metadata]
-description-file = README.md
-license_file = LICENSE
+name = jupyter-scatter
+author = Fritz Lekschas
+author_email = code@lekschas.de
+license = Apache-2.0
+description = A scatter plot extension for Jupyter Notebook and Lab
+url = https://github.com/flekschas/jscatter
+long_description = file: README.md
+long_description_content_type = text/markdown
+classifiers =
+    Development Status :: 4 - Beta
+    Intended Audience :: Developers
+    Intended Audience :: Science/Research
+    Topic :: Multimedia :: Graphics
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+keywords =
+    scatter
+    scatter plot
+    jupyter
+    ipython
+    ipywidgets
+    jupyterlab
+    jupyterlab-extension
+    widgets
+
+[options]
+zip_safe = False
+include_package_data = True
+packages = find:
+tests_require =
+  pytest

--- a/setup.py
+++ b/setup.py
@@ -1,235 +1,52 @@
-from setuptools import setup, find_packages
-# from setuptools import setup, find_packages, Command
-# from setuptools.command.build_py import build_py
-# from setuptools.command.egg_info import egg_info
-# from setuptools.command.sdist import sdist
-# from subprocess import check_call
-# import platform
-# import sys
-import os
-import io
-# import re
-from distutils import log
-from jupyter_packaging import (
-    # create_cmdclass,
-    # install_npm,
-    # ensure_targets,
-    # combine_commands,
-    get_version,
-)
+from pathlib import Path
 
+from jupyter_packaging import get_data_files, get_version, npm_builder, wrap_installers
+from setuptools import setup
 
-log.set_verbosity(log.DEBUG)
-log.info("setup.py entered")
-log.info("$PATH=%s" % os.environ["PATH"])
-
-here = os.path.dirname(os.path.abspath(__file__))
-# IS_REPO = os.path.exists(os.path.join(here, ".git"))
-# STATIC_DIR = os.path.join(here, "scatterplot", "static")
-# NODE_ROOT = os.path.join(here, "js")
-# NPM_PATH = os.pathsep.join(
-#     [
-#         os.path.join(NODE_ROOT, "node_modules", ".bin"),
-#         os.environ.get("PATH", os.defpath),
-#     ]
-# )
-js_dir = os.path.join(here, 'js')
+here = Path(__file__).parent.resolve()
 version = get_version("jscatter/_version.py")
 
-js_targets = [
-    os.path.join(js_dir, 'dist', 'index.js'),
+builder = npm_builder(path=str(here / "js"), build_cmd="build", npm="npm")
+
+# representative files that should exist after build
+targets = [
+    str(here / "jscatter" / "nbextension" / "index.js"),
+    str(here / "jscatter" / "labextension" / "package.json"),
 ]
 
-data_files_spec = [
-    ("share/jupyter/nbextensions/jscatter", "jscatter/nbextension", "*.*"),
-    ("share/jupyter/labextensions/jscatter", "jscatter/labextension", "**"),
-    ("share/jupyter/labextensions/jscatter", ".", "install.json"),
-    ("etc/jupyter/nbconfig/notebook.d", ".", "jscatter.json"),
-]
-
-
-def read(*parts, **kwargs):
-    filepath = os.path.join(here, *parts)
-    encoding = kwargs.pop("encoding", "utf-8")
-    with io.open(filepath, encoding=encoding) as fh:
-        text = fh.read()
-    return text
-
-
-# def get_version():
-#     version = re.search(
-#         r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]',
-#         read("scatterplot", "__version__.py"),
-#         re.MULTILINE,
-#     ).group(1)
-#     return version
-
-
-def get_requirements(path):
-    content = read(path)
-    return [req for req in content.split("\n") if req != "" and not req.startswith("#")]
-
-
-# def js_prerelease(command, strict=False):
-#     """decorator for building minified js/css prior to another command"""
-
-#     class DecoratedCommand(command):
-#         def run(self):
-#             jsdeps = self.distribution.get_command_obj("jsdeps")
-#             if not IS_REPO and all(os.path.exists(t) for t in jsdeps.targets):
-#                 # sdist, nothing to do
-#                 command.run(self)
-#                 return
-
-#             try:
-#                 self.distribution.run_command("jsdeps")
-#             except Exception as e:
-#                 missing = [t for t in jsdeps.targets if not os.path.exists(t)]
-#                 if strict or missing:
-#                     log.warn("rebuilding js and css failed")
-#                     if missing:
-#                         log.error("missing files: %s" % missing)
-#                     raise e
-#                 else:
-#                     log.warn("rebuilding js and css failed (not a problem)")
-#                     log.warn(str(e))
-#             command.run(self)
-#             update_package_data(self.distribution)
-
-#     return DecoratedCommand
-
-
-# def update_package_data(distribution):
-#     """update package_data to catch changes during setup"""
-#     build_py = distribution.get_command_obj("build_py")
-#     # distribution.package_data = find_package_data()
-#     # re-init build_py options which load package_data
-#     build_py.finalize_options()
-
-
-# class NPM(Command):
-#     description = "install package.json dependencies using npm"
-
-#     user_options = []
-
-#     node_modules = os.path.join(NODE_ROOT, "node_modules")
-
-#     targets = [
-#         os.path.join(STATIC_DIR, "extension.js"),
-#         os.path.join(STATIC_DIR, "index.js"),
-#     ]
-
-#     def initialize_options(self):
-#         pass
-
-#     def finalize_options(self):
-#         pass
-
-#     def get_npm_name(self):
-#         npm_name = "npm"
-#         if platform.system() == "Windows":
-#             npm_name = "npm.cmd"
-#         return npm_name
-
-#     def has_npm(self):
-#         npm_name = self.get_npm_name()
-#         try:
-#             check_call([npm_name, "--version"])
-#             return True
-#         except:
-#             return False
-
-#     def should_run_npm_install(self):
-#         node_modules_exists = os.path.exists(self.node_modules)
-#         return self.has_npm() and not node_modules_exists
-
-#     def run(self):
-#         has_npm = self.has_npm()
-#         if not has_npm:
-#             log.error(
-#                 "`npm` unavailable. If you're running this command using "
-#                 "sudo, make sure `npm` is available to sudo"
-#             )
-
-#         env = os.environ.copy()
-#         env["PATH"] = NPM_PATH
-
-#         npm_name = self.get_npm_name()
-
-#         if self.should_run_npm_install():
-#             log.info(
-#                 "Installing build dependencies with npm. "
-#                 "This may take a while..."
-#             )
-#             check_call(
-#                 [npm_name, "install"],
-#                 cwd=NODE_ROOT,
-#                 stdout=sys.stdout,
-#                 stderr=sys.stderr,
-#             )
-#             os.utime(self.node_modules, None)
-
-#         check_call(
-#             [npm_name, "run", "build"],
-#             cwd=NODE_ROOT,
-#             stdout=sys.stdout,
-#             stderr=sys.stderr,
-#         )
-
-#         for t in self.targets:
-#             if not os.path.exists(t):
-#                 msg = "Missing file: %s" % t
-#                 if not has_npm:
-#                     msg += "\nnpm is required to build a development version "
-#                     "of a widget extension"
-#                 raise ValueError(msg)
-
-#         # update package data in case this created new files
-#         update_package_data(self.distribution)
-
-
-setup_args = dict(
-    name="jupyter-scatter",
-    version=version,
-    packages=find_packages(),
-    license="Apache-2.0",
-    description="A scatter plot extension for Jupyter Notebook and Lab",
-    long_description=read("README.md"),
-    long_description_content_type="text/markdown",
-    url="https://github.com/flekschas/jscatter",
-    include_package_data=True,
-    zip_safe=False,
-    author="Fritz Lekschas",
-    author_email="code@lekschas.de",
-    keywords=[
-        "scatter",
-        "scatter plot",
-        "jupyter",
-        "ipython",
-        "ipywidgets",
-        "jupyterlab",
-        "jupyterlab-extension",
-        "widgets"
-    ],
-    classifiers=[
-        "Development Status :: 4 - Beta",
-        "Intended Audience :: Developers",
-        "Intended Audience :: Science/Research",
-        "Topic :: Multimedia :: Graphics",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-    ],
-    install_requires=get_requirements("requirements.txt"),
-    setup_requires=[],
-    tests_require=["pytest"],
-    # "cmdclass": {
-    #     "build_py": js_prerelease(build_py),
-    #     "egg_info": js_prerelease(egg_info),
-    #     "sdist": js_prerelease(sdist, strict=True),
-    #     "jsdeps": NPM,
-    # },
+cmdclass = wrap_installers(
+    pre_develop=builder,
+    pre_dist=builder,
+    ensured_targets=targets,
+    skip_if_exists=targets,
 )
 
-setup(**setup_args)
+data_files = get_data_files([
+    (
+        "share/jupyter/nbextensions/jscatter/",
+        "jscatter/nbextension/",
+        "*",
+    ),
+    (
+        "share/jupyter/labextensions/jscatter/",
+        "jscatter/labextension/",
+        "**",
+    ),
+    (
+        "etc/jupyter/nbconfig/notebook.d/",
+        ".",
+        "jupyter-scatter.json",
+    ),
+])
+
+def get_requirements(path):
+    with open(here / path) as f:
+        content = f.read()
+    return [req for req in content.split("\n") if req != "" and not req.startswith("#")]
+
+setup(
+    version=version,
+    install_requires=get_requirements("requirements.txt"),
+    cmdclass=cmdclass,
+    data_files=data_files,
+)

--- a/setup.py
+++ b/setup.py
@@ -23,12 +23,12 @@ cmdclass = wrap_installers(
 
 data_files = get_data_files([
     (
-        "share/jupyter/nbextensions/jscatter/",
+        "share/jupyter/nbextensions/jupyter-scatter/",
         "jscatter/nbextension/",
         "*",
     ),
     (
-        "share/jupyter/labextensions/jscatter/",
+        "share/jupyter/labextensions/jupyter-scatter/",
         "jscatter/labextension/",
         "**",
     ),

--- a/test-environment/README.md
+++ b/test-environment/README.md
@@ -9,24 +9,13 @@ This directory contains a minimal environment to test the extension in Jupyter L
   conda activate jscatter-test
   ```
 
-2. **Enable the extension for Jupyter Lab and Notebook**
-
-  ```bash
-  # For Jupyter Lab
-  jupyter labextension install jupyter-scatter
-
-  # For Jupyter Notebook
-  jupyter nbextension install --py --sys-prefix jscatter
-  jupyter nbextension enable --py --sys-prefix jscatter
-  ```
-
-3. **Start Jupyter Lab**
+2. **Start Jupyter Lab**
 
   ```bash
   jupyter-lab
   ```
 
-4. **Go to the following two pages and run the notebook**
+3. **Go to the following two pages and run the notebook**
 
   - [http://localhost:8888/lab/tree/test.ipynb](http://localhost:8888/lab/tree/test.ipynb)
   - [http://localhost:8888/notebooks/test.ipynb](http://localhost:8888/notebooks/test.ipynb)


### PR DESCRIPTION
**Motivation**:

- JS currently must be manually built (`npm install && npm run build`) for the repo. 
- `jupyter-scatter` does not automatically install extension with `pip install jupyter-scatter`.


Newer versions of Jupyter and JupyterLab support automatic installation of extensions from PyPI (not local dev install with `pip install -e .`). This PR will make jupyter-scatter automatically install extensions with `pip install jupyter-scatter`.

~Blocking:~

~- Mixed naming of `jscatter`/`jupyter-scatter` seems to cause an issue for auto install of jupyter notebook extension.~

**How to try out this PR?**

```bash
pip install build
python -m build . # inside jupyter-scatter dir
pip install dist/jupyter-scatter-0.2.0.tar.gz
jupyter nbextension list
# Known nbextensions:
#   config dir: /Users/manzt/dev/miniconda3/envs/jsc/etc/jupyter/nbconfig
#     notebook section
#       jupyter-scatter/extension  enabled
#       - Validating: OK
jupyter labextension list
# JupyterLab v3.2.9
# Other labextensions (built into JupyterLab)
#    app dir: /Users/manzt/dev/miniconda3/envs/jsc/share/jupyter/lab
#         jupyter-scatter v0.2.0 enabled OK
```

**How to actually uninstall jupyter-scatter**:

```bash
pip uninstall jupyter-scatter # does not remove installed extensions
rm -rf $CONDA_PREFIX/share/jupyter/{nbextensions,labextensions}/jupyter-scatter # remove extensions
rm $CONDA_PREFIX/etc/jupyter/nbconfig/notebook.d/jupyter-scatter.json
```

> **NOTE**: manual extension install commands will still work, and are required when developing locally. 