### PR TITLE
Add support for legend end labeling

### DIFF
--- a/API.md
+++ b/API.md
@@ -112,7 +112,7 @@ Get or set the selected points.
 scatter.selection(cars.query('speed < 50').index)
 ```
 
-<h3><a name="scatter.color" href="#scatter.color">#</a> scatter.<b>color</b>(<i>default=Undefined</i>, <i>selected=Undefined</i>, <i>hover=Undefined</i>, <i>by=Undefined</i>, <i>map=Undefined</i>, <i>norm=Undefined</i>, <i>order=Undefined</i>, <i>**kwargs</i>)</h3>
+<h3><a name="scatter.color" href="#scatter.color">#</a> scatter.<b>color</b>(<i>default=Undefined</i>, <i>selected=Undefined</i>, <i>hover=Undefined</i>, <i>by=Undefined</i>, <i>map=Undefined</i>, <i>norm=Undefined</i>, <i>order=Undefined</i>, <i>labeling=Undefined</i>, <i>**kwargs</i>)</h3>
 
 Get or set the point color.
 
@@ -125,6 +125,7 @@ Get or set the point color.
 - `map` is either a string referencing a matplotlib color map, a matplotlib color map object, a list of matplotlib-compatible colors, a dictionary of category-color pairs, or `auto` (to let jscatter choose a default color map).
 - `norm` is either a tuple defining a value range that's map to `[0, 1]` with `matplotlib.colors.Normalize` or a [matplotlib normalizer](https://matplotlib.org/3.5.0/api/_as_gen/matplotlib.colors.Normalize.html).
 - `order` is either a list of values (for categorical coloring) or `reverse` to reverse a color map.
+- `labeling` is either a tuple of three strings specyfing a label for the minimum value, maximum value, and variable that the color encodes or a dictionary of the form `{'minValue': 'label', 'maxValue': 'label', 'variable': 'label'}`. The specified labels are only used for continuous color encoding and are displayed together with the legend.
 - `kwargs`:
   - `skip_widget_update` allows to skip the dynamic widget update when `True`. This can be useful when you want to animate the transition of multiple properties at once instead of animating one after the other.
 
@@ -152,7 +153,7 @@ scatter.color(
 scatter.color(by='gpd', map='viridis')
 ```
 
-<h3><a name="scatter.opacity" href="#scatter.opacity">#</a> scatter.<b>opacity</b>(<i>default=Undefined</i>, <i>unselected=Undefined</i>, <i>by=Undefined</i>, <i>map=Undefined</i>, <i>norm=Undefined</i>, <i>order=Undefined</i>, <i>**kwargs</i>)</h3>
+<h3><a name="scatter.opacity" href="#scatter.opacity">#</a> scatter.<b>opacity</b>(<i>default=Undefined</i>, <i>unselected=Undefined</i>, <i>by=Undefined</i>, <i>map=Undefined</i>, <i>norm=Undefined</i>, <i>order=Undefined</i>, <i>labeling=Undefined</i>, <i>**kwargs</i>)</h3>
 
 Get or set the point opacity.
 
@@ -164,6 +165,7 @@ Get or set the point opacity.
 - `map` is either a triple specifying an `np.linspace(*map)`, a list of opacities, a dictionary of category-opacity pairs, or `auto` (to let jscatter choose a default opacity map).
 - `norm` is either a tuple defining a value range that's map to `[0, 1]` with `matplotlib.colors.Normalize` or a [matplotlib normalizer](https://matplotlib.org/3.5.0/api/_as_gen/matplotlib.colors.Normalize.html).
 - `order` is either a list of values (for categorical opacity encoding) or `reverse` to reverse the opacity map.
+- `labeling` is either a tuple of three strings specyfing a label for the minimum value, maximum value, and variable that the opacity encodes or a dictionary of the form `{'minValue': 'label', 'maxValue': 'label', 'variable': 'label'}`. The specified labels are only used for continuous opacity encoding and are displayed together with the legend.
 - `kwargs`:
   - `skip_widget_update` allows to skip the dynamic widget update when `True`. This can be useful when you want to animate the transition of multiple properties at once instead of animating one after the other.
 
@@ -180,7 +182,7 @@ scatter.opacity(by='price', map=(1, 0.25, 10))
 scatter.opacity(by='density')
 ```
 
-<h3><a name="scatter.size" href="#scatter.size">#</a> scatter.<b>size</b>(<i>default=Undefined</i>, <i>by=Undefined</i>, <i>map=Undefined</i>, <i>norm=Undefined</i>, <i>order=Undefined</i>, <i>**kwargs</i>)</h3>
+<h3><a name="scatter.size" href="#scatter.size">#</a> scatter.<b>size</b>(<i>default=Undefined</i>, <i>by=Undefined</i>, <i>map=Undefined</i>, <i>norm=Undefined</i>, <i>order=Undefined</i>, <i>labeling=Undefined</i>, <i>**kwargs</i>)</h3>
 
 Get or set the point size.
 
@@ -191,6 +193,7 @@ Get or set the point size.
 - `map` is either a triple specifying an `np.linspace(*map)`, a list of sizes, a dictionary of category-size pairs, or `auto` (to let jscatter choose a default size map).
 - `norm` is either a tuple defining a value range that's map to `[0, 1]` with `matplotlib.colors.Normalize` or a [matplotlib normalizer](https://matplotlib.org/3.5.0/api/_as_gen/matplotlib.colors.Normalize.html).
 - `order` is either a list of values (for categorical size encoding) or `reverse` to reverse the size map.
+- `labeling` is either a tuple of three strings specyfing a label for the minimum value, maximum value, and variable that the size encodes or a dictionary of the form `{'minValue': 'label', 'maxValue': 'label', 'variable': 'label'}`. The specified labels are only used for continuous size encoding and are displayed together with the legend.
 - `kwargs`:
   - `skip_widget_update` allows to skip the dynamic widget update when `True`. This can be useful when you want to animate the transition of multiple properties at once instead of animating one after the other.
 
@@ -245,19 +248,19 @@ scatter.connect(by='group', order='order')
 ```
 
 
-<h3><a name="scatter.connection_color" href="#scatter.connection_color">#</a> scatter.<b>connection_color</b>(<i>default=Undefined</i>, <i>selected=Undefined</i>, <i>hover=Undefined</i>, <i>by=Undefined</i>, <i>map=Undefined</i>, <i>norm=Undefined</i>, <i>order=Undefined</i>, <i>**kwargs</i>)</h3>
+<h3><a name="scatter.connection_color" href="#scatter.connection_color">#</a> scatter.<b>connection_color</b>(<i>default=Undefined</i>, <i>selected=Undefined</i>, <i>hover=Undefined</i>, <i>by=Undefined</i>, <i>map=Undefined</i>, <i>norm=Undefined</i>, <i>order=Undefined</i>, <i>labeling=Undefined</i>, <i>**kwargs</i>)</h3>
 
 Get or set the point connection color. This function behaves identical to [scatter.color()][scatter.color].
 
 
-<h3><a name="scatter.connection_opacity" href="#scatter.connection_opacity">#</a> scatter.<b>connection_opacity</b>(<i>default=Undefined</i>, <i>by=Undefined</i>, <i>map=Undefined</i>, <i>norm=Undefined</i>, <i>order=Undefined</i>, <i>**kwargs</i>)</h3>
+<h3><a name="scatter.connection_opacity" href="#scatter.connection_opacity">#</a> scatter.<b>connection_opacity</b>(<i>default=Undefined</i>, <i>by=Undefined</i>, <i>map=Undefined</i>, <i>norm=Undefined</i>, <i>order=Undefined</i>, <i>labeling=Undefined</i>, <i>**kwargs</i>)</h3>
 
-Get or set the point connection opacity. This function behaves identical to [scatter.opacity()][scatter.color].
+Get or set the point connection opacity. This function behaves identical to [scatter.opacity()][scatter.opacity].
 
 
-<h3><a name="scatter.connection_size" href="#scatter.connection_size">#</a> scatter.<b>connection_size</b>(<i>default=Undefined</i>, <i>by=Undefined</i>, <i>map=Undefined</i>, <i>norm=Undefined</i>, <i>order=Undefined</i>, <i>**kwargs</i>)</h3>
+<h3><a name="scatter.connection_size" href="#scatter.connection_size">#</a> scatter.<b>connection_size</b>(<i>default=Undefined</i>, <i>by=Undefined</i>, <i>map=Undefined</i>, <i>norm=Undefined</i>, <i>order=Undefined</i>, <i>labeling=Undefined</i>, <i>**kwargs</i>)</h3>
 
-Get or set the point connection size. This function behaves identical to [scatter.size()][scatter.color].
+Get or set the point connection size. This function behaves identical to [scatter.size()][scatter.size].
 
 
 <h3><a name="scatter.axes" href="#scatter.axes">#</a> scatter.<b>axes</b>(<i>axes=Undefined</i>, <i>grid=Undefined</i>, <i>labels=Undefined</i>)</h3>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v0.8.0
 
 - Add support for end labeling of continuous data encoding via a new `labeling` argument of `color()`, `opacity()`, `size()`, `connection_color()`, `connection_opacity()`, and `connection_size()`. ([#46](https://github.com/flekschas/jupyter-scatter/pull/46))
+- Fix the incorrect size legend when the size map is reversed ([#47](https://github.com/flekschas/jupyter-scatter/issues/47))
 
 ## v0.7.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.8.0
+
+- Add support for end labeling of continuous data encoding via a new `labeling` argument of `color()`, `opacity()`, `size()`, `connection_color()`, `connection_opacity()`, and `connection_size()`. ([#46](https://github.com/flekschas/jupyter-scatter/pull/46))
+
 ## v0.7.4
 
 - Adjust widget to be compatible with ipywidgets `v8` and jupyterlab-widgets `v3` ([#39]((https://github.com/flekschas/jupyter-scatter/issues/39)))

--- a/js/src/legend.js
+++ b/js/src/legend.js
@@ -58,7 +58,7 @@ function createIcon(
   element.style.borderRadius = sizePx + 'px';
   element.style.backgroundColor = 'rgb(' + fontColor + ','  + fontColor + ',' + fontColor + ')';
 
-  if (visualChannel.indexOf('color') >= 0) {
+  if (visualChannel.includes('color')) {
     element.style.backgroundColor = Array.isArray(encoding)
       ? 'rgb(' + encoding.slice(0, 3).map((v) => v * 255).join(', ') + ')'
       : encoding;

--- a/js/src/legend.js
+++ b/js/src/legend.js
@@ -68,8 +68,10 @@ function createIcon(
       element.style.boxShadow = 'inset 0 0 1px rgba(' + fontColor + ',' + fontColor + ','  + fontColor + ', 0.66)';
     }
   } else if (visualChannel.indexOf('size') >= 0) {
-    const extent = encodingRange[1] - encodingRange[0];
-    const normEncoding = 0.2 + ((encoding - encodingRange[0]) / extent) * 0.8;
+    const minValue = Math.min.apply(null, encodingRange);
+    const maxValue = Math.max.apply(null, encodingRange);
+    const extent = maxValue - minValue;
+    const normEncoding = 0.2 + ((encoding - minValue) / extent) * 0.8;
     element.style.transform = `scale(${normEncoding})`;
   }
 

--- a/js/src/legend.js
+++ b/js/src/legend.js
@@ -62,12 +62,12 @@ function createIcon(
     element.style.backgroundColor = Array.isArray(encoding)
       ? 'rgb(' + encoding.slice(0, 3).map((v) => v * 255).join(', ') + ')'
       : encoding;
-  } else if (visualChannel.indexOf('opacity') >= 0) {
+  } else if (visualChannel.includes('opacity')) {
     element.style.backgroundColor = 'rgba(' + fontColor + ',' + fontColor + ','  + fontColor + ',' + encoding + ')';
     if (encoding < 0.2) {
       element.style.boxShadow = 'inset 0 0 1px rgba(' + fontColor + ',' + fontColor + ','  + fontColor + ', 0.66)';
     }
-  } else if (visualChannel.indexOf('size') >= 0) {
+  } else if (visualChannel.includes('size')) {
     const minValue = Math.min.apply(null, encodingRange);
     const maxValue = Math.max.apply(null, encodingRange);
     const extent = maxValue - minValue;

--- a/js/src/legend.js
+++ b/js/src/legend.js
@@ -24,9 +24,9 @@ function createLabelFormatter(valueRange) {
   return function (value) { return (Math.round(value * l) / l).toFixed(k); }
 }
 
-function createLabel(value) {
+function createValue(value) {
   const element = document.createElement('span');
-  element.className = 'legend-label';
+  element.className = 'legend-value';
   element.style.marginLeft = '0.25rem';
 
   element.textContent = value;
@@ -34,7 +34,23 @@ function createLabel(value) {
   return element;
 }
 
-function createIcon(title, encoding, encodingRange, sizePx, fontColor) {
+function createLabel(label) {
+  const element = document.createElement('span');
+  element.className = 'legend-label';
+  element.style.opacity = 0.5;
+
+  element.textContent = label || '';
+
+  return element;
+}
+
+function createIcon(
+  visualChannel,
+  encoding,
+  encodingRange,
+  sizePx,
+  fontColor
+) {
   const element = document.createElement('div');
   element.className = 'legend-icon';
   element.style.width = sizePx + 'px';
@@ -42,16 +58,16 @@ function createIcon(title, encoding, encodingRange, sizePx, fontColor) {
   element.style.borderRadius = sizePx + 'px';
   element.style.backgroundColor = 'rgb(' + fontColor + ','  + fontColor + ',' + fontColor + ')';
 
-  if (title.indexOf('color') >= 0) {
+  if (visualChannel.indexOf('color') >= 0) {
     element.style.backgroundColor = Array.isArray(encoding)
       ? 'rgb(' + encoding.slice(0, 3).map((v) => v * 255).join(', ') + ')'
       : encoding;
-  } else if (title.indexOf('opacity') >= 0) {
+  } else if (visualChannel.indexOf('opacity') >= 0) {
     element.style.backgroundColor = 'rgba(' + fontColor + ',' + fontColor + ','  + fontColor + ',' + encoding + ')';
     if (encoding < 0.2) {
       element.style.boxShadow = 'inset 0 0 1px rgba(' + fontColor + ',' + fontColor + ','  + fontColor + ', 0.66)';
     }
-  } else if (title.indexOf('size') >= 0) {
+  } else if (visualChannel.indexOf('size') >= 0) {
     const extent = encodingRange[1] - encodingRange[0];
     const normEncoding = 0.2 + ((encoding - encodingRange[0]) / extent) * 0.8;
     element.style.transform = `scale(${normEncoding})`;
@@ -60,25 +76,36 @@ function createIcon(title, encoding, encodingRange, sizePx, fontColor) {
   return element;
 }
 
-function createEntry(title, value, encoding, encodingRange, sizePx, fontColor) {
+function createEntry(
+  visualChannel,
+  value,
+  encodedValue,
+  encodingRange,
+  sizePx,
+  fontColor
+) {
   const element = document.createElement('div');
   element.className = 'legend-entry';
   element.style.display = 'flex';
   element.style.alignItems = 'center';
 
-  element.appendChild(createIcon(title, encoding, encodingRange, sizePx, fontColor));
-  element.appendChild(createLabel(value));
+  element.appendChild(
+    createIcon(visualChannel, encodedValue, encodingRange, sizePx, fontColor)
+  );
+  element.appendChild(createValue(value));
 
   return element;
 }
 
-function createTitle(title) {
+function createTitle(visualChannel, isRightAligned) {
   const element = document.createElement('div');
   element.className = 'legend-title';
-  element.style.fontWeight = 'bold';
   element.style.textTransform = 'capitalize';
-
-  element.textContent = title.replace('connection', 'line').replaceAll('_', ' ');
+  element.style.fontWeight = 'bold';
+  if (isRightAligned) element.style.textAlign = 'right';
+  element.textContent = visualChannel
+    .replace('connection', 'line')
+    .replaceAll('_', ' ');
 
   return element;
 }
@@ -86,8 +113,9 @@ function createTitle(title) {
 function createEncoding() {
   const element = document.createElement('div');
   element.className = 'legend-encoding';
-  element.style.display = 'flex';
-  element.style.flexDirection = 'column';
+  element.style.display = 'grid';
+  element.style.gridTemplateColumns = 'max-content max-content';
+  element.style.gap = '0 0.2rem';
 
   return element;
 }
@@ -103,7 +131,7 @@ function createLegend(encodings, fontColor, backgroundColor, size) {
   const root = document.createElement('div');
   root.className = 'legend';
   root.style.display = 'flex';
-  root.style.gap = (sizePx * 0.5) + 'px';
+  root.style.gap = sizePx + 'px';
   root.style.margin = (sizePx * 0.2) + 'px';
   root.style.padding = (sizePx * 0.25) + 'px';
   root.style.fontSize = sizePx + 'px';
@@ -116,27 +144,28 @@ function createLegend(encodings, fontColor, backgroundColor, size) {
   Object.entries(encodings)
     .sort((a, b) => sortOrder[a[0]] - sortOrder[b[0]])
     .forEach((encodingEntry) => {
-      const title = encodingEntry[0];
-      const valueEncodingPairs = encodingEntry[1];
+      const visualChannel = encodingEntry[0];
+      const visualEncoding = encodingEntry[1];
       const encoding = createEncoding();
-      encoding.appendChild(createTitle(title));
+      encoding.appendChild(createTitle(visualChannel, Boolean(visualEncoding.variable)));
+      encoding.appendChild(createLabel(visualEncoding.variable));
 
       const valueRange = [
-        valueEncodingPairs[0][0],
-        valueEncodingPairs[valueEncodingPairs.length - 1][0]
+        visualEncoding.values[0][0],
+        visualEncoding.values[visualEncoding.values.length - 1][0]
       ];
 
       const encodingRange = [
-        valueEncodingPairs[0][1],
-        valueEncodingPairs[valueEncodingPairs.length - 1][1]
+        visualEncoding.values[0][1],
+        visualEncoding.values[visualEncoding.values.length - 1][1]
       ];
 
       const formatter = createLabelFormatter(valueRange);
 
-      valueEncodingPairs.forEach(([value, encodedValue]) => {
+      visualEncoding.values.forEach(([value, encodedValue, label]) => {
         encoding.appendChild(
           createEntry(
-            title,
+            visualChannel,
             formatter(value),
             encodedValue,
             encodingRange,
@@ -144,6 +173,7 @@ function createLegend(encodings, fontColor, backgroundColor, size) {
             f
           )
         );
+        encoding.appendChild(createLabel(label));
       });
 
       root.append(encoding);

--- a/jscatter/encodings.py
+++ b/jscatter/encodings.py
@@ -14,8 +14,6 @@ def create_legend(encoding, norm, categories, labeling=None, linspace_num=5):
         cat_by_idx = { catIdx: cat for cat, catIdx in categories.items() }
         values = [(cat_by_idx[i], encoding[i], None) for i in range(len(cat_by_idx))]
     else:
-        S = np.linspace(0, 1, linspace_num)
-
         values = [
             (norm.inverse(s), encoding[floor((len(encoding) - 1) * s)], None)
             for s in np.linspace(0, 1, linspace_num)

--- a/jscatter/encodings.py
+++ b/jscatter/encodings.py
@@ -15,21 +15,15 @@ def create_legend(encoding, norm, categories, labeling=None, linspace_num=5):
         values = [(cat_by_idx[i], encoding[i], None) for i in range(len(cat_by_idx))]
     else:
         S = np.linspace(0, 1, linspace_num)
-        for s in S:
-            label = None
 
-            if labeling:
-                if s == 0:
-                    label = labeling.get('minValue')
+        values = [
+            (norm.inverse(s), encoding[floor((len(encoding) - 1) * s)], None)
+            for s in np.linspace(0, 1, linspace_num)
+        ]
 
-                if s == S[-1]:
-                    label = labeling.get('maxValue')
-
-            values.append((
-                norm.inverse(s),
-                encoding[floor((len(encoding) - 1) * s)],
-                label
-            ))
+        if labeling:
+            values[0] = (*values[0][0:2], labeling.get('minValue'))
+            values[-1] = (*values[-1][0:2], labeling.get('maxValue'))
 
     return dict(variable=variable, values=values)
 

--- a/jscatter/encodings.py
+++ b/jscatter/encodings.py
@@ -20,16 +20,10 @@ def create_legend(encoding, norm, categories, labeling=None, linspace_num=5):
 
             if labeling:
                 if s == 0:
-                    try:
-                        label = labeling['minValue']
-                    except KeyError as e:
-                        label = None
+                    label = labeling.get('minValue')
 
                 if s == S[-1]:
-                    try:
-                        label = labeling['maxValue']
-                    except KeyError as e:
-                        label = None
+                    label = labeling.get('maxValue')
 
             values.append((
                 norm.inverse(s),

--- a/jscatter/encodings.py
+++ b/jscatter/encodings.py
@@ -5,14 +5,44 @@ from functools import reduce
 from math import floor
 from typing import List, Tuple, Union
 
-def create_legend(values, encoding, norm, categories, linspace_num=5):
+def create_legend(encoding, norm, categories, labeling=None, linspace_num=5):
+    variable = None
+    if labeling:
+        try:
+            variable = labeling['variable']
+        except KeyError as e:
+            variable = None
+    values = []
+
     if categories:
         assert len(categories) == len(encoding), 'The categories and encoding need to be of the same size'
         cat_by_idx = { catIdx: cat for cat, catIdx in categories.items() }
-        return [(cat_by_idx[i], encoding[i]) for i in range(len(cat_by_idx))]
+        values = [(cat_by_idx[i], encoding[i], None) for i in range(len(cat_by_idx))]
+    else:
+        S = np.linspace(0, 1, linspace_num)
+        for s in S:
+            label = None
 
-    S = np.linspace(0, 1, linspace_num)
-    return [(norm.inverse(s), encoding[floor((len(encoding) - 1) * s)]) for s in S]
+            if labeling:
+                if s == 0:
+                    try:
+                        label = labeling['minValue']
+                    except KeyError as e:
+                        label = None
+
+                if s == S[-1]:
+                    try:
+                        label = labeling['maxValue']
+                    except KeyError as e:
+                        label = None
+
+            values.append((
+                norm.inverse(s),
+                encoding[floor((len(encoding) - 1) * s)],
+                label
+            ))
+
+    return dict(variable=variable, values=values)
 
 
 class Component():
@@ -121,13 +151,21 @@ class Encodings():
         if visual_enc in self.visual:
             return self.visual[visual_enc].legend
 
-    def set_legend(self, visual_enc, values, encoding, norm, categories, linspace_num=5):
+    def set_legend(
+        self,
+        visual_enc,
+        encoding,
+        norm,
+        categories,
+        labeling = None,
+        linspace_num = 5
+    ):
         if visual_enc in self.visual:
             self.visual[visual_enc].legend = create_legend(
-                values,
                 encoding,
                 norm,
                 categories,
+                labeling,
                 linspace_num
             )
 

--- a/jscatter/encodings.py
+++ b/jscatter/encodings.py
@@ -6,12 +6,7 @@ from math import floor
 from typing import List, Tuple, Union
 
 def create_legend(encoding, norm, categories, labeling=None, linspace_num=5):
-    variable = None
-    if labeling:
-        try:
-            variable = labeling['variable']
-        except KeyError as e:
-            variable = None
+    variable = labeling.get('variable') if labeling else None
     values = []
 
     if categories:

--- a/jscatter/types.py
+++ b/jscatter/types.py
@@ -1,5 +1,6 @@
 from enum import Enum
 from typing import Union, Tuple
+from typing_extensions import NotRequired, TypedDict
 
 Rgb = Tuple[float, float, float]
 Rgba = Tuple[float, float, float, float]
@@ -47,3 +48,8 @@ class Position(Enum):
     RIGHT = 'right'
     LEFT = 'left'
     CENTER = 'center'
+
+class Labeling(TypedDict):
+    variable: NotRequired[str]
+    minValue: NotRequired[str]
+    maxValue: NotRequired[str]

--- a/jscatter/utils.py
+++ b/jscatter/utils.py
@@ -2,6 +2,8 @@ from matplotlib.colors import LogNorm, PowerNorm, Normalize
 import ipywidgets as widgets
 from urllib.parse import urlparse
 
+from .types import Labeling
+
 def to_uint8(x):
   return int(max(0, min(x * 255, 255)))
 
@@ -58,3 +60,30 @@ def to_scale_type(norm):
         return f'pow_{norm.gamma}'
 
     return 'linear'
+
+def create_labeling(partial_labeling, column: str | None = None) -> Labeling:
+    labeling: Labeling = {}
+
+    if isinstance(partial_labeling, dict):
+        if 'minValue' in partial_labeling:
+            labeling['minValue'] = partial_labeling['minValue']
+
+        if 'maxValue' in partial_labeling:
+            labeling['maxValue'] = partial_labeling['maxValue']
+
+        if 'variable' in partial_labeling:
+            labeling['variable'] = partial_labeling['variable']
+    else:
+        if len(partial_labeling) > 0:
+            labeling['minValue'] = partial_labeling[0]
+
+        if len(partial_labeling) > 1:
+            labeling['maxValue'] = partial_labeling[1]
+
+        if len(partial_labeling) > 2:
+            labeling['variable'] = partial_labeling[2]
+
+    if 'variable' not in labeling and column is not None:
+        labeling['variable'] = column
+
+    return labeling

--- a/jscatter/utils.py
+++ b/jscatter/utils.py
@@ -1,6 +1,7 @@
 from matplotlib.colors import LogNorm, PowerNorm, Normalize
 import ipywidgets as widgets
 from urllib.parse import urlparse
+from typing import Union
 
 from .types import Labeling
 
@@ -61,7 +62,7 @@ def to_scale_type(norm):
 
     return 'linear'
 
-def create_labeling(partial_labeling, column: str | None = None) -> Labeling:
+def create_labeling(partial_labeling, column: Union[str, None] = None) -> Labeling:
     labeling: Labeling = {}
 
     if isinstance(partial_labeling, dict):

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ matplotlib
 numpy
 pandas
 traittypes>=0.2.1
+typing_extensions

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
 keywords =
     scatter
     scatter plot


### PR DESCRIPTION
This PR adds a new argument called `labeling` to the `color()`, `opacity()`, `size()`, `connection_color()`, `connection_opacity()`, and `connection_size()` methods. This argument allows defining end labels (i.e., labels for the minimum and maximum value) for continuous data encoding. If defined, those labels will be shown in the legend.

For example:

```python
import jscatter
import numpy as np
import pandas as pd

data = np.random.rand(500, 4)

df = pd.DataFrame(data, columns=['mass', 'speed', 'pval', 'group'])
df['group'] = df['group'].map(lambda c: chr(65 + round(c)), na_action=None)

sc = jscatter.Scatter(
    data=df,
    x='mass',
    y='speed',
    color_by='mass',
    color_map='plasma',
    color_order='reverse',
    color_norm=[0, 1],
    color_labeling=['low', 'high'],
    size_by='pval',
    size_norm=[0, 1],
    size_map=[2, 4, 6, 8, 10],
    size_order='reverse',
    size_labeling=['significant', 'insignificant'],
    legend=True,
)
sc.show()
```

<img width="809" alt="Screen Shot 2022-11-14 at 3 55 50 PM" src="https://user-images.githubusercontent.com/932103/201763826-2bec07e5-fef8-43c4-b332-cba239fb08f2.png">

The `labeling` understands two formats: a list of strings or a dictionary
1.  List-based approach: `[minValueLabel, maxValueLabel, variableLabel]`
2. Dict-based approach: `{ 'minValue': 'label', 'maxValue': 'label', 'variable': 'label' }`

In both cases, all values are optional.