### PR TITLE
Add support for zooming to points

### DIFF
--- a/API.md
+++ b/API.md
@@ -323,7 +323,7 @@ scatter.background(image='https://picsum.photos/640/640?random')
 Zoom to a set of points.
 
 **Arguments:**
-- `target` is a list of point indices or `None`. When set to `None` the camera zoom is reset.
+- `to` is a list of point indices or `None`. When set to `None` the camera zoom is reset.
 - `animation` defines whether to animate the transition to the new zoom state. This value can either be a Boolean or an Integer specifying the duration of the animation in milliseconds.
 - `padding` is the relative padding around the bounding box of the target points. E.g., `0` stands for no padding and `1` stands for a padding that is as wide and tall as the width and height of the points' bounding box.
 
@@ -335,7 +335,7 @@ Zoom to a set of points.
 scatter.zoom([0, 1, 2, 3])
 scatter.zoom(None)
 scatter.zoom(scatter.selection())
-scatter.zoom(target=scatter.selection(), animation=2000, padding=0.1)
+scatter.zoom(to=scatter.selection(), animation=2000, padding=0.1)
 ```
 
 

--- a/API.md
+++ b/API.md
@@ -7,7 +7,7 @@
     - [color()](#scatter.color), [opacity()](#scatter.opacity), and [size()](#scatter.size)
     - [connect()](#scatter.connect), [connection_color()](#scatter.connection_color), [connection_opacity()](#scatter.connection_opacity), and [connection_size()](#scatter.connection_size)
     - [axes()](#scatter.axes), [background()](#scatter.background), [lasso()](#scatter.lasso), and [reticle()](#scatter.reticle)
-    - [camera()](#scatter.camera), [mouse()](#scatter.mouse), and [options()](scatter.options)
+    - [zoom()](#scatter.zoom), [camera()](#scatter.camera), [mouse()](#scatter.mouse), and [options()](scatter.options)
   - [Properties](#properties)
   - [Widget](#widget)
 - [Plotting](#plotting)
@@ -318,14 +318,25 @@ scatter.background(image='https://picsum.photos/640/640?random')
 ```
 
 
-<h3><a name="scatter.mouse" href="#scatter.mouse">#</a> scatter.<b>mouse</b>(<i>mode=Undefined</i>)</h3>
+<h3><a name="scatter.zoom" href="#scatter.zoom">#</a> scatter.<b>zoom</b>(<i>target=Undefined</i>, <i>animation=Undefined</i>, <i>padding=Undefined</i>)</h3>
 
-Get or set the mouse mode.
+Zoom to a set of points.
 
 **Arguments:**
-- `mode` is either `'panZoom'`, `'lasso'`, or `'rotate'`
+- `target` is a list of point indices or `None`. When set to `None` the camera zoom is reset.
+- `animation` defines whether to animate the transition to the new zoom state. This value can either be a Boolean or an Integer specifying the duration of the animation in milliseconds.
+- `padding` is the relative padding around the bounding box of the target points. E.g., `0` stands for no padding and `1` stands for a padding that is as wide and tall as the width and height of the points' bounding box.
 
-**Returns:** either the mouse mode when mode is `Undefined` or `self`.
+**Returns:** either the current zoom state (when all arguments are `Undefined`) or `self`.
+
+**Example:**
+
+```python
+scatter.zoom([0, 1, 2, 3])
+scatter.zoom(None)
+scatter.zoom(scatter.selection())
+scatter.zoom(target=scatter.selection(), animation=2000, padding=0.1)
+```
 
 
 <h3><a name="scatter.camera" href="#scatter.camera">#</a> scatter.<b>camera</b>(<i>target=Undefined</i>, <i>distance=Undefined</i>, <i>rotation=Undefined</i>, <i>view=Undefined</i>)</h3>
@@ -339,6 +350,16 @@ Get or set the camera view.
 - `view` is an array-like list of 16 floats defining a view matrix.
 
 **Returns:** either the camera properties when all arguments are `Undefined` or `self`.
+
+
+<h3><a name="scatter.mouse" href="#scatter.mouse">#</a> scatter.<b>mouse</b>(<i>mode=Undefined</i>)</h3>
+
+Get or set the mouse mode.
+
+**Arguments:**
+- `mode` is either `'panZoom'`, `'lasso'`, or `'rotate'`
+
+**Returns:** either the mouse mode when mode is `Undefined` or `self`.
 
 
 <h3><a name="scatter.options" href="#scatter.options">#</a> scatter.<b>options</b>(<i>options=Undefined</i>)</h3>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.9.0
+
+- Add support for animated zooming to a set of points via `scatter.zoom(pointIndices)` ([#49](https://github.com/flekschas/jupyter-scatter/issues/49))
+- Bump regl-scatterplot to `v1.4.0`
+
 ## v0.8.0
 
 - Add support for end labeling of continuous data encoding via a new `labeling` argument of `color()`, `opacity()`, `size()`, `connection_color()`, `connection_opacity()`, and `connection_size()`. ([#46](https://github.com/flekschas/jupyter-scatter/pull/46))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## v0.9.0
 
 - Add support for animated zooming to a set of points via `scatter.zoom(pointIndices)` ([#49](https://github.com/flekschas/jupyter-scatter/issues/49))
-- Bump regl-scatterplot to `v1.4.0`
+- Bump regl-scatterplot to `v1.4.1`
 
 ## v0.8.0
 

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -19,7 +19,7 @@
         "lodash": "~4.17.21",
         "pub-sub-es": "~2.0.1",
         "regl": "~2.1.0",
-        "regl-scatterplot": "~1.3.0"
+        "regl-scatterplot": "~1.4.0"
       },
       "devDependencies": {
         "@jupyterlab/builder": "^3.4.8",
@@ -6601,9 +6601,9 @@
       }
     },
     "node_modules/regl-scatterplot": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/regl-scatterplot/-/regl-scatterplot-1.3.0.tgz",
-      "integrity": "sha512-HobgXk8Sa8A8HeqxARXZx44dI7q+mvbF5sncIG0Z3vEHBJEA5nGxw9vM9vypGIl9HivL7vA72o107r+hxxi6fw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/regl-scatterplot/-/regl-scatterplot-1.4.0.tgz",
+      "integrity": "sha512-F7yGcDAZQdiU7D7z+gML7mUJb67AlAMweh+y2cCIHdgZbCkmVhifkpe0Dih5XHNc5AEe5G91mYwVV4/rEp0Qow==",
       "dependencies": {
         "@flekschas/utils": "^0.29.0",
         "dom-2d-camera": "~2.2.3",
@@ -13928,9 +13928,9 @@
       }
     },
     "regl-scatterplot": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/regl-scatterplot/-/regl-scatterplot-1.3.0.tgz",
-      "integrity": "sha512-HobgXk8Sa8A8HeqxARXZx44dI7q+mvbF5sncIG0Z3vEHBJEA5nGxw9vM9vypGIl9HivL7vA72o107r+hxxi6fw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/regl-scatterplot/-/regl-scatterplot-1.4.0.tgz",
+      "integrity": "sha512-F7yGcDAZQdiU7D7z+gML7mUJb67AlAMweh+y2cCIHdgZbCkmVhifkpe0Dih5XHNc5AEe5G91mYwVV4/rEp0Qow==",
       "requires": {
         "@flekschas/utils": "^0.29.0",
         "dom-2d-camera": "~2.2.3",

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -19,7 +19,7 @@
         "lodash": "~4.17.21",
         "pub-sub-es": "~2.0.1",
         "regl": "~2.1.0",
-        "regl-scatterplot": "~1.4.0"
+        "regl-scatterplot": "~1.4.1"
       },
       "devDependencies": {
         "@jupyterlab/builder": "^3.4.8",
@@ -2569,9 +2569,9 @@
       }
     },
     "node_modules/dom-2d-camera": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/dom-2d-camera/-/dom-2d-camera-2.2.3.tgz",
-      "integrity": "sha512-oakGz91ABp1TrGmvv5+ogirbLZQv/9FFYkfGdEtYdFXbOQ3RfiHJC48NgWJkgs395n1ZNdp3WQ65/8wr2/SC/Q==",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/dom-2d-camera/-/dom-2d-camera-2.2.5.tgz",
+      "integrity": "sha512-BmjIiinZsvllot3E7HGsQRS4rfDfmsJK8urFL7po3Sx5r8ZrWvEcHxYxeUqxjEIGqp1Re5qRGTUx3pAACI3mjg==",
       "dependencies": {
         "camera-2d-simple": "^3.0.0",
         "gl-matrix": "^3.3.0"
@@ -6601,12 +6601,12 @@
       }
     },
     "node_modules/regl-scatterplot": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/regl-scatterplot/-/regl-scatterplot-1.4.0.tgz",
-      "integrity": "sha512-F7yGcDAZQdiU7D7z+gML7mUJb67AlAMweh+y2cCIHdgZbCkmVhifkpe0Dih5XHNc5AEe5G91mYwVV4/rEp0Qow==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/regl-scatterplot/-/regl-scatterplot-1.4.1.tgz",
+      "integrity": "sha512-GElcNnGLlmeRXoPZBZVduKhzGHCZ+11l5kU3SqPfX76Zdt47W2o4Q7tN19EZbZRDpCACEamxKpa7XON5I6R3nQ==",
       "dependencies": {
         "@flekschas/utils": "^0.29.0",
-        "dom-2d-camera": "~2.2.3",
+        "dom-2d-camera": "~2.2.5",
         "gl-matrix": "~3.3.0",
         "kdbush": "~3.0.0",
         "lodash-es": "~4.17.21",
@@ -10711,9 +10711,9 @@
       }
     },
     "dom-2d-camera": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/dom-2d-camera/-/dom-2d-camera-2.2.3.tgz",
-      "integrity": "sha512-oakGz91ABp1TrGmvv5+ogirbLZQv/9FFYkfGdEtYdFXbOQ3RfiHJC48NgWJkgs395n1ZNdp3WQ65/8wr2/SC/Q==",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/dom-2d-camera/-/dom-2d-camera-2.2.5.tgz",
+      "integrity": "sha512-BmjIiinZsvllot3E7HGsQRS4rfDfmsJK8urFL7po3Sx5r8ZrWvEcHxYxeUqxjEIGqp1Re5qRGTUx3pAACI3mjg==",
       "requires": {
         "camera-2d-simple": "^3.0.0",
         "gl-matrix": "^3.3.0"
@@ -13928,12 +13928,12 @@
       }
     },
     "regl-scatterplot": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/regl-scatterplot/-/regl-scatterplot-1.4.0.tgz",
-      "integrity": "sha512-F7yGcDAZQdiU7D7z+gML7mUJb67AlAMweh+y2cCIHdgZbCkmVhifkpe0Dih5XHNc5AEe5G91mYwVV4/rEp0Qow==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/regl-scatterplot/-/regl-scatterplot-1.4.1.tgz",
+      "integrity": "sha512-GElcNnGLlmeRXoPZBZVduKhzGHCZ+11l5kU3SqPfX76Zdt47W2o4Q7tN19EZbZRDpCACEamxKpa7XON5I6R3nQ==",
       "requires": {
         "@flekschas/utils": "^0.29.0",
-        "dom-2d-camera": "~2.2.3",
+        "dom-2d-camera": "~2.2.5",
         "gl-matrix": "~3.3.0",
         "kdbush": "~3.0.0",
         "lodash-es": "~4.17.21",

--- a/js/package.json
+++ b/js/package.json
@@ -47,7 +47,7 @@
     "lodash": "~4.17.21",
     "pub-sub-es": "~2.0.1",
     "regl": "~2.1.0",
-    "regl-scatterplot": "~1.3.0"
+    "regl-scatterplot": "~1.4.0"
   },
   "devDependencies": {
     "@jupyterlab/builder": "^3.4.8",

--- a/js/package.json
+++ b/js/package.json
@@ -47,7 +47,7 @@
     "lodash": "~4.17.21",
     "pub-sub-es": "~2.0.1",
     "regl": "~2.1.0",
-    "regl-scatterplot": "~1.4.0"
+    "regl-scatterplot": "~1.4.1"
   },
   "devDependencies": {
     "@jupyterlab/builder": "^3.4.8",

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -35,7 +35,7 @@ JupyterScatterModel.serializers = Object.assign(
     points: new codecs.Numpy2D('float32'),
     selection: new codecs.Numpy1D('uint32'),
     view_data: new codecs.Numpy1D('uint8'),
-    zoom_target: new codecs.Numpy1D('uint32'),
+    zoom_to: new codecs.Numpy1D('uint32'),
   }
 );
 
@@ -137,7 +137,7 @@ const properties = {
   legendEncoding: 'legendEncoding',
   xScale: 'xScale',
   yScale: 'yScale',
-  zoomTarget: 'zoomTarget',
+  zoomTo: 'zoomTo',
   zoomAnimation: 'zoomAnimation',
   zoomPadding: 'zoomPadding',
 };
@@ -974,7 +974,7 @@ class JupyterScatterView extends widgets.DOMWidgetView {
     this.showLegend();
   }
 
-  zoomTargetHandler(newTarget) {
+  zoomToHandler(points) {
     const animation = this.model.get('zoom_animation');
     const padding = this.model.get('zoom_padding');
 
@@ -985,8 +985,8 @@ class JupyterScatterView extends widgets.DOMWidgetView {
       ? { padding, transition, transitionDuration }
       : { padding };
 
-    if (newTarget) {
-      this.scatterplot.zoomToPoints(newTarget, options);
+    if (points) {
+      this.scatterplot.zoomToPoints(points, options);
     } else {
       this.scatterplot.zoomToOrigin(options);
     }

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -35,6 +35,7 @@ JupyterScatterModel.serializers = Object.assign(
     points: new codecs.Numpy2D('float32'),
     selection: new codecs.Numpy1D('uint32'),
     view_data: new codecs.Numpy1D('uint8'),
+    zoom_target: new codecs.Numpy1D('uint32'),
   }
 );
 
@@ -136,6 +137,9 @@ const properties = {
   legendEncoding: 'legendEncoding',
   xScale: 'xScale',
   yScale: 'yScale',
+  zoomTarget: 'zoomTarget',
+  zoomAnimation: 'zoomAnimation',
+  zoomPadding: 'zoomPadding',
 };
 
 const reglScatterplotProperty = new Set([
@@ -968,6 +972,24 @@ class JupyterScatterView extends widgets.DOMWidgetView {
   legendEncodingHandler() {
     if (!this.model.get('legend')) return;
     this.showLegend();
+  }
+
+  zoomTargetHandler(newTarget) {
+    const animation = this.model.get('zoom_animation');
+    const padding = this.model.get('zoom_padding');
+
+    const transition = animation > 0;
+    const transitionDuration = animation;
+
+    const options = transition
+      ? { padding, transition, transitionDuration }
+      : { padding };
+
+    if (newTarget) {
+      this.scatterplot.zoomToPoints(newTarget, options);
+    } else {
+      this.scatterplot.zoomToOrigin(options);
+    }
   }
 
   otherOptionsHandler(newOptions) {

--- a/jscatter/jscatter.py
+++ b/jscatter/jscatter.py
@@ -216,8 +216,8 @@ class Scatter():
         self._legend = False
         self._legend_position = 'top-left'
         self._legend_size = 'small'
-        self._zoom_target = None
-        self._zoom_animation = 1000
+        self._zoom_to = None
+        self._zoom_animation = 500
         self._zoom_padding = 0.33
         self._options = {}
 
@@ -316,7 +316,7 @@ class Scatter():
             kwargs.get('legend_size', UNDEF),
         )
         self.zoom(
-            kwargs.get('zoom_target', UNDEF),
+            kwargs.get('zoom_to', UNDEF),
             kwargs.get('zoom_animation', UNDEF),
             kwargs.get('zoom_padding', UNDEF),
         )
@@ -2726,7 +2726,7 @@ class Scatter():
 
     def zoom(
         self,
-        target: Optional[Union[List[int], np.ndarray, None, Undefined]] = UNDEF,
+        to: Optional[Union[List[int], np.ndarray, None, Undefined]] = UNDEF,
         animation: Optional[Union[bool, int, Undefined]] = UNDEF,
         padding: Optional[Union[float, Undefined]] = UNDEF,
     ):
@@ -2735,7 +2735,7 @@ class Scatter():
 
         Parameters
         ----------
-        target : array_like, optional
+        to : array_like, optional
             A list of point indices or `None`. When set to `None` the
             camera's zoom state is reset.
         animation : bool or int, optional
@@ -2780,15 +2780,15 @@ class Scatter():
             self._zoom_padding = padding
             self.update_widget('zoom_padding', padding)
 
-        if target is not UNDEF:
-            self._zoom_target = target
-            self.update_widget('zoom_target', target)
+        if to is not UNDEF:
+            self._zoom_to = to
+            self.update_widget('zoom_to', to)
 
-        if any_not([target, animation], UNDEF):
+        if any_not([to, animation, padding], UNDEF):
             return self
 
         return dict(
-            target = self._zoom_target,
+            to = self._zoom_to,
             animation = self._zoom_animation,
             padding = self._zoom_padding
         )
@@ -2988,7 +2988,7 @@ class Scatter():
             legend_position=self._legend_position,
             legend_color=self.get_legend_color(),
             legend_encoding=self.get_legend_encoding(),
-            zoom_target=self._zoom_target,
+            zoom_to=self._zoom_to,
             zoom_animation=self._zoom_animation,
             zoom_padding=self._zoom_padding,
             other_options=self._options

--- a/jscatter/widget.py
+++ b/jscatter/widget.py
@@ -78,7 +78,7 @@ class JupyterScatter(widgets.DOMWidget):
     camera_view = List(None, allow_none=True).tag(sync=True)
 
     # Zoom properties
-    zoom_target = Array(default_value=None, allow_none=True).tag(sync=True, **ndarray_serialization)
+    zoom_to = Array(default_value=None, allow_none=True).tag(sync=True, **ndarray_serialization)
     zoom_animation = Int(1000).tag(sync=True)
     zoom_padding = Float(0.333).tag(sync=True)
 

--- a/jscatter/widget.py
+++ b/jscatter/widget.py
@@ -77,6 +77,11 @@ class JupyterScatter(widgets.DOMWidget):
     camera_rotation = Float(1).tag(sync=True)
     camera_view = List(None, allow_none=True).tag(sync=True)
 
+    # Zoom properties
+    zoom_target = Array(default_value=None, allow_none=True).tag(sync=True, **ndarray_serialization)
+    zoom_animation = Int(1000).tag(sync=True)
+    zoom_padding = Float(0.333).tag(sync=True)
+
     # Interaction properties
     mouse_mode = Enum(['panZoom', 'lasso', 'rotate'], default_value='panZoom').tag(sync=True)
     lasso_initiator = Bool().tag(sync=True)


### PR DESCRIPTION
This PR integrate's regl-scatterplots new `zoomToPoints()` method via a new `scatter.zoom()` method.

**Example:**

```python
#########
# 1. Cell
import jscatter
import numpy as np
import pandas as pd

df = pd.DataFrame(np.random.rand(500, 4), columns=['mass', 'speed', 'pval', 'group'])
df['group'] = df['group'].map(lambda c: chr(65 + round(c)), na_action=None)

sc = jscatter.Scatter(data=df, x='mass', y='speed')
sc.selection(df.query('mass > 0.4 and mass < 0.6 and speed > 0.4 and speed < 0.6').index)
sc.show()

#########
# 2. Cell
sc.zoom(sc.selection())

#########
# 3. Cell
sc.zoom(None)
```

https://user-images.githubusercontent.com/932103/203417646-2fd0ba60-9192-4aaa-8d08-9cc494328b56.mp4
