### PR TITLE
fix: correct `main` field in package.json for CDN support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Add support for animated zooming to a set of points via `scatter.zoom(pointIndices)` ([#49](https://github.com/flekschas/jupyter-scatter/issues/49))
 - Bump regl-scatterplot to `v1.4.1`
+- Add support for VSCode and Colab ([#37](https://github.com/flekschas/jupyter-scatter/issues/37))
 
 ## v0.8.0
 

--- a/js/package.json
+++ b/js/package.json
@@ -4,6 +4,9 @@
   "description": "A scatter plot extension for Jupyter Notebook and Lab",
   "author": "Fritz Lekschas",
   "main": "src/index.js",
+  "publishConfig": {
+    "main": "dist/index.js"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/flekschas/jupyter-scatter.git"


### PR DESCRIPTION
Should fix #37

Google Colab and VSCode rely on loading the bundled _extension_ (`dist/index.js`) from a CDN. I believe Colab uses unpkg, but others may use jsdelivr, etc. 

CDNs generally defer to the `main` field of the `package.json` (since this is how Node's resolution algorithm works), but there are unofficial fields like `unpkg`, `jsdelivr`, `module`, `browser`, etc. It would be simple enough to make the `main` field `dist/index.js` to support most CDNs, but then that breaks `jupyterlab extension build` (which requires the `main` to be `src/index.js`). Fix one leak and another opens 🙃 

This PR uses [`publishConfig`](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#publishconfig) – an formal field used by `npm` (and other package managers) to override properties in the `package.json` at publish-time (e.g., when running `npm publish`). This means `main` remains `src/index.js` during development and when running all build commands, and then is changed to `dist/index.js` only when publish to npm.

In my experience, this is the easiest fix - especially since the source code (`js/src/index.js`) isn't useable in any JS runtime nor would be used by others with a bundler since it's so specific for the Jupyter-like clients.
