### PR TITLE
chore: make embed export and unnamed module

### DIFF
--- a/js/webpack.config.js
+++ b/js/webpack.config.js
@@ -65,7 +65,6 @@ module.exports = (env, argv) => {
         filename: 'index.js',
         path: path.resolve(__dirname, 'dist'),
         libraryTarget: 'amd',
-        library: "jscatter",
         publicPath: '', // Set in amd-public-path.js
       },
       devtool,


### PR DESCRIPTION
FWIW, I don't think the `dist/index.js` is consumed anywhere by either Jupyter or JupyterLab. It is just intended for Google Colab or VSCode and doesn't seem to be working. Hopefully this does the fix, but honestly it is so hard to know (and so hard to debug without pushing to NPM).

This PR aligns embed config in the `webpack.config.js` with the latest from the cookiecutter template. It changes the amd output from an named module to an unnamed module.

Suggested here: https://github.com/flekschas/jupyter-scatter/pull/51#issuecomment-1347641482
