### PR TITLE
New `scatter.filter()` and `scatter.data()` methods

### DIFF
--- a/API.md
+++ b/API.md
@@ -317,32 +317,19 @@ Get or set the x and y axes.
 
 **Example:**
 
-<<<<<<< HEAD
 ```python
 scatter = Scatter(data=df, x='speed', y='weight')
 scatter.axes(axes=True, labels=['Speed (km/h)', 'Weight (tons)'])
 ```
-=======
-<h3><a name="scatter.lasso" href="#scatter.lasso">#</a> scatter.<b>lasso</b>(<i>color=Undefined</i>, <i>initiator=Undefined</i>, <i>min_delay=Undefined</i>, <i>min_dist=Undefined</i>, <i>on_long_press=Undefined</i>)</h3>
->>>>>>> dda0106 (Add filter function)
-
 
 <h3><a name="scatter.legend" href="#scatter.legend">#</a> scatter.<b>legend</b>(<i>legend=Undefined</i>, <i>position=Undefined</i>, <i>size=Undefined</i>)</h3>
 
 Set or get the legend settings.
 
 **Arguments:**
-<<<<<<< HEAD
 - `legend` is a Boolean specifying if the legend should be shown or not.
 - `position` is a string specifying the legend position. It must be one of `top`, `left`, `right`, `bottom`, `top-left`, `top-right`, `bottom-left`, `bottom-right`, or `center`.
 - `size` is a string specifying the size of the legend. It must be one of `small`, `medium`, or `large`.
-=======
-- `color` is a string referring to a Matplotlib-compatible color.
-- `initiator` is a Boolean value specifying if the click-based lasso initiator should be enabled or not.
-- `min_delay` is an integer specifying the minimal delay in milliseconds before a new lasso point is stored. Higher values will result in more coarse grain lasso polygons but might be more performant. 
-- `min_dist` is an integer specifying the minimal distance in pixels that the mouse has to move before a new lasso point is stored. Higher values will result in more coarse grain lasso polygons but might be more performant.
-- `on_long_press` is a Boolean value specifying if the lasso should be activated upon a long press.
->>>>>>> dda0106 (Add filter function)
 
 **Returns:** either the legend properties when all arguments are `Undefined` or `self`.
 
@@ -411,7 +398,7 @@ scatter.mouse(mode='lasso')
 ```
 
 
-<h3><a name="scatter.lasso" href="#scatter.lasso">#</a> scatter.<b>lasso</b>(<i>color=Undefined</i>, <i>initiator=Undefined</i>, <i>min_delay=Undefined</i>, <i>min_dist=Undefined</i>)</h3>
+<h3><a name="scatter.lasso" href="#scatter.lasso">#</a> scatter.<b>lasso</b>(<i>color=Undefined</i>, <i>initiator=Undefined</i>, <i>min_delay=Undefined</i>, <i>min_dist=Undefined</i>, <i>on_long_press=Undefined</i>)</h3>
 
 Get or set the lasso for selecting multiple points.
 
@@ -420,6 +407,7 @@ Get or set the lasso for selecting multiple points.
 - `initiator` is a Boolean value to specify if the click-based lasso initiator should be enabled or not.
 - `min_delay` is an integer specifying the minimal delay in milliseconds before a new lasso point is stored. Higher values will result in more coarse grain lasso polygons but might be more performant. 
 - `min_dist` is an integer specifying the minimal distance in pixels that the mouse has to move before a new lasso point is stored. Higher values will result in more coarse grain lasso polygons but might be more performant.
+- `on_long_press` is a Boolean value specifying if the lasso should be activated upon a long press.
 
 **Returns:** either the lasso properties when all arguments are `Undefined` or `self`.
 

--- a/API.md
+++ b/API.md
@@ -2,7 +2,7 @@
 
 - [Scatter](#scatter)
   - [Methods](#methods)
-    - [x()](#scatter.x), [y()](#scatter.x), and [xy()](#scatter.xy)
+    - [x()](#scatter.x), [y()](#scatter.x), [xy()](#scatter.xy), and [data()](#scatter.data)
     - [selection()](#scatter.selection), [filter()](#scatter.filter)
     - [color()](#scatter.color), [opacity()](#scatter.opacity), and [size()](#scatter.size)
     - [connect()](#scatter.connect), [connection_color()](#scatter.connection_color), [connection_opacity()](#scatter.connection_opacity), and [connection_size()](#scatter.connection_size)
@@ -96,6 +96,24 @@ Get or set the x and y coordinate. This is just a convenience function to animat
 
 ```python
 scatter.xy('size', 'speed') # Mirror plot along the diagonal
+```
+
+<h3><a name="scatter.data" href="#scatter.data">#</a> scatter.<b>data</b>(<i>data=Undefined</i>, <i>**kwargs</i>)</h3>
+
+Get or set the referenced Pandas DataFrame. This is just a convenience function to animate a change in the x and y coordinate at the same time.
+
+**Arguments:**
+
+- `data` is a Pandas DataFrame.
+- `kwargs`:
+  - `skip_widget_update` allows to skip the dynamic widget update when `True`. This can be useful when you want to animate the transition of multiple properties at once instead of animating one after the other.
+
+**Returns:** either the DataFrame `data` is `Undefined` or `self`.
+
+**Examples:**
+
+```python
+scatter.data(df)
 ```
 
 <h3><a name="scatter.selection" href="#scatter.selection">#</a> scatter.<b>selection</b>(<i>point_idxs=Undefined</i>)</h3>

--- a/API.md
+++ b/API.md
@@ -3,7 +3,7 @@
 - [Scatter](#scatter)
   - [Methods](#methods)
     - [x()](#scatter.x), [y()](#scatter.x), and [xy()](#scatter.xy)
-    - [selection()](#scatter.selection)
+    - [selection()](#scatter.selection), [filter()](#scatter.filter)
     - [color()](#scatter.color), [opacity()](#scatter.opacity), and [size()](#scatter.size)
     - [connect()](#scatter.connect), [connection_color()](#scatter.connection_color), [connection_opacity()](#scatter.connection_opacity), and [connection_size()](#scatter.connection_size)
     - [axes()](#scatter.axes) and [legend()](#scatter.legend)
@@ -98,15 +98,15 @@ Get or set the x and y coordinate. This is just a convenience function to animat
 scatter.xy('size', 'speed') # Mirror plot along the diagonal
 ```
 
-<h3><a name="scatter.selection" href="#scatter.selection">#</a> scatter.<b>selection</b>(<i>selection=Undefined</i>)</h3>
+<h3><a name="scatter.selection" href="#scatter.selection">#</a> scatter.<b>selection</b>(<i>point_idxs=Undefined</i>)</h3>
 
 Get or set the selected points.
 
 **Arguments:**
 
-- `selection` is an array-like list of point indices.
+- `point_idxs` is either an array-like list of point indices.
 
-**Returns:** either the indices of selected points when `selection` is `Undefined`, or `self`.
+**Returns:** either the currently selected point indices when `point_idxs` is `Undefined` or `self`.
 
 **Examples:**
 
@@ -117,6 +117,22 @@ scatter.selection(cars.query('speed < 50').index)
 # Retrieve the point indices of the currently selected points
 scatter.selection()
 # => array([0, 42, 1337], dtype=uint32)
+```
+
+<h3><a name="scatter.filter" href="#scatter.filter">#</a> scatter.<b>filter</b>(<i>point_idxs=Undefined</i>)</h3>
+
+Get or set the filtered points. When filtering down to a set of points, all other points will be hidden from the view.
+
+**Arguments:**
+
+- `point_idxs` is either an array-like list of point indices.
+
+**Returns:** either the currently filtered point indices when `point_idxs` is `Undefined` or `self`.
+
+**Examples:**
+
+```python
+scatter.filter(cars.query('speed < 50').index)
 ```
 
 <h3><a name="scatter.color" href="#scatter.color">#</a> scatter.<b>color</b>(<i>default=Undefined</i>, <i>selected=Undefined</i>, <i>hover=Undefined</i>, <i>by=Undefined</i>, <i>map=Undefined</i>, <i>norm=Undefined</i>, <i>order=Undefined</i>, <i>labeling=Undefined</i>, <i>**kwargs</i>)</h3>
@@ -283,10 +299,14 @@ Get or set the x and y axes.
 
 **Example:**
 
+<<<<<<< HEAD
 ```python
 scatter = Scatter(data=df, x='speed', y='weight')
 scatter.axes(axes=True, labels=['Speed (km/h)', 'Weight (tons)'])
 ```
+=======
+<h3><a name="scatter.lasso" href="#scatter.lasso">#</a> scatter.<b>lasso</b>(<i>color=Undefined</i>, <i>initiator=Undefined</i>, <i>min_delay=Undefined</i>, <i>min_dist=Undefined</i>, <i>on_long_press=Undefined</i>)</h3>
+>>>>>>> dda0106 (Add filter function)
 
 
 <h3><a name="scatter.legend" href="#scatter.legend">#</a> scatter.<b>legend</b>(<i>legend=Undefined</i>, <i>position=Undefined</i>, <i>size=Undefined</i>)</h3>
@@ -294,9 +314,17 @@ scatter.axes(axes=True, labels=['Speed (km/h)', 'Weight (tons)'])
 Set or get the legend settings.
 
 **Arguments:**
+<<<<<<< HEAD
 - `legend` is a Boolean specifying if the legend should be shown or not.
 - `position` is a string specifying the legend position. It must be one of `top`, `left`, `right`, `bottom`, `top-left`, `top-right`, `bottom-left`, `bottom-right`, or `center`.
 - `size` is a string specifying the size of the legend. It must be one of `small`, `medium`, or `large`.
+=======
+- `color` is a string referring to a Matplotlib-compatible color.
+- `initiator` is a Boolean value specifying if the click-based lasso initiator should be enabled or not.
+- `min_delay` is an integer specifying the minimal delay in milliseconds before a new lasso point is stored. Higher values will result in more coarse grain lasso polygons but might be more performant. 
+- `min_dist` is an integer specifying the minimal distance in pixels that the mouse has to move before a new lasso point is stored. Higher values will result in more coarse grain lasso polygons but might be more performant.
+- `on_long_press` is a Boolean value specifying if the lasso should be activated upon a long press.
+>>>>>>> dda0106 (Add filter function)
 
 **Returns:** either the legend properties when all arguments are `Undefined` or `self`.
 
@@ -307,7 +335,7 @@ scatter.legend(true, 'top-right', 'small')
 ```
 
 
-<h3><a name="scatter.zoom" href="#scatter.zoom">#</a> scatter.<b>zoom</b>(<i>target=Undefined</i>, <i>animation=Undefined</i>, <i>padding=Undefined</i>, <i>on_selection=Undefined</i>)</h3>
+<h3><a name="scatter.zoom" href="#scatter.zoom">#</a> scatter.<b>zoom</b>(<i>target=Undefined</i>, <i>animation=Undefined</i>, <i>padding=Undefined</i>, <i>on_selection=Undefined</i>, <i>on_filter=Undefined</i>)</h3>
 
 Zoom to a set of points.
 
@@ -316,6 +344,7 @@ Zoom to a set of points.
 - `animation` defines whether to animate the transition to the new zoom state. This value can either be a Boolean or an Integer specifying the duration of the animation in milliseconds.
 - `padding` is the relative padding around the bounding box of the target points. E.g., `0` stands for no padding and `1` stands for a padding that is as wide and tall as the width and height of the points' bounding box.
 - `on_selection` if `True` jscatter will automatically zoom to selected points.
+- `on_filter` if `True` jscatter will automatically zoom to filtered points.
 
 **Returns:** either the current zoom state (when all arguments are `Undefined`) or `self`.
 
@@ -493,9 +522,10 @@ You can define those property when creating a `Scatter` instance. For example,
 | `axes`                     | bool                                                                                     | `True`                                         |
 | `axes_grid`                | bool                                                                                     | `False`                                        |
 | `lasso_color`              | str \| tuple[float] \| list[float]                                                       | `(0, 0.666666667, 1, 1)`                       |
-| `lasso_initiator`          | bool                                                                                     | `True`                                         |
+| `lasso_initiator`          | bool                                                                                     | `False`                                        |
 | `lasso_min_delay`          | int                                                                                      | `10`                                           |
 | `lasso_min_dist`           | int                                                                                      | `3`                                            |
+| `lasso_on_long_press`      | bool                                                                                     | `True`                                         |
 | `reticle`                  | bool                                                                                     | `True`                                         |
 | `reticle_color`            | str \| 'auto'                                                                            | `'auto'`                                       |
 | `background_color`         | str                                                                                      | `'white'`                                      |
@@ -505,6 +535,11 @@ You can define those property when creating a `Scatter` instance. For example,
 | `camera_distance`          | float                                                                                    | `1`                                            |
 | `camera_rotation`          | float                                                                                    | `0`                                            |
 | `camera_view`              | list[float]                                                                              | `None`                                         |
+| `zoom_to`                  | list[int]                                                                                | `None`                                         |
+| `zoom_animation`           | int                                                                                      | `500`                                          |
+| `zoom_on_selection`        | list[float]                                                                              | `0.33`                                         |
+| `zoom_on_filter`           | list[float]                                                                              | `False`                                        |
+| `zoom_padding`             | list[float]                                                                              | `False`                                        |
 | `options`                  | dict                                                                                     | `{}`                                           |
 
 [LogNorm]: https://matplotlib.org/3.5.0/api/_as_gen/matplotlib.colors.LogNorm.html

--- a/API.md
+++ b/API.md
@@ -143,7 +143,7 @@ Get or set the filtered points. When filtering down to a set of points, all othe
 
 **Arguments:**
 
-- `point_idxs` is either an array-like list of point indices.
+- `point_idxs` is a list or an array-like object of point indices.
 
 **Returns:** either the currently filtered point indices when `point_idxs` is `Undefined` or `self`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v0.11.0
 
 - Add `scatter.filter([0, 1, 2])` for filtering down points. Filtering down to a specific subset of points is much faster than than updating the underlying data ([#61](https://github.com/flekschas/jupyter-scatter/issues/61))
+- Add `scatter.data(df)` to allow rendering new data points without having to re-initialize the scatter instance ([#61](https://github.com/flekschas/jupyter-scatter/issues/61))
 - Add the ability to automatically zoom to filtered points via `Scatter(zoom_on_filter=True)` or `scatter.zoom(on_filter=True)`
 - Add lasso on long press and make it the default. The behavior can be changed via `Scatter(lasso_on_long_press=False)` or `scatter.lasso(on_long_press=False)`
 - Updated `regl-scatterplot` to `v1.6`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v0.11.0
+
+- Add `scatter.filter([0, 1, 2])` for filtering down points. Filtering down to a specific subset of points is much faster than than updating the underlying data ([#61](https://github.com/flekschas/jupyter-scatter/issues/61))
+- Add the ability to automatically zoom to filtered points via `Scatter(zoom_on_filter=True)` or `scatter.zoom(on_filter=True)`
+- Add lasso on long press and make it the default. The behavior can be changed via `Scatter(lasso_on_long_press=False)` or `scatter.lasso(on_long_press=False)`
+- Updated `regl-scatterplot` to `v1.6`
+
 ## v0.10.0
 
 - Add support for automatic zooming to selected points via `scatter.zoom(on_selection=True)`

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -19,7 +19,7 @@
         "lodash": "~4.17.21",
         "pub-sub-es": "~2.0.1",
         "regl": "~2.1.0",
-        "regl-scatterplot": "~1.6.2"
+        "regl-scatterplot": "~1.6.3"
       },
       "devDependencies": {
         "@jupyterlab/builder": "^3.5.2",
@@ -6172,9 +6172,9 @@
       }
     },
     "node_modules/regl-scatterplot": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/regl-scatterplot/-/regl-scatterplot-1.6.2.tgz",
-      "integrity": "sha512-Cvw7gVW/i/cL/g6+XCjk0IrcWnznfP4vGO7NI881lkO5NvkHWA8Ln+nv/dvI12DDtW5ztxW48v7Bg9TZlOdE/w==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/regl-scatterplot/-/regl-scatterplot-1.6.3.tgz",
+      "integrity": "sha512-KeXPCXTQxERRPOu97/F7Dyiw8jHt+dsa6UnOY/eRFl9WExsVR/NGI1WOg+9oKAYrceKyg7g4OtTfAv7CzROf/g==",
       "dependencies": {
         "@flekschas/utils": "^0.30.1",
         "dom-2d-camera": "~2.2.5",
@@ -12862,9 +12862,9 @@
       }
     },
     "regl-scatterplot": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/regl-scatterplot/-/regl-scatterplot-1.6.2.tgz",
-      "integrity": "sha512-Cvw7gVW/i/cL/g6+XCjk0IrcWnznfP4vGO7NI881lkO5NvkHWA8Ln+nv/dvI12DDtW5ztxW48v7Bg9TZlOdE/w==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/regl-scatterplot/-/regl-scatterplot-1.6.3.tgz",
+      "integrity": "sha512-KeXPCXTQxERRPOu97/F7Dyiw8jHt+dsa6UnOY/eRFl9WExsVR/NGI1WOg+9oKAYrceKyg7g4OtTfAv7CzROf/g==",
       "requires": {
         "@flekschas/utils": "^0.30.1",
         "dom-2d-camera": "~2.2.5",

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -19,7 +19,7 @@
         "lodash": "~4.17.21",
         "pub-sub-es": "~2.0.1",
         "regl": "~2.1.0",
-        "regl-scatterplot": "~1.4.2"
+        "regl-scatterplot": "~1.6.2"
       },
       "devDependencies": {
         "@jupyterlab/builder": "^3.5.2",
@@ -116,9 +116,9 @@
       }
     },
     "node_modules/@flekschas/utils": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@flekschas/utils/-/utils-0.29.0.tgz",
-      "integrity": "sha512-iIthDImmmZ7pHHJuSVQqLPqKfaD4RxgmMlibMcfqIb20q9WK1uoqRJbHcIIIecZmEJ+VHZohvmMSacXegf5PHQ=="
+      "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/@flekschas/utils/-/utils-0.30.1.tgz",
+      "integrity": "sha512-JV/bGmX5hsh3uEKgcV9xe1QymrsXGCaWnD387VBB56sQdpsBexs9d2HmcRbN07DYzF+C89sQ1zP1MeLN2YfOZQ=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.8",
@@ -6172,13 +6172,13 @@
       }
     },
     "node_modules/regl-scatterplot": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/regl-scatterplot/-/regl-scatterplot-1.4.2.tgz",
-      "integrity": "sha512-dvuMlkYvyBNrvujDbUggpPoeL2MWW13Wq0r3FZ8xPEPPKa91Hv+aSA1UxdjkBSLdabiYbHAvXHTFm9v4RRKuZA==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/regl-scatterplot/-/regl-scatterplot-1.6.2.tgz",
+      "integrity": "sha512-Cvw7gVW/i/cL/g6+XCjk0IrcWnznfP4vGO7NI881lkO5NvkHWA8Ln+nv/dvI12DDtW5ztxW48v7Bg9TZlOdE/w==",
       "dependencies": {
-        "@flekschas/utils": "^0.29.0",
+        "@flekschas/utils": "^0.30.1",
         "dom-2d-camera": "~2.2.5",
-        "gl-matrix": "~3.3.0",
+        "gl-matrix": "~3.4.3",
         "kdbush": "~3.0.0",
         "lodash-es": "~4.17.21",
         "pub-sub-es": "~2.0.1",
@@ -6189,6 +6189,11 @@
         "pub-sub-es": "~2.0.1",
         "regl": "~2.1.0"
       }
+    },
+    "node_modules/regl-scatterplot/node_modules/gl-matrix": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.3.tgz",
+      "integrity": "sha512-wcCp8vu8FT22BnvKVPjXa/ICBWRq/zjFfdofZy1WSpQZpphblv12/bOQLBC1rMM7SGOFS9ltVmKOHil5+Ml7gA=="
     },
     "node_modules/request": {
       "version": "2.88.0",
@@ -8055,9 +8060,9 @@
       }
     },
     "@flekschas/utils": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@flekschas/utils/-/utils-0.29.0.tgz",
-      "integrity": "sha512-iIthDImmmZ7pHHJuSVQqLPqKfaD4RxgmMlibMcfqIb20q9WK1uoqRJbHcIIIecZmEJ+VHZohvmMSacXegf5PHQ=="
+      "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/@flekschas/utils/-/utils-0.30.1.tgz",
+      "integrity": "sha512-JV/bGmX5hsh3uEKgcV9xe1QymrsXGCaWnD387VBB56sQdpsBexs9d2HmcRbN07DYzF+C89sQ1zP1MeLN2YfOZQ=="
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.8",
@@ -12857,18 +12862,25 @@
       }
     },
     "regl-scatterplot": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/regl-scatterplot/-/regl-scatterplot-1.4.2.tgz",
-      "integrity": "sha512-dvuMlkYvyBNrvujDbUggpPoeL2MWW13Wq0r3FZ8xPEPPKa91Hv+aSA1UxdjkBSLdabiYbHAvXHTFm9v4RRKuZA==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/regl-scatterplot/-/regl-scatterplot-1.6.2.tgz",
+      "integrity": "sha512-Cvw7gVW/i/cL/g6+XCjk0IrcWnznfP4vGO7NI881lkO5NvkHWA8Ln+nv/dvI12DDtW5ztxW48v7Bg9TZlOdE/w==",
       "requires": {
-        "@flekschas/utils": "^0.29.0",
+        "@flekschas/utils": "^0.30.1",
         "dom-2d-camera": "~2.2.5",
-        "gl-matrix": "~3.3.0",
+        "gl-matrix": "~3.4.3",
         "kdbush": "~3.0.0",
         "lodash-es": "~4.17.21",
         "pub-sub-es": "~2.0.1",
         "regl": "~2.1.0",
         "regl-line": "~1.0.0"
+      },
+      "dependencies": {
+        "gl-matrix": {
+          "version": "3.4.3",
+          "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.3.tgz",
+          "integrity": "sha512-wcCp8vu8FT22BnvKVPjXa/ICBWRq/zjFfdofZy1WSpQZpphblv12/bOQLBC1rMM7SGOFS9ltVmKOHil5+Ml7gA=="
+        }
       }
     },
     "request": {

--- a/js/package.json
+++ b/js/package.json
@@ -50,7 +50,7 @@
     "lodash": "~4.17.21",
     "pub-sub-es": "~2.0.1",
     "regl": "~2.1.0",
-    "regl-scatterplot": "~1.4.2"
+    "regl-scatterplot": "~1.6.2"
   },
   "devDependencies": {
     "@jupyterlab/builder": "^3.5.2",

--- a/js/package.json
+++ b/js/package.json
@@ -50,7 +50,7 @@
     "lodash": "~4.17.21",
     "pub-sub-es": "~2.0.1",
     "regl": "~2.1.0",
-    "regl-scatterplot": "~1.6.2"
+    "regl-scatterplot": "~1.6.3"
   },
   "devDependencies": {
     "@jupyterlab/builder": "^3.5.2",

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -790,11 +790,18 @@ class JupyterScatterView extends widgets.DOMWidgetView {
 
   // Event handlers for Python-triggered events
   pointsHandler(newPoints) {
-    this.scatterplot.draw(newPoints, {
-      transition: true,
-      transitionDuration: 3000,
-      transitionEasing: 'quadInOut',
-    });
+    if (newPoints.length === this.scatterplot.get('points').length) {
+      // We assume point correspondence
+      this.scatterplot.draw(newPoints, {
+        transition: true,
+        transitionDuration: 3000,
+        transitionEasing: 'quadInOut',
+      });
+    } else {
+      this.scatterplot.deselect();
+      this.scatterplot.unfilter();
+      this.scatterplot.draw(newPoints);
+    }
   }
 
   selectionHandler(pointIdxs) {

--- a/jscatter/jscatter.py
+++ b/jscatter/jscatter.py
@@ -345,6 +345,61 @@ class Scatter():
 
         return view.copy()
 
+    def data(
+        self,
+        data: Optional[pd.DataFrame] = None,
+        **kwargs
+    ) -> Union[Scatter, dict]:
+        """
+        Set or get the referenced Pandas DataFrame
+
+        Parameters
+        ----------
+        data : pd.DataFrame, optional
+            The data frame that holds the x and y coordinates as well as other
+            possible dimensions that can be used for color, size, or opacity
+            encoding.
+
+        Returns
+        -------
+        self or dict
+            If no parameter was provided a dictionary with the current `data`
+            is returned. Otherwise, `self` is returned.
+
+        See Also
+        --------
+        x : Set or get the x coordinates.
+        y : Set or get the y coordinates.
+        xy : Set or get the x and y coordinates.
+
+        Examples
+        --------
+        >>> scatter.data(df)
+        <jscatter.jscatter.Scatter>
+
+        >>> scatter.data()
+        {'data': <pandas.DataFrame>}
+        """
+        if data is not None:
+            try:
+                self._n = len(data)
+                self._data = data
+            except TypeError:
+                return self
+
+            self._points = np.zeros((self._n, 6))
+
+            self.x(self._x, skip_widget_update=True)
+            self.y(self._y, skip_widget_update=True)
+
+            if 'skip_widget_update' not in kwargs:
+                self.update_widget('points', self.get_point_list())
+
+        if any_not([data], UNDEF):
+            return self
+
+        return dict(data = self._data)
+
     def x(
         self,
         x: Optional[Union[str, List[float], np.ndarray, Undefined]] = UNDEF,

--- a/jscatter/widget.py
+++ b/jscatter/widget.py
@@ -69,6 +69,7 @@ class JupyterScatter(widgets.DOMWidget):
     x_scale = Unicode(None, allow_none=True).tag(sync=True)
     y_scale = Unicode(None, allow_none=True).tag(sync=True)
     selection = Array(default_value=None, allow_none=True).tag(sync=True, **ndarray_serialization)
+    filter = Array(default_value=None, allow_none=True).tag(sync=True, **ndarray_serialization)
     hovering = Int(None, allow_none=True).tag(sync=True)
 
     # View properties
@@ -82,10 +83,12 @@ class JupyterScatter(widgets.DOMWidget):
     zoom_animation = Int(1000).tag(sync=True)
     zoom_padding = Float(0.333).tag(sync=True)
     zoom_on_selection = Bool(False).tag(sync=True)
+    zoom_on_filter = Bool(False).tag(sync=True)
 
     # Interaction properties
     mouse_mode = Enum(['panZoom', 'lasso', 'rotate'], default_value='panZoom').tag(sync=True)
     lasso_initiator = Bool().tag(sync=True)
+    lasso_on_long_press = Bool().tag(sync=True)
 
     # Axes
     axes = Bool().tag(sync=True)


### PR DESCRIPTION
This PR addresses #61 and adds two new methods for filtering and updating the data: `scatter.filter()` and `scatter.data()`

### Filter

**API**:

```py
scatter.filter(point_idxs=[0, 1, 2])
```

**Example**:

```py
x = np.random.rand(500)
y = np.random.rand(500)

s1 = jscatter.Scatter(x=x, y=y)
s2 = jscatter.Scatter(x=x, y=y, zoom_on_filter=True)

def on_selection_change(change):
    s2.filter(change.new)

s1.widget.observe(on_selection_change, names='selection')

ipywidgets.HBox([s1.show(), s2.show()])
```

https://user-images.githubusercontent.com/932103/223148819-04060f54-9dc1-424c-bb3c-851f04d7690d.mp4


### Data

**API**:

```py
scatter.data(data=df)
```

**Example**:

```py
data = np.random.rand(500, 4)
df = pd.DataFrame(data, columns=['mass', 'speed', 'pval', 'group'])
df['group'] = df['group'].map(lambda c: chr(65 + round(c)), na_action=None)

s1 = jscatter.Scatter(data=df, x='mass', y='speed')
s2 = jscatter.Scatter(data=df, x='mass', y='speed')

def on_selection_change(change):
    new_data = df.iloc[change.new] if len(change.new) > 0 else df
    s2.data(new_data)

s1.widget.observe(on_selection_change, names='selection')
```

https://user-images.githubusercontent.com/932103/223148337-f0eecaa5-e467-4078-b604-007ab4d323e1.mp4

