### PR TITLE
fix: avoid ES6 class for codec

### DIFF
--- a/js/src/codecs.js
+++ b/js/src/codecs.js
@@ -17,75 +17,73 @@ const DTYPES = {
  * @prop {Shape} shape
  */
 
-class NumpyCodec {
-  /** @param {keyof typeof DTYPES} dtype */
-  constructor(dtype) {
-    if (!(dtype in DTYPES)) {
-      throw Error(`Dtype not supported, got ${JSON.stringify(dtype)}.`);
+function Numpy2D(dtype) {
+  if (!(dtype in DTYPES)) {
+    throw Error(`Dtype not supported, got ${JSON.stringify(dtype)}.`);
+  }
+  return {
+    /**
+     * @param {SerializedArray<[number, number]>} data
+     * @returns {number[][] | null}
+     */
+    deserialize(data) {
+      if (data == null) return null;
+      // Take full view of data buffer
+      const arr = new DTYPES[dtype](data.view.buffer);
+      // Chunk single TypedArray into nested Array of points
+      const [height, width] = data.shape;
+      // Float32Array(width * height) -> [Array(width), Array(width), ...]
+      const points = Array.from({ length: height }).map((_, i) =>
+        Array.from(arr.subarray(i * width, (i + 1) * width))
+      );
+      return points;
+    },
+    /**
+     * @param {number[][]} data
+     * @returns {SerializedArray<[number, number]>}
+     */
+    serialize(data) {
+      const height = data.length;
+      const width = data[0].length;
+      const arr = new DTYPES[dtype](height * width);
+      for (let i = 0; i < data.length; i++) {
+        arr.set(data[i], i * height);
+      }
+      return {
+        view: new DataView(arr.buffer),
+        dtype: dtype,
+        shape: [height, width],
+      };
     }
-    this.dtype = dtype;
   }
 }
 
-class Numpy2D extends NumpyCodec {
-  /**
-   * @param {SerializedArray<[number, number]>} data
-   * @returns {number[][] | null}
-   */
-  deserialize(data) {
-    if (data == null) return null;
-    // Take full view of data buffer
-    const arr = new DTYPES[this.dtype](data.view.buffer);
-    // Chunk single TypedArray into nested Array of points
-    const [height, width] = data.shape;
-    // Float32Array(width * height) -> [Array(width), Array(width), ...]
-    const points = Array.from({ length: height }).map((_, i) =>
-      Array.from(arr.subarray(i * width, (i + 1) * width))
-    );
-    return points;
+function Numpy1D(dtype) {
+  if (!(dtype in DTYPES)) {
+    throw Error(`Dtype not supported, got ${JSON.stringify(dtype)}.`);
   }
-
-  /**
-   * @param {number[][]} data
-   * @returns {SerializedArray<[number, number]>}
-   */
-  serialize(data) {
-    const height = data.length;
-    const width = data[0].length;
-    const arr = new DTYPES[this.dtype](height * width);
-    for (let i = 0; i < data.length; i++) {
-      arr.set(data[i], i * height);
+  return {
+    /**
+     * @param {SerializedArray<[number]>} data
+     * @returns {number[] | null}
+     */
+    deserialize(data) {
+      if (data == null) return null;
+      // for some reason can't be a typed array
+      return Array.from(new DTYPES[dtype](data.view.buffer));
+    },
+    /**
+     * @param {number[]} data
+     * @returns {SerializedArray<[number]>}
+     */
+    serialize(data) {
+      const arr = new DTYPES[dtype](data);
+      return {
+        view: new DataView(arr.buffer),
+        dtype: dtype,
+        shape: [data.length],
+      };
     }
-    return {
-      view: new DataView(arr.buffer),
-      dtype: this.dtype,
-      shape: [height, width],
-    };
-  }
-}
-
-class Numpy1D extends NumpyCodec {
-  /**
-   * @param {SerializedArray<[number]>} data
-   * @returns {number[] | null}
-   */
-  deserialize(data) {
-    if (data == null) return null;
-    // for some reason can't be a typed array
-    return Array.from(new DTYPES[this.dtype](data.view.buffer));
-  }
-
-  /**
-   * @param {number[]} data
-   * @returns {SerializedArray<[number]>}
-   */
-  serialize(data) {
-    const arr = new DTYPES[this.dtype](data);
-    return {
-      view: new DataView(arr.buffer),
-      dtype: this.dtype,
-      shape: [data.length],
-    };
   }
 }
 


### PR DESCRIPTION
I'm not sure but I was running into an issue where `this` was undefined in the codec, throwing an error when syncing selections. I'm not sure where the issue is coming from, but this PR just avoids relying on `this` and instead passes the `dtype` from a closure.
