### PR TITLE
feat: tooltip

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,6 +13,6 @@ Fixes #___
 - [ ] Provided a concise title as a [semantic commit message](https://www.conventionalcommits.org) (e.g. "fix: correctly handle undefined properties")
 - [ ] `CHANGELOG.md` updated
 - [ ] Tests added or updated
-- [ ] Documentation in `README.md` added or updated
+- [ ] Documentation in `API.md`/`README.md` added or updated
 - [ ] Example(s) added or updated
 - [ ] Screenshot, gif, or video attached for visual changes

--- a/API.md
+++ b/API.md
@@ -6,7 +6,7 @@
     - [selection()](#scatter.selection), [filter()](#scatter.filter)
     - [color()](#scatter.color), [opacity()](#scatter.opacity), and [size()](#scatter.size)
     - [connect()](#scatter.connect), [connection_color()](#scatter.connection_color), [connection_opacity()](#scatter.connection_opacity), and [connection_size()](#scatter.connection_size)
-    - [axes()](#scatter.axes) and [legend()](#scatter.legend)
+    - [axes()](#scatter.axes) [legend()](#scatter.legend),  and [tooltip()](#scatter.tooltip)
     - [zoom()](#scatter.zoom) and [camera()](#scatter.camera)
     - [lasso()](#scatter.lasso), [reticle()](#scatter.reticle), and [mouse()](#scatter.mouse),
     - [background()](#scatter.background) and [options()](scatter.options)
@@ -342,6 +342,24 @@ Set or get the legend settings.
 
 ```python
 scatter.legend(true, 'top-right', 'small')
+```
+
+
+<h3><a name="scatter.legend" href="#scatter.tooltip">#</a> scatter.<b>tooltip</b>(<i>enable=Undefined</i>, <i>contents=Undefined</i>, <i>size=Undefined</i>)</h3>
+
+Set or get the tooltip settings.
+
+**Arguments:**
+- `enable` is a Boolean specifying if the tooltip should be enabled or disabled.
+- `contents` is either `"all"` or a set of string specifying for which visual channels the data should be shown in the tooltip. It can be some of `x`, `y`, `color`, `opacity`, and `size`.
+- `size` is a string specifying the size of the legend. It must be one of `small`, `medium`, or `large`.
+
+**Returns:** either the legend properties when all arguments are `Undefined` or `self`.
+
+**Example:**
+
+```python
+scatter.tooltip(true, 'all', 'small')
 ```
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.14.0
+
+- Add the ability to show a tooltip upon hovering over a point via `scatter.tooltip(true)` ([#86](https://github.com/flekschas/jupyter-scatter/pull/86))
+
 ## v0.13.2
 
 - Fix a type in the return value of `scatter.xy()`
@@ -13,7 +17,7 @@
 - Fix: Add docstrings to `compose()` and `link()`
 - Fix: Optimize height of the legend
 - Fix: Check if axes are enabled before updating them when the x or y scale changes
-- Fix: Merge point selections on `SHIFT` instead of activating the lasso as `SHIFT` interfers with Jupyter Lab
+- Fix: Merge point selections on `SHIFT` instead of activating the lasso as `SHIFT` interferes with Jupyter Lab
 - Fix: Allow to call `scatter.zoomTo()` with the same points multiple times
 - Fix: Unfilter when calling `scatter.filter(None)`
 - Fix: Properly listen to changes when setting custom `regl-scatterplot` options via `scatter.options()`
@@ -25,7 +29,7 @@
 
 ## v0.12.5
 
-> **Warning**: do not use this version! The disitributed build is broken. Use `v0.12.6` instead. :pray:
+> **Warning**: do not use this version! The distributed build is broken. Use `v0.12.6` instead. :pray:
 
 - Ensure that the default point colors respect the background when setting both at the same time during initialization. I.e., in the following scenario, the point color will be set to _white_ by default as the background color was set to _black_:
 
@@ -108,7 +112,7 @@
 ## v0.10.0
 
 - Add support for automatic zooming to selected points via `scatter.zoom(on_selection=True)`
-- Fix view sychronization issue
+- Fix view synchronization issue
 - Add `remove()` to the JS widget to ensure that the scatterplot is destroyed in ipywidgets `v8`.
 
 ## v0.9.0
@@ -116,7 +120,7 @@
 - Add support for animated zooming to a set of points via `scatter.zoom(pointIndices)` ([#49](https://github.com/flekschas/jupyter-scatter/issues/49))
 - Bump regl-scatterplot to `v1.4.1`
 - Add support for VSCode and Colab ([#37](https://github.com/flekschas/jupyter-scatter/issues/37))
-- Fix serde of numpy data for JS client. Use consistent serialization object between JS and Python.
+- Fix serving of numpy data for JS client. Use consistent serialization object between JS and Python.
 
 ## v0.8.0
 

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -9,15 +9,17 @@
       "version": "0.13.1",
       "license": "Apache-2.0",
       "dependencies": {
+        "@flekschas/utils": "^0.32.1",
         "@jupyter-widgets/base": "^1.1 || ^2 || ^3 || ^4 || ^5 || ^6",
         "d3-axis": "~3.0.0",
+        "d3-format": "~3.1.0",
         "d3-scale": "~4.0.2",
         "d3-selection": "~3.0.0",
         "dom-2d-camera": "~2.2.5",
         "gl-matrix": "~3.3.0",
         "pub-sub-es": "~2.0.2",
         "regl": "~2.1.0",
-        "regl-scatterplot": "~1.7.1"
+        "regl-scatterplot": "~1.8.2"
       },
       "devDependencies": {
         "esbuild": "^0.17.14",
@@ -150,9 +152,9 @@
       }
     },
     "node_modules/@flekschas/utils": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@flekschas/utils/-/utils-0.31.0.tgz",
-      "integrity": "sha512-ejl+9LrhyTbKjokbTHFqlwBZjqMBttD3R4M5t6p6sKcLRBKVn4gDporO76b/yIGQ0esN90G6/+uGNgjpf/AzXA=="
+      "version": "0.32.1",
+      "resolved": "https://registry.npmjs.org/@flekschas/utils/-/utils-0.32.1.tgz",
+      "integrity": "sha512-T3jiw++IfNmm0L1/xGx0bqNYpv/imuUO0iQyF6CV+plJtoCdENw3WJ/yvZVOuK51/klnlV5EIMyhMpGTPsadxA=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.8",
@@ -2800,9 +2802,9 @@
       }
     },
     "node_modules/regl-scatterplot": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/regl-scatterplot/-/regl-scatterplot-1.7.1.tgz",
-      "integrity": "sha512-fi9Ybz3gh7KQw68lCKhrT1csqVY0ZG5wQhdGFrcdLNOH6BngSGkdYl8mT+q5RB/yVBQBZ3Wif6NHe12YADaWBg==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/regl-scatterplot/-/regl-scatterplot-1.8.2.tgz",
+      "integrity": "sha512-m4tB0EcV0oOnvNsMbbmwcznJXN1cPDRs1yKFwEG1WiZ1wAfLy5/g4kIdQhZFmNXBUlcnqt3IW81+sdvduEfTrg==",
       "dependencies": {
         "@flekschas/utils": "^0.31.0",
         "dom-2d-camera": "~2.2.5",
@@ -2821,6 +2823,11 @@
         "pub-sub-es": "~2.0.2",
         "regl": "~2.1.0"
       }
+    },
+    "node_modules/regl-scatterplot/node_modules/@flekschas/utils": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@flekschas/utils/-/utils-0.31.0.tgz",
+      "integrity": "sha512-ejl+9LrhyTbKjokbTHFqlwBZjqMBttD3R4M5t6p6sKcLRBKVn4gDporO76b/yIGQ0esN90G6/+uGNgjpf/AzXA=="
     },
     "node_modules/regl-scatterplot/node_modules/gl-matrix": {
       "version": "3.4.3",

--- a/js/package.json
+++ b/js/package.json
@@ -17,15 +17,17 @@
     "test": "npm run lint"
   },
   "dependencies": {
+    "@flekschas/utils": "^0.32.1",
     "@jupyter-widgets/base": "^1.1 || ^2 || ^3 || ^4 || ^5 || ^6",
     "d3-axis": "~3.0.0",
+    "d3-format": "~3.1.0",
     "d3-scale": "~4.0.2",
     "d3-selection": "~3.0.0",
     "dom-2d-camera": "~2.2.5",
     "gl-matrix": "~3.3.0",
     "pub-sub-es": "~2.0.2",
     "regl": "~2.1.0",
-    "regl-scatterplot": "~1.7.1"
+    "regl-scatterplot": "~1.8.2"
   },
   "devDependencies": {
     "esbuild": "^0.17.14",

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -1,6 +1,6 @@
 import createScatterplot, { createRenderer } from 'regl-scatterplot';
 import * as pubSub from 'pub-sub-es';
-import { getD3FormatSpecifier } from '@flekschas/utils';
+import { min, max, getD3FormatSpecifier } from '@flekschas/utils';
 
 import { axisBottom, axisRight } from 'd3-axis';
 import { format } from 'd3-format';
@@ -581,26 +581,62 @@ class JupyterScatterView {
     this.tooltipContentXChannel = document.createElement('div');
     this.tooltipContentXTitle = document.createElement('div');
     this.tooltipContentXValue = document.createElement('div');
+    this.tooltipContentXValueBadge = document.createElement('div');
+    this.tooltipContentXValueBadgeMark = document.createElement('div');
+    this.tooltipContentXValueBadgeBg = document.createElement('div');
+    this.tooltipContentXValueText = document.createElement('div');
+    this.tooltipContentXValueBadge.appendChild(this.tooltipContentXValueBadgeMark);
+    this.tooltipContentXValueBadge.appendChild(this.tooltipContentXValueBadgeBg);
+    this.tooltipContentXValue.appendChild(this.tooltipContentXValueBadge);
+    this.tooltipContentXValue.appendChild(this.tooltipContentXValueText);
 
     this.tooltipContentYChannel = document.createElement('div');
     this.tooltipContentYTitle = document.createElement('div');
     this.tooltipContentYValue = document.createElement('div');
+    this.tooltipContentYValueBadge = document.createElement('div');
+    this.tooltipContentYValueBadgeMark = document.createElement('div');
+    this.tooltipContentYValueBadgeBg = document.createElement('div');
+    this.tooltipContentYValueText = document.createElement('div');
+    this.tooltipContentYValueBadge.appendChild(this.tooltipContentYValueBadgeMark);
+    this.tooltipContentYValueBadge.appendChild(this.tooltipContentYValueBadgeBg);
+    this.tooltipContentYValue.appendChild(this.tooltipContentYValueBadge);
+    this.tooltipContentYValue.appendChild(this.tooltipContentYValueText);
 
     this.tooltipContentColorChannel = document.createElement('div');
     this.tooltipContentColorTitle = document.createElement('div');
     this.tooltipContentColorValue = document.createElement('div');
     this.tooltipContentColorValueBadge = document.createElement('div');
+    this.tooltipContentColorValueBadgeMark = document.createElement('div');
+    this.tooltipContentColorValueBadgeBg = document.createElement('div');
     this.tooltipContentColorValueText = document.createElement('div');
+    this.tooltipContentColorValueBadge.appendChild(this.tooltipContentColorValueBadgeMark);
+    this.tooltipContentColorValueBadge.appendChild(this.tooltipContentColorValueBadgeBg);
     this.tooltipContentColorValue.appendChild(this.tooltipContentColorValueBadge);
     this.tooltipContentColorValue.appendChild(this.tooltipContentColorValueText);
 
     this.tooltipContentOpacityChannel = document.createElement('div');
     this.tooltipContentOpacityTitle = document.createElement('div');
     this.tooltipContentOpacityValue = document.createElement('div');
+    this.tooltipContentOpacityValueBadge = document.createElement('div');
+    this.tooltipContentOpacityValueBadgeMark = document.createElement('div');
+    this.tooltipContentOpacityValueBadgeBg = document.createElement('div');
+    this.tooltipContentOpacityValueText = document.createElement('div');
+    this.tooltipContentOpacityValueBadge.appendChild(this.tooltipContentOpacityValueBadgeMark);
+    this.tooltipContentOpacityValueBadge.appendChild(this.tooltipContentOpacityValueBadgeBg);
+    this.tooltipContentOpacityValue.appendChild(this.tooltipContentOpacityValueBadge);
+    this.tooltipContentOpacityValue.appendChild(this.tooltipContentOpacityValueText);
 
     this.tooltipContentSizeChannel = document.createElement('div');
     this.tooltipContentSizeTitle = document.createElement('div');
     this.tooltipContentSizeValue = document.createElement('div');
+    this.tooltipContentSizeValueBadge = document.createElement('div');
+    this.tooltipContentSizeValueBadgeMark = document.createElement('div');
+    this.tooltipContentSizeValueBadgeBg = document.createElement('div');
+    this.tooltipContentSizeValueText = document.createElement('div');
+    this.tooltipContentSizeValueBadge.appendChild(this.tooltipContentSizeValueBadgeMark);
+    this.tooltipContentSizeValueBadge.appendChild(this.tooltipContentSizeValueBadgeBg);
+    this.tooltipContentSizeValue.appendChild(this.tooltipContentSizeValueBadge);
+    this.tooltipContentSizeValue.appendChild(this.tooltipContentSizeValueText);
 
     this.tooltipContentXChannel.textContent = 'X';
     this.tooltipContentYChannel.textContent = 'Y';
@@ -819,11 +855,90 @@ class JupyterScatterView {
     this.tooltipArrow.style.backgroundColor = bg;
     this.tooltipContent.style.backgroundColor = bg;
 
+    this.tooltipContentXValue.style.alignItems = 'center';
+    this.tooltipContentYValue.style.alignItems = 'center';
     this.tooltipContentColorValue.style.alignItems = 'center';
-    this.tooltipContentColorValueBadge.style.width = '0.5em';
-    this.tooltipContentColorValueBadge.style.height = '1em';
-    this.tooltipContentColorValueBadge.style.marginRight = '0.125rem';
-    this.tooltipContentColorValueBadge.style.borderRadius = '0.125rem';
+    this.tooltipContentOpacityValue.style.alignItems = 'center';
+    this.tooltipContentSizeValue.style.alignItems = 'center';
+
+    [
+      this.tooltipContentXValueBadge,
+      this.tooltipContentYValueBadge,
+      this.tooltipContentColorValueBadge,
+      this.tooltipContentOpacityValueBadge,
+      this.tooltipContentSizeValueBadge,
+    ].forEach((element) => {
+      element.style.position = 'relative';
+      element.style.width = '1em';
+      element.style.height = '1em';
+      element.style.marginRight = '0.125rem';
+    });
+
+    [
+      this.tooltipContentXValueBadgeBg,
+      this.tooltipContentYValueBadgeBg,
+      this.tooltipContentColorValueBadgeBg,
+      this.tooltipContentOpacityValueBadgeBg,
+      this.tooltipContentSizeValueBadgeBg,
+    ].forEach((element) => {
+      element.style.position = 'absolute';
+      element.style.zIndex = 2;
+      element.style.top = 0;
+      element.style.left = 0;
+      element.style.width = '1em';
+      element.style.height = '1em';
+    });
+
+    this.tooltipContentXValueBadgeBg.style.zIndex = 0;
+    this.tooltipContentXValueBadgeBg.style.top = '50%';
+    this.tooltipContentXValueBadgeBg.style.transform = 'translate(0, -50%)';
+    this.tooltipContentXValueBadgeBg.style.height = '2px';
+    this.tooltipContentXValueBadgeBg.style.background = `rgba(${contrast}, ${contrast}, ${contrast}, 0.2)`;
+
+    this.tooltipContentXValueBadgeMark.style.position = 'absolute';
+    this.tooltipContentXValueBadgeMark.style.zIndex = 1;
+    this.tooltipContentXValueBadgeMark.style.top = '50%';
+    this.tooltipContentXValueBadgeMark.style.width = '2px';
+    this.tooltipContentXValueBadgeMark.style.height = '6px';
+    this.tooltipContentXValueBadgeMark.style.background = `rgb(${contrast}, ${contrast}, ${contrast})`;
+
+    this.tooltipContentYValueBadgeBg.style.zIndex = 0;
+    this.tooltipContentYValueBadgeBg.style.left = '50%';
+    this.tooltipContentYValueBadgeBg.style.transform = 'translate(-50%, 0)';
+    this.tooltipContentYValueBadgeBg.style.width = '2px';
+    this.tooltipContentYValueBadgeBg.style.background = `rgba(${contrast}, ${contrast}, ${contrast}, 0.2)`;
+
+    this.tooltipContentYValueBadgeMark.style.position = 'absolute';
+    this.tooltipContentYValueBadgeMark.style.zIndex = 1;
+    this.tooltipContentYValueBadgeMark.style.left = '50%';
+    this.tooltipContentYValueBadgeMark.style.width = '6px';
+    this.tooltipContentYValueBadgeMark.style.height = '2px';
+    this.tooltipContentYValueBadgeMark.style.background = `rgb(${contrast}, ${contrast}, ${contrast})`;
+
+    [
+      this.tooltipContentOpacityValueBadgeBg,
+      this.tooltipContentSizeValueBadgeBg,
+    ].forEach((element) => {
+      element.style.borderRadius = '1em';
+      element.style.boxShadow = `inset 0 0 0 1px rgba(${contrast}, ${contrast}, ${contrast}, 0.2)`;
+    });
+
+    [
+      this.tooltipContentColorValueBadgeMark,
+      this.tooltipContentOpacityValueBadgeMark,
+      this.tooltipContentSizeValueBadgeMark,
+    ].forEach((element) => {
+      element.style.width = '1em';
+      element.style.height = '1em';
+      element.style.borderRadius = '1em';
+    });
+
+    [
+      this.tooltipContentOpacityValueBadgeMark,
+      this.tooltipContentSizeValueBadgeMark,
+    ].forEach((element) => {
+      element.style.background = `rgb(${contrast}, ${contrast}, ${contrast})`;
+    });
 
     const channelBg = `rgba(${contrast}, ${contrast}, ${contrast}, 0.075)`;
     const channelColor = `rgba(${contrast}, ${contrast}, ${contrast}, 0.5)`;
@@ -870,12 +985,19 @@ class JupyterScatterView {
 
   createXGetter() {
     if (!this.xScale) this.createXScale();
-    this.getX = (i) => this.xFormat(this.xScale.invert(this.getPoint(i)[0]));
+    this.getX = (i) => {
+      const xNdc = this.getPoint(i)[0];
+      return [(xNdc + 1) / 2, this.xFormat(this.xScale.invert(xNdc))];
+    }
   }
 
   createYGetter() {
     if (!this.yScale) this.createYScale();
-    this.getY = (i) => this.yFormat(this.yScale.invert(this.getPoint(i)[1]));
+    this.getY = (i) => {
+      const yNdc = this.getPoint(i)[1];
+      console.log('yNDC', yNdc);
+      return [(yNdc + 1) / 2, this.yFormat(this.yScale.invert(yNdc))];
+    }
   }
 
   createColorGetter() {
@@ -911,18 +1033,69 @@ class JupyterScatterView {
 
   createOpacityGetter() {
     if (!this.opacityScale) this.createOpacityScale();
+    if (!this.opacityScale) {
+      this.getOpacity = () => [0.5, 'Unknown'];
+      return;
+    }
+
     const dim = this.model.get('opacity_by') === 'valueA' ? 2 : 3;
-    this.getOpacity = this.opacityScale
-      ? (i) => this.opacityFormat(this.opacityScale.invert(this.getPoint(i)[dim]))
-      : () => undefined;
+    const opacities = this.model.get('opacity');
+
+    if (this.model.get('opacity_scale') === 'categorical') {
+      this.getOpacity = (i) => {
+        const value = this.getPoint(i)[dim];
+        return [
+          opacities[value] || '#808080',
+          this.opacityFormat(this.opacityScale.invert(value)),
+        ]
+      }
+    } else {
+      const numOpacities = opacities.length;
+      this.getOpacity = (i) => {
+        const value = this.getPoint(i)[dim];
+        const idx = Math.min(numOpacities - 1, Math.floor(numOpacities * value));
+        return [
+          opacities[idx] || 0.5,
+          this.opacityFormat(this.opacityScale.invert(value)),
+        ]
+      }
+    }
   }
 
   createSizeGetter() {
     if (!this.sizeScale) this.createSizeScale();
+    if (!this.sizeScale) {
+      this.getSize = () => [0.5, 'Unknown'];
+      return;
+    }
+
     const dim = this.model.get('size_by') === 'valueA' ? 2 : 3;
-    this.getSize = this.sizeScale
-      ? (i) => this.sizeFormat(this.sizeScale.invert(this.getPoint(i)[dim]))
-      : () => undefined;
+    const sizes = this.model.get('size');
+    const sizesMin = min(sizes);
+    const sizesMax = max(sizes);
+    const sizesExtent = sizesMax - sizesMin;
+
+    if (this.model.get('size_scale') === 'categorical') {
+      this.getSize = (i) => {
+        const value = this.getPoint(i)[dim];
+        return [
+          sizes[value] !== undefined
+            ? Math.max(0.1, (sizes[value] - sizesMin) / sizesExtent)
+            : '#808080',
+          this.sizeFormat(this.sizeScale.invert(value)),
+        ]
+      }
+    } else {
+      const numSizes = sizes.length;
+      this.getSize = (i) => {
+        const value = this.getPoint(i)[dim];
+        const idx = Math.min(numSizes - 1, Math.floor(numSizes * value));
+        return [
+          Math.max(0.1, (sizes[idx] - sizesMin) / sizesExtent),
+          this.sizeFormat(this.sizeScale.invert(value)),
+        ]
+      }
+    }
   }
 
   createTooltipContentUpdater() {
@@ -931,9 +1104,26 @@ class JupyterScatterView {
       const contentTitle = toCapitalCase(content);
       const get = this[`get${contentTitle}`];
 
+      const textElement = this[`tooltipContent${contentTitle}ValueText`];
+      const badgeElement = this[`tooltipContent${contentTitle}ValueBadgeMark`];
+
+      if (content === 'x') {
+        return (pointIdx) => {
+          const [x, text] = get(pointIdx);
+          badgeElement.style.transform = `translate(calc(${x}em - 50%), -50%)`;
+          textElement.textContent = text;
+        }
+      }
+
+      if (content === 'y') {
+        return (pointIdx) => {
+          const [y, text] = get(pointIdx);
+          badgeElement.style.transform = `translate(-50%, calc(${1 - y}em - 50%))`;
+          textElement.textContent = text;
+        }
+      }
+
       if (content === 'color') {
-        const badgeElement = this[`tooltipContent${contentTitle}ValueBadge`];
-        const textElement = this[`tooltipContent${contentTitle}ValueText`];
         return (pointIdx) => {
           const [color, text] = get(pointIdx);
           badgeElement.style.background = color;
@@ -941,9 +1131,23 @@ class JupyterScatterView {
         }
       }
 
-      const element = this[`tooltipContent${contentTitle}Value`];
+      if (content === 'opacity') {
+        return (pointIdx) => {
+          const [opacity, text] = get(pointIdx);
+          badgeElement.style.opacity = opacity;
+          textElement.textContent = text;
+        }
+      }
 
-      return (pointIdx) => element.textContent = get(pointIdx);
+      if (content === 'size') {
+        return (pointIdx) => {
+          const [scale, text] = get(pointIdx);
+          badgeElement.style.transform = `scale(${scale})`;
+          textElement.textContent = text;
+        }
+      }
+
+      return (pointIdx) => textElement.textContent = get(pointIdx);
     });
     this.tooltipContentsUpdater = (pointIdx) => {
       updaters.forEach((updater) => { updater(pointIdx); });

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -880,22 +880,38 @@ class JupyterScatterView {
 
   createColorGetter() {
     if (!this.colorScale) this.createColorScale();
+    if (!this.colorScale) {
+      this.getColor = () => ['#808080', 'Unknown'];
+      return;
+    }
+
     const dim = this.model.get('color_by') === 'valueA' ? 2 : 3;
     const colors = this.model.get('color').map((color) => `rgb(${color.slice(0, 3).map((v) => Math.round(v * 255)).join(', ')})`);
-    this.getColor = this.colorScale
-      ? (i) => {
+
+    if (this.model.get('color_scale') === 'categorical') {
+      this.getColor = (i) => {
         const value = this.getPoint(i)[dim];
         return [
           colors[value] || '#808080',
           this.colorFormat(this.colorScale.invert(value)),
         ]
       }
-      : () => undefined;
+    } else {
+      const numColors = colors.length;
+      this.getColor = (i) => {
+        const value = this.getPoint(i)[dim];
+        const colorIdx = Math.min(numColors - 1, Math.floor(numColors * value));
+        return [
+          colors[colorIdx] || '#808080',
+          this.colorFormat(this.colorScale.invert(value)),
+        ]
+      }
+    }
   }
 
   createOpacityGetter() {
     if (!this.opacityScale) this.createOpacityScale();
-    const dim = this.model.get('color_by') === 'valueA' ? 2 : 3;
+    const dim = this.model.get('opacity_by') === 'valueA' ? 2 : 3;
     this.getOpacity = this.opacityScale
       ? (i) => this.opacityFormat(this.opacityScale.invert(this.getPoint(i)[dim]))
       : () => undefined;
@@ -903,7 +919,7 @@ class JupyterScatterView {
 
   createSizeGetter() {
     if (!this.sizeScale) this.createSizeScale();
-    const dim = this.model.get('color_by') === 'valueA' ? 2 : 3;
+    const dim = this.model.get('size_by') === 'valueA' ? 2 : 3;
     this.getSize = this.sizeScale
       ? (i) => this.sizeFormat(this.sizeScale.invert(this.getPoint(i)[dim]))
       : () => undefined;

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -15,6 +15,7 @@ import {
   downloadBlob,
   getScale,
   createOrdinalScaleInverter,
+  getTooltipFontSize,
 } from "./utils";
 
 import { version } from "../package.json";
@@ -571,11 +572,11 @@ class JupyterScatterView {
     this.tooltipContent.style.position = 'relative';
     this.tooltipContent.style.display = 'grid';
     this.tooltipContent.style.gridTemplateColumns = 'max-content max-content max-content';
-    this.tooltipContent.style.gap = '0.25rem 0.2rem';
+    this.tooltipContent.style.gap = '0.3em 0.25em';
     this.tooltipContent.style.userSelect = 'none';
     this.tooltipContent.style.borderRadius = '0.2rem';
-    this.tooltipContent.style.padding = '0.2rem 0.25rem';
-    this.tooltipContent.style.fontSize = '0.675rem';
+    this.tooltipContent.style.padding = '0.25em';
+    this.tooltipContent.style.fontSize = getTooltipFontSize(this.model.get('tooltip_size'));
     this.tooltip.appendChild(this.tooltipContent);
 
     this.tooltipContentXChannel = document.createElement('div');
@@ -1176,8 +1177,8 @@ class JupyterScatterView {
     if (!tooltip) this.hideToolip;
   }
 
-  tooltipSizeHandler() {
-    this.styleTooltip();
+  tooltipSizeHandler(newSize) {
+    this.tooltipContent.style.fontSize = getTooltipFontSize(newSize);
   }
 
   tooltipColorHandler() {

--- a/js/src/utils.js
+++ b/js/src/utils.js
@@ -1,0 +1,53 @@
+import { scaleLog, scalePow, scaleLinear, scaleOrdinal } from 'd3-scale';
+
+export function camelToSnake(string) {
+  return string.replace(/[\w]([A-Z])/g, (m) => m[0] + "_" + m[1]).toLowerCase();
+}
+
+export function toCapitalCase(string) {
+  if (string.length === 0) return string;
+  return string.at(0).toUpperCase() + string.slice(1).toLowerCase();
+}
+
+export function downloadBlob(blob, name) {
+  const link = document.createElement('a');
+  link.href = URL.createObjectURL(blob);
+  link.download = name || 'jscatter.png';
+
+  document.body.appendChild(link);
+
+  link.dispatchEvent(
+    new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      view: window,
+    })
+  );
+
+  document.body.removeChild(link);
+}
+
+export function getScale(scaleType) {
+  if (scaleType.startsWith('log'))
+    return scaleLog().base(scaleType.split('_')[1] || 10);
+
+  if (scaleType.startsWith('pow'))
+    return scalePow().exponent(scaleType.split('_')[1] || 2);
+
+  if (scaleType === 'linear')
+    return scaleLinear();
+
+  return scaleOrdinal();
+}
+
+export function invertObjToMap(obj) {
+  return Object.keys(obj).reduce((invertedMap, key) => {
+    invertedMap.set(obj[key], key);
+    return invertedMap;
+  }, new Map());
+}
+
+export function createOrdinalScaleInverter(domain) {
+  const invertedDomainMap = invertObjToMap(domain);
+  return (value) => invertedDomainMap.get(value);
+}

--- a/js/src/utils.js
+++ b/js/src/utils.js
@@ -51,3 +51,9 @@ export function createOrdinalScaleInverter(domain) {
   const invertedDomainMap = invertObjToMap(domain);
   return (value) => invertedDomainMap.get(value);
 }
+
+export function getTooltipFontSize(size) {
+  if (size === 'large') return '1rem';
+  if (size === 'medium') return '0.85rem';
+  return '0.675rem';
+}

--- a/jscatter/encodings.py
+++ b/jscatter/encodings.py
@@ -3,7 +3,7 @@ import pandas as pd
 from dataclasses import dataclass
 from functools import reduce
 from math import floor
-from typing import List, Tuple, Union
+from typing import List, Tuple, Union, Optional
 
 def create_legend(encoding, norm, categories, labeling=None, linspace_num=5, category_order=None):
     variable = labeling.get('variable') if labeling else None
@@ -106,7 +106,7 @@ class Components():
 class VisualEncoding():
     channel: str  # Visual channel. E.g., color
     dimension: str  # Data dimension E.g., column name
-    legend: List[Tuple[float, Union[float, int, str]]] = None
+    legend: Optional[List[Tuple[float, Union[float, int, str]]]] = None
 
 
 class Encodings():

--- a/jscatter/encodings.py
+++ b/jscatter/encodings.py
@@ -104,8 +104,8 @@ class Components():
 
 @dataclass
 class VisualEncoding():
-    channel: str
-    data: str
+    channel: str  # Visual channel. E.g., color
+    dimension: str  # Data dimension E.g., column name
     legend: List[Tuple[float, Union[float, int, str]]] = None
 
 
@@ -116,30 +116,30 @@ class Encodings():
         self.max = total_components - reserved_components
         self.components = Components(total_components, reserved_components)
 
-    def set(self, visual_enc: str, data_enc: str):
-        # Remove previous `visual_enc` encoding
-        if self.is_unique(visual_enc):
-            self.delete(visual_enc)
+    def set(self, channel: str, dimension: str):
+        # Remove previous `channel` encoding
+        if self.is_unique(channel):
+            self.delete(channel)
 
-        if data_enc not in self.data:
+        if dimension not in self.data:
             assert not self.components.full, f'Only {self.max} data encodings are supported'
             # The first value specifies the component
             # The second value
-            self.data[data_enc] = self.components.add(data_enc)
+            self.data[dimension] = self.components.add(dimension)
 
-        self.visual[visual_enc] = VisualEncoding(visual_enc, data_enc)
+        self.visual[channel] = VisualEncoding(channel, dimension)
 
-    def get(self, visual_enc):
-        if visual_enc in self.visual:
-            return self.data[self.visual[visual_enc].data]
+    def get(self, channel):
+        if channel in self.visual:
+            return self.data[self.visual[channel].dimension]
 
-    def get_legend(self, visual_enc):
-        if visual_enc in self.visual:
-            return self.visual[visual_enc].legend
+    def get_legend(self, channel):
+        if channel in self.visual:
+            return self.visual[channel].legend
 
     def set_legend(
         self,
-        visual_enc,
+        channel,
         encoding,
         norm,
         categories,
@@ -147,8 +147,8 @@ class Encodings():
         linspace_num = 5,
         category_order = None,
     ):
-        if visual_enc in self.visual:
-            self.visual[visual_enc].legend = create_legend(
+        if channel in self.visual:
+            self.visual[channel].legend = create_legend(
                 encoding,
                 norm,
                 categories,
@@ -157,20 +157,20 @@ class Encodings():
                 category_order,
             )
 
-    def delete(self, visual_enc):
-        if visual_enc in self.visual:
-            data_enc = self.visual[visual_enc].data
+    def delete(self, channel):
+        if channel in self.visual:
+            dimension = self.visual[channel].dimension
 
-            del self.visual[visual_enc]
+            del self.visual[channel]
 
-            if sum([v == data_enc for v in self.visual.values()]) == 0:
-                self.components.delete(data_enc)
-                del self.data[data_enc]
+            if sum([v == dimension for v in self.visual.values()]) == 0:
+                self.components.delete(dimension)
+                del self.data[dimension]
 
-    def is_unique(self, visual_enc):
-        if visual_enc not in self.visual:
+    def is_unique(self, channel):
+        if channel not in self.visual:
             return False
 
         return sum(
-            [v.data == self.visual[visual_enc].data for v in self.visual.values()]
+            [v.dimension == self.visual[channel].dimension for v in self.visual.values()]
         ) == 1

--- a/jscatter/jscatter.py
+++ b/jscatter/jscatter.py
@@ -12,7 +12,7 @@ from .encodings import Encodings
 from .widget import JupyterScatter, SELECTION_DTYPE
 from .color_maps import okabe_ito, glasbey_light, glasbey_dark
 from .utils import any_not, to_ndc, tolist, uri_validator, to_scale_type, create_default_norm, create_labeling
-from .types import Color, Scales, MouseModes, All, Auto, Reverse, Segment, Size, LegendPosition, TooltipPosition, TooltipContent, Labeling, Undefined
+from .types import Color, Scales, MouseModes, All, Auto, Reverse, Segment, Size, LegendPosition, TooltipContent, Labeling, Undefined
 
 COMPONENT_CONNECT = 4
 COMPONENT_CONNECT_ORDER = 5
@@ -240,7 +240,6 @@ class Scatter():
         self._legend_size = 'small'
         self._tooltip = False
         self._tooltip_contents = all_tooltip_contents.copy()
-        self._tooltip_position = 'top'
         self._tooltip_size = 'small'
         self._zoom_to = None
         self._zoom_to_call_idx = 0
@@ -344,7 +343,6 @@ class Scatter():
         self.tooltip(
             kwargs.get('tooltip', UNDEF),
             kwargs.get('tooltip_contents', UNDEF),
-            kwargs.get('tooltip_position', UNDEF),
             kwargs.get('tooltip_size', UNDEF),
         )
         self.zoom(
@@ -3005,7 +3003,6 @@ class Scatter():
         self,
         tooltip: Optional[Union[bool, Undefined]] = UNDEF,
         contents: Optional[Union[All, Set[TooltipContent], Undefined]] = UNDEF,
-        position: Optional[Union[TooltipPosition, Undefined]] = UNDEF,
         size: Optional[Union[Size, Undefined]] = UNDEF,
     ):
         """
@@ -3016,9 +3013,10 @@ class Scatter():
         tooltip : bool, optional
             When set to `True`, a tooltip will be shown upon hovering a point.
         contents : all or set(str), optional
-            The tooltip position. Must be one of top, left, right, bottom.
-        position : str, optional
-            The tooltip position. Must be one of top, left, right, bottom.
+            The channels that should be shown in the tooltip. Note, that only
+            the visual channels that are actually used for encoding will be
+            shown in the tooltip eventually. Can be either `all` (default) or
+            some of `x`, `y`, `color`, `opacity`, and `size`.
         size : small or medium or large, optional
             The size of the tooltip. Must be one of small, medium, or large
 
@@ -3033,14 +3031,14 @@ class Scatter():
         >>> scatter.tooltip(True)
         <jscatter.jscatter.Scatter>
 
-        >>> scatter.tooltip(position='right')
+        >>> scatter.tooltip(contents={'color', 'opacity'})
         <jscatter.jscatter.Scatter>
 
         >>> scatter.tooltip(size='large')
         <jscatter.jscatter.Scatter>
 
         >>> scatter.tooltip()
-        {'tooltip': True, 'position': 'right', size: 'large'}
+        {'tooltip': True, 'contents': {'color', 'opacity'}, size: 'large'}
         """
         if tooltip is not UNDEF:
             self._tooltip = tooltip
@@ -3052,10 +3050,6 @@ class Scatter():
             self._tooltip_contents = contents
             self.update_widget('tooltip_contents', contents)
 
-        if position is not UNDEF:
-            self._tooltip_position = position
-            self.update_widget('tooltip_position', position)
-
         if size is not UNDEF:
             self._tooltip_size = size
             self.update_widget('tooltip_size', size)
@@ -3066,7 +3060,6 @@ class Scatter():
         return dict(
             legend = self._tooltip,
             contents = self._tooltip_contents,
-            position = self._tooltip_position,
             size = self._tooltip_size,
         )
 
@@ -3367,7 +3360,6 @@ class Scatter():
             tooltip_enable=self._tooltip,
             tooltip_contents=self._tooltip_contents,
             tooltip_size=self._tooltip_size,
-            tooltip_position=self._tooltip_position,
             tooltip_color=self.get_tooltip_color(),
             zoom_to=self._zoom_to,
             zoom_animation=self._zoom_animation,

--- a/jscatter/jscatter.py
+++ b/jscatter/jscatter.py
@@ -83,6 +83,21 @@ def get_map_order(map, categories):
 
     return order
 
+def get_scale(scatter: Scatter, channel: str):
+    return to_scale_type(
+        getattr(scatter, f'_{channel}_norm')
+        if getattr(scatter, f'_{channel}_categories') is None
+        else None
+    )
+
+def get_domain(scatter: Scatter, channel: str):
+    if getattr(scatter, f'_{channel}_categories') is None:
+        return (
+            getattr(scatter, f'_{channel}_norm').vmin,
+            getattr(scatter, f'_{channel}_norm').vmax
+        )
+    return getattr(scatter, f'_{channel}_categories')
+
 
 class Scatter():
     def __init__(
@@ -1056,13 +1071,8 @@ class Scatter():
                 self._color_labeling,
                 category_order=self._color_map_order,
             )
-            self.update_widget('color_scale', to_scale_type(self._color_norm if self._color_categories is None else None))
-            self.update_widget(
-                'color_domain',
-                (self._color_norm.vmin, self._color_norm.vmax)
-                if self._color_categories is None
-                else self._color_categories
-            )
+            self.update_widget('color_scale', get_scale(self, 'color'))
+            self.update_widget('color_domain', get_domain(self, 'color'))
         else:
             self.update_widget('color', self._color)
 
@@ -1288,13 +1298,8 @@ class Scatter():
                     self._opacity_labeling,
                     category_order=self._opacity_map_order,
                 )
-            self.update_widget('opacity_scale', to_scale_type(self._opacity_norm if self._opacity_categories is None else None))
-            self.update_widget(
-                'opacity_domain',
-                (self._opacity_norm.vmin, self._opacity_norm.vmax)
-                if self._opacity_categories is None
-                else self._opacity_categories
-            )
+            self.update_widget('opacity_scale', get_scale(self, 'opacity'))
+            self.update_widget('opacity_domain', get_domain(self, 'opacity'))
         else:
             self.update_widget('opacity', self._opacity)
 
@@ -1505,13 +1510,8 @@ class Scatter():
                 self._size_labeling,
                 category_order=self._size_map_order,
             )
-            self.update_widget('size_scale', to_scale_type(self._size_norm if self._size_categories is None else None))
-            self.update_widget(
-                'size_domain',
-                (self._size_norm.vmin, self._size_norm.vmax)
-                if self._size_categories is None
-                else self._size_categories
-            )
+            self.update_widget('size_scale', get_scale(self, 'size'))
+            self.update_widget('size_domain', get_domain(self, 'size'))
         else:
             self.update_widget('size', self._size)
 
@@ -3054,7 +3054,7 @@ class Scatter():
             self._tooltip_size = size
             self.update_widget('tooltip_size', size)
 
-        if any_not([tooltip, position, size], UNDEF):
+        if any_not([tooltip, contents, size], UNDEF):
             return self
 
         return dict(
@@ -3296,76 +3296,76 @@ class Scatter():
             return self._widget
 
         self._widget = JupyterScatter(
-            x_scale=to_scale_type(self._x_scale),
-            y_scale=to_scale_type(self._y_scale),
-            color_scale=to_scale_type(self._color_norm if self._color_categories is None else None),
-            opacity_scale=to_scale_type(self._opacity_norm if self._opacity_categories is None else None),
-            size_scale=to_scale_type(self._size_norm if self._size_categories is None else None),
-            x_title=self._x_by,
-            y_title=self._y_by,
-            color_title=self._color_by,
-            opacity_title=self._opacity_by,
-            size_title=self._size_by,
-            points=self.get_point_list(),
-            selection=self._selected_points_idxs,
-            filter=self._filtered_points_idxs,
-            width=self._width,
-            height=self._height,
+            axes=self._axes,
+            axes_color=self.get_axes_color(),
+            axes_grid=self._axes_grid,
+            axes_labels=self._axes_labels,
             background_color=self._background_color,
             background_image=self._background_image,
+            camera_distance=self._camera_distance,
+            camera_rotation=self._camera_rotation,
+            camera_target=self._camera_target,
+            camera_view=self._camera_view,
+            color=order_map(self._color_map, self._color_order) if self._color_map else self._color,
+            color_by=self.js_color_by,
+            color_domain=get_domain(self, 'color'),
+            color_hover=self._color_hover,
+            color_scale=get_scale(self, 'color'),
+            color_selected=self._color_selected,
+            color_title=self._color_by,
+            connect=bool(self._connect_by),
+            connection_color=order_map(self._connection_color_map, self._connection_color_order) if self._connection_color_map else self._connection_color,
+            connection_color_by=self.js_connection_color_by,
+            connection_color_hover=self._connection_color_hover,
+            connection_color_selected=self._connection_color_selected,
+            connection_opacity=order_map(self._connection_opacity_map, self._connection_opacity_order) if self._connection_opacity_map else self._connection_opacity,
+            connection_opacity_by=self.js_connection_opacity_by,
+            connection_size=order_map(self._connection_size_map, self._connection_size_order) if self._connection_size_map else self._connection_size,
+            connection_size_by=self.js_connection_size_by,
+            filter=self._filtered_points_idxs,
+            height=self._height,
             lasso_color=self._lasso_color,
             lasso_initiator=self._lasso_initiator,
             lasso_min_delay=self._lasso_min_delay,
             lasso_min_dist=self._lasso_min_dist,
             lasso_on_long_press=self._lasso_on_long_press,
-            color=order_map(self._color_map, self._color_order) if self._color_map else self._color,
-            color_selected=self._color_selected,
-            color_hover=self._color_hover,
-            color_by=self.js_color_by,
-            opacity=order_map(self._opacity_map, self._opacity_order) if self._opacity_map else self._opacity,
-            opacity_by=self.js_opacity_by,
-            opacity_unselected=self._opacity_unselected,
-            size=order_map(self._size_map, self._size_order) if self._size_map else self._size,
-            size_by=self.js_size_by,
-            connect=bool(self._connect_by),
-            connection_color=order_map(self._connection_color_map, self._connection_color_order) if self._connection_color_map else self._connection_color,
-            connection_color_selected=self._connection_color_selected,
-            connection_color_hover=self._connection_color_hover,
-            connection_color_by=self.js_connection_color_by,
-            connection_opacity=order_map(self._connection_opacity_map, self._connection_opacity_order) if self._connection_opacity_map else self._connection_opacity,
-            connection_opacity_by=self.js_connection_opacity_by,
-            connection_size=order_map(self._connection_size_map, self._connection_size_order) if self._connection_size_map else self._connection_size,
-            connection_size_by=self.js_connection_size_by,
-            reticle=self._reticle,
-            reticle_color=self.get_reticle_color(),
-            camera_target=self._camera_target,
-            camera_distance=self._camera_distance,
-            camera_rotation=self._camera_rotation,
-            camera_view=self._camera_view,
-            mouse_mode=self._mouse_mode,
-            x_domain=self._x_domain,
-            y_domain=self._y_domain,
-            color_domain=self._color_categories,
-            opacity_domain=self._opacity_categories,
-            size_domain=self._size_categories,
-            axes=self._axes,
-            axes_grid=self._axes_grid,
-            axes_labels=self._axes_labels,
-            axes_color=self.get_axes_color(),
             legend=self._legend,
-            legend_size=self._legend_size,
-            legend_position=self._legend_position,
             legend_color=self.get_legend_color(),
             legend_encoding=self.get_legend_encoding(),
-            tooltip_enable=self._tooltip,
-            tooltip_contents=self._tooltip_contents,
-            tooltip_size=self._tooltip_size,
+            legend_position=self._legend_position,
+            legend_size=self._legend_size,
+            mouse_mode=self._mouse_mode,
+            opacity=order_map(self._opacity_map, self._opacity_order) if self._opacity_map else self._opacity,
+            opacity_by=self.js_opacity_by,
+            opacity_domain=get_domain(self, 'opacity'),
+            opacity_scale=get_scale(self, 'opacity'),
+            opacity_title=self._opacity_by,
+            opacity_unselected=self._opacity_unselected,
+            points=self.get_point_list(),
+            reticle=self._reticle,
+            reticle_color=self.get_reticle_color(),
+            selection=self._selected_points_idxs,
+            size=order_map(self._size_map, self._size_order) if self._size_map else self._size,
+            size_by=self.js_size_by,
+            size_domain=get_domain(self, 'size'),
+            size_scale=get_scale(self, 'size'),
+            size_title=self._size_by,
             tooltip_color=self.get_tooltip_color(),
-            zoom_to=self._zoom_to,
+            tooltip_contents=self._tooltip_contents,
+            tooltip_enable=self._tooltip,
+            tooltip_size=self._tooltip_size,
+            width=self._width,
+            x_domain=self._x_domain,
+            x_scale=to_scale_type(self._x_scale),
+            x_title=self._x_by,
+            y_domain=self._y_domain,
+            y_scale=to_scale_type(self._y_scale),
+            y_title=self._y_by,
             zoom_animation=self._zoom_animation,
-            zoom_on_selection=self._zoom_on_selection,
             zoom_on_filter=self._zoom_on_filter,
+            zoom_on_selection=self._zoom_on_selection,
             zoom_padding=self._zoom_padding,
+            zoom_to=self._zoom_to,
             other_options=self._options
         )
 

--- a/jscatter/types.py
+++ b/jscatter/types.py
@@ -52,12 +52,6 @@ class LegendPosition(Enum):
     LEFT = 'left'
     CENTER = 'center'
 
-class TooltipPosition(Enum):
-    TOP = 'top'
-    BOTTOM = 'bottom'
-    RIGHT = 'right'
-    LEFT = 'left'
-
 class TooltipContent(Enum):
     X = 'x'
     Y = 'y'

--- a/jscatter/types.py
+++ b/jscatter/types.py
@@ -29,6 +29,9 @@ class MouseModes(Enum):
     LASSO = 'lasso'
     ROTATE = 'rotate'
 
+class All(Enum):
+    ALL = 'all'
+
 class Auto(Enum):
     AUTO = 'auto'
 
@@ -38,7 +41,7 @@ class Reverse(Enum):
 class Segment(Enum):
     SEGMENT = 'segment'
 
-class Position(Enum):
+class LegendPosition(Enum):
     TOP = 'top'
     TOP_RIGHT = 'top-right'
     TOP_LEFT = 'top-left'
@@ -48,6 +51,19 @@ class Position(Enum):
     RIGHT = 'right'
     LEFT = 'left'
     CENTER = 'center'
+
+class TooltipPosition(Enum):
+    TOP = 'top'
+    BOTTOM = 'bottom'
+    RIGHT = 'right'
+    LEFT = 'left'
+
+class TooltipContent(Enum):
+    X = 'x'
+    Y = 'y'
+    COLOR = 'color'
+    OPACITY = 'opacity'
+    SIZE = 'size'
 
 class Labeling(TypedDict):
     variable: NotRequired[str]

--- a/jscatter/utils.py
+++ b/jscatter/utils.py
@@ -53,14 +53,17 @@ def create_default_norm():
 def to_ndc(X, norm):
     return (norm(X).data * 2) - 1
 
-def to_scale_type(norm):
+def to_scale_type(norm = None):
     if (isinstance(norm, LogNorm)):
         return 'log_10'
 
     if (isinstance(norm, PowerNorm)):
         return f'pow_{norm.gamma}'
 
-    return 'linear'
+    if (isinstance(norm, Normalize)):
+        return 'linear'
+
+    return 'categorical'
 
 def create_labeling(partial_labeling, column: Union[str, None] = None) -> Labeling:
     labeling: Labeling = {}

--- a/jscatter/widget.py
+++ b/jscatter/widget.py
@@ -1,6 +1,4 @@
-import io
 import base64
-import uuid
 import IPython.display as ipydisplay
 import ipywidgets as widgets
 import matplotlib.pyplot as plt
@@ -8,8 +6,7 @@ import numpy as np
 import anywidget
 import pathlib
 
-from IPython.display import display, update_display
-from traitlets import Bool, Dict, Enum, Float, Int, List, Unicode, Union
+from traitlets import Bool, Dict, Enum, Float, Int, List, Set, Unicode, Union
 from traittypes import Array
 
 from .utils import to_hex, with_left_label
@@ -59,13 +56,30 @@ class JupyterScatter(anywidget.AnyWidget):
     # Data
     points = Array(default_value=None).tag(sync=True, **ndarray_serialization)
     prevent_filter_reset = Bool(False).tag(sync=True)
-    x_domain = List(minlen=2, maxlen=2).tag(sync=True)
-    y_domain = List(minlen=2, maxlen=2).tag(sync=True)
-    x_scale = Unicode(None, allow_none=True).tag(sync=True)
-    y_scale = Unicode(None, allow_none=True).tag(sync=True)
     selection = Array(default_value=None, allow_none=True).tag(sync=True, **ndarray_serialization)
     filter = Array(default_value=None, allow_none=True).tag(sync=True, **ndarray_serialization)
     hovering = Int(None, allow_none=True).tag(sync=True)
+
+    # Channel titles
+    x_title = Unicode(None, allow_none=True).tag(sync=True)
+    y_title = Unicode(None, allow_none=True).tag(sync=True)
+    color_title = Unicode(None, allow_none=True).tag(sync=True)
+    opacity_title = Unicode(None, allow_none=True).tag(sync=True)
+    size_title = Unicode(None, allow_none=True).tag(sync=True)
+
+    # Scales
+    x_scale = Unicode(None, allow_none=True).tag(sync=True)
+    y_scale = Unicode(None, allow_none=True).tag(sync=True)
+    color_scale = Unicode(None, allow_none=True).tag(sync=True)
+    opacity_scale = Unicode(None, allow_none=True).tag(sync=True)
+    size_scale = Unicode(None, allow_none=True).tag(sync=True)
+
+    # Domains
+    x_domain = List(minlen=2, maxlen=2).tag(sync=True)
+    y_domain = List(minlen=2, maxlen=2).tag(sync=True)
+    color_domain = Union([Dict(), List(minlen=2, maxlen=2)], allow_none=True).tag(sync=True)
+    opacity_domain = Union([Dict(), List(minlen=2, maxlen=2)], allow_none=True).tag(sync=True)
+    size_domain = Union([Dict(), List(minlen=2, maxlen=2)], allow_none=True).tag(sync=True)
 
     # View properties
     camera_target = List([0, 0]).tag(sync=True)
@@ -115,6 +129,18 @@ class JupyterScatter(anywidget.AnyWidget):
         default_value=[0, 0, 0, 1], minlen=4, maxlen=4
     ).tag(sync=True)
     legend_encoding = Dict(dict()).tag(sync=True)
+
+    # Tooltip
+    tooltip_enable = Bool().tag(sync=True)
+    tooltip_size = Enum(
+        ['small', 'medium', 'large'], default_value='small'
+    ).tag(sync=True)
+    tooltip_color = List(
+        default_value=[0, 0, 0, 1], minlen=4, maxlen=4
+    ).tag(sync=True)
+    tooltip_contents = Set(
+        default_value={'x', 'y', 'color', 'opacity', 'size'}
+    ).tag(sync=True)
 
     # Options
     color = Union([Union([Unicode(), List(minlen=4, maxlen=4)]), List(Union([Unicode(), List(minlen=4, maxlen=4)]))]).tag(sync=True)


### PR DESCRIPTION
This PR adds support for showing a tooltip upon hovering a point.

## Description

> What was changed in this pull request?

This PR adds a new method to the `Scatter` class called `tooltip`:

```py
# Enable tooltip via the constructor
scatter = Scatter(data=df, x='mass', y='speed', color_by='group', size=6, tooltip=True)

# Or via the `tooltip` method
scatter.tooltip(true, contents={'color'})
```

### Examples

<img width="531" alt="Screenshot 2023-08-14 at 7 58 53 PM" src="https://github.com/flekschas/jupyter-scatter/assets/932103/a77e5fb7-f56f-4738-bdff-2f0fa7705bb0">


https://github.com/flekschas/jupyter-scatter/assets/932103/eeae0635-d12a-46d3-a9b3-cd2515d699b9

<img width="533" alt="Screenshot 2023-08-14 at 7 59 35 PM" src="https://github.com/flekschas/jupyter-scatter/assets/932103/71960cc0-669f-4b32-9249-3c739dd454e2">


https://github.com/flekschas/jupyter-scatter/assets/932103/258d0b93-50e9-4c28-a45f-928d6973a435


<img width="534" alt="Screenshot 2023-08-14 at 8 10 22 PM" src="https://github.com/flekschas/jupyter-scatter/assets/932103/4cb110fc-9f43-466a-9fc6-7f5d5b062b3e">

<img width="535" alt="Screenshot 2023-08-14 at 8 10 02 PM" src="https://github.com/flekschas/jupyter-scatter/assets/932103/133498c5-9d8d-4127-bacc-8edf0f10e91b">


> Why is it necessary?

It makes it easier to interpret data points by showing the underlying data that is visually encoded by the `x`, `y`, `color`, `opacity`, or `size` channel.

## Checklist

- [x] Provided a concise title as a [semantic commit message](https://www.conventionalcommits.org) (e.g. "fix: correctly handle undefined properties")
- [x] `CHANGELOG.md` updated
- [ ] Tests added or updated
- [x] Documentation in `API.md`/`README.md` added or updated
- [ ] Example(s) added or updated
- [x] Screenshot, gif, or video attached for visual changes
