### PR TITLE
fix: show missing x-axes and updating all axes of linked scatter plots upon pan&zoom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Add the ability to show a tooltip upon hovering over a point via `scatter.tooltip(true)` ([#86](https://github.com/flekschas/jupyter-scatter/pull/86))
 - Fix axes updating of linked scatter plots when panning and zooming ([#87](https://github.com/flekschas/jupyter-scatter/issues/87))
+- Fix missing x-axes of linked scatter plots ([#84](https://github.com/flekschas/jupyter-scatter/issues/84))
 
 ## v0.13.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v0.14.0
 
 - Add the ability to show a tooltip upon hovering over a point via `scatter.tooltip(true)` ([#86](https://github.com/flekschas/jupyter-scatter/pull/86))
+- Fix axes updating of linked scatter plots when panning and zooming ([#87](https://github.com/flekschas/jupyter-scatter/issues/87))
 
 ## v0.13.2
 

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -1377,9 +1377,28 @@ class JupyterScatterView {
     }
   }
 
+  updateAxes(xScaleDomain, yScaleDomain) {
+    if (!this.model.get('axes')) return;
+
+    this.xScaleAxis.domain(xScaleDomain.map(this.xScaleRegl2Axis.invert));
+    this.yScaleAxis.domain(yScaleDomain.map(this.yScaleRegl2Axis.invert));
+
+    this.xAxisContainer.call(this.xAxis.scale(this.xScaleAxis));
+    this.yAxisContainer.call(this.yAxis.scale(this.yScaleAxis));
+
+    if (this.model.get('axes_grid')) {
+      this.axesSvg.selectAll('line')
+        .attr('stroke-opacity', 0.2)
+        .attr('stroke-dasharray', 2);
+    }
+  }
+
   externalViewChangeHandler(event) {
     if (event.uuid === this.viewSync && event.src !== this.randomStr) {
       this.scatterplot.view(event.view, { preventEvent: true });
+      if (this.model.get('axes')) {
+        this.updateAxes(event.xScaleDomain, event.yScaleDomain);
+      }
     }
   }
 
@@ -1391,22 +1410,14 @@ class JupyterScatterView {
           src: this.randomStr,
           uuid: this.viewSync,
           view: event.view,
+          xScaleDomain: event.xScale.domain(),
+          yScaleDomain: event.yScale.domain(),
         },
         { async: true }
       );
     }
     if (this.model.get('axes')) {
-      this.xScaleAxis.domain(event.xScale.domain().map(this.xScaleRegl2Axis.invert));
-      this.yScaleAxis.domain(event.yScale.domain().map(this.yScaleRegl2Axis.invert));
-
-      this.xAxisContainer.call(this.xAxis.scale(this.xScaleAxis));
-      this.yAxisContainer.call(this.yAxis.scale(this.yScaleAxis));
-
-      if (this.model.get('axes_grid')) {
-        this.axesSvg.selectAll('line')
-          .attr('stroke-opacity', 0.2)
-          .attr('stroke-dasharray', 2);
-      }
+      this.updateAxes(event.xScale.domain(), event.yScale.domain());
     }
   }
 

--- a/jscatter/compose.py
+++ b/jscatter/compose.py
@@ -5,6 +5,10 @@ from typing import List, Optional, Union, Tuple
 
 from .jscatter import Scatter
 
+AXES_LABEL_SIZE = 16;
+AXES_PADDING_Y = 20;
+AXES_PADDING_Y_WITH_LABEL = AXES_PADDING_Y + AXES_LABEL_SIZE;
+
 def compose(
     scatters: Union[List[Scatter], List[Tuple[Scatter, str]]],
     sync_view: bool = False,
@@ -193,9 +197,12 @@ def compose(
 
         return hover_handler
 
+    has_labels = any([get_scatter(i)._axes_labels != False for i, _ in enumerate(scatters)])
+    y_padding = AXES_PADDING_Y_WITH_LABEL if has_labels else  AXES_PADDING_Y
+
     for i, _ in enumerate(scatters):
         scatter = get_scatter(i)
-        scatter.height(row_height)
+        scatter.height(row_height - y_padding)
 
         trait_notifiers = scatter.widget._trait_notifiers
 


### PR DESCRIPTION
This PR fixes two issues with axes of linked scatter plots: it makes sure the x-axes are always shown and that all axes updated appropriately upon view changes.

## Description

> What was changed in this pull request?

The missing x-axes was a result of an incorrect assigned height. With this fix the height of the scatter plots shrinks to give space to the x-axes.

<img width="1000" alt="Screenshot 2023-08-14 at 9 35 51 PM" src="https://github.com/flekschas/jupyter-scatter/assets/932103/6a6d4b19-5df5-4fe5-9c1e-6037499b7f05">

<img width="1001" alt="Screenshot 2023-08-14 at 9 36 08 PM" src="https://github.com/flekschas/jupyter-scatter/assets/932103/4a4cdf6c-2276-4220-a0dc-a50bc666c895">

<img width="998" alt="Screenshot 2023-08-14 at 9 36 20 PM" src="https://github.com/flekschas/jupyter-scatter/assets/932103/93647e4a-128e-4c60-aa57-eeb782c173d0">

<img width="1001" alt="Screenshot 2023-08-14 at 9 36 33 PM" src="https://github.com/flekschas/jupyter-scatter/assets/932103/21fb61c9-84c2-43a9-b075-a668b236cdeb">

With this PR, all axes also update appropriately upon pan & zoom events of linked scatter plots

https://github.com/flekschas/jupyter-scatter/assets/932103/ee6cd826-4d14-4bc7-b611-d5f3259dcc97

> Why is it necessary?

Fixes #84
Fixes #87

## Checklist

- [x] Provided a concise title as a [semantic commit message](https://www.conventionalcommits.org) (e.g. "fix: correctly handle undefined properties")
- [x] `CHANGELOG.md` updated
- [ ] Tests added or updated
- [ ] Documentation in `API.md`/`README.md` added or updated
- [ ] Example(s) added or updated
- [x] Screenshot, gif, or video attached for visual changes
