### PR TITLE
fix: several smaller issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,10 @@ js/npm-debug.log
 js/node_modules
 js/dist
 
+docs/npm-debug.log
+docs/node_modules
+docs/dist
+
 jscatter/labextension
 jscatter/nbextension
 jscatter/bundle.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
+## v0.14.1
+
+- Fix: update `color`, `opacity`, and `size` scales as the domains update
+- Fix: auto-reset `x` and `y` scale domains upon updating the `x` and `y` data
+- Fix: use better number formatter for the legend
+
 ## v0.14.0
 
 - Add the ability to show a tooltip upon hovering over a point via `scatter.tooltip(true)` ([#86](https://github.com/flekschas/jupyter-scatter/pull/86))
 - Fix axes updating of linked scatter plots when panning and zooming ([#87](https://github.com/flekschas/jupyter-scatter/issues/87))
 - Fix missing x-axes of linked scatter plots ([#84](https://github.com/flekschas/jupyter-scatter/issues/84))
-
-## v0.13.2
-
 - Fix a type in the return value of `scatter.xy()`
 
 ## v0.13.1

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -19,7 +19,7 @@
         "gl-matrix": "~3.3.0",
         "pub-sub-es": "~2.0.2",
         "regl": "~2.1.0",
-        "regl-scatterplot": "~1.8.2"
+        "regl-scatterplot": "~1.8.4"
       },
       "devDependencies": {
         "esbuild": "^0.17.14",
@@ -2802,9 +2802,9 @@
       }
     },
     "node_modules/regl-scatterplot": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/regl-scatterplot/-/regl-scatterplot-1.8.2.tgz",
-      "integrity": "sha512-m4tB0EcV0oOnvNsMbbmwcznJXN1cPDRs1yKFwEG1WiZ1wAfLy5/g4kIdQhZFmNXBUlcnqt3IW81+sdvduEfTrg==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/regl-scatterplot/-/regl-scatterplot-1.8.4.tgz",
+      "integrity": "sha512-f+h7/0Vqd0APXvYlCj8cnYpc48n9NxK2dk0CYVguxbQwmP3357JWmXCZqIgyqkmSf5uJvhIEySvP6vPcb5zGuQ==",
       "dependencies": {
         "@flekschas/utils": "^0.31.0",
         "dom-2d-camera": "~2.2.5",

--- a/js/package.json
+++ b/js/package.json
@@ -27,7 +27,7 @@
     "gl-matrix": "~3.3.0",
     "pub-sub-es": "~2.0.2",
     "regl": "~2.1.0",
-    "regl-scatterplot": "~1.8.2"
+    "regl-scatterplot": "~1.8.4"
   },
   "devDependencies": {
     "esbuild": "^0.17.14",

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -1513,6 +1513,7 @@ class JupyterScatterView {
   }
 
   yScaleHandler() {
+    this.createYScale();
     if (this.model.get('axes')) this.createAxes();
   }
 
@@ -1522,19 +1523,20 @@ class JupyterScatterView {
   }
 
   yDomainHandler() {
+    this.createYScale();
     if (this.model.get('axes')) this.createAxes();
   }
 
   colorDomainHandler() {
-    if (this.model.get('axes')) this.createAxes();
+    this.createColorScale();
   }
 
   opacityDomainHandler() {
-    if (this.model.get('axes')) this.createAxes();
+    this.createOpacityScale();
   }
 
   sizeDomainHandler() {
-    if (this.model.get('axes')) this.createAxes();
+    this.createSizeScale();
   }
 
   // Event handlers for Python-triggered events

--- a/js/src/legend.js
+++ b/js/src/legend.js
@@ -1,3 +1,6 @@
+import { getD3FormatSpecifier } from '@flekschas/utils';
+import { format } from 'd3-format';
+
 const sortOrder = {
   'color': 0,
   'opacity': 1,
@@ -7,21 +10,15 @@ const sortOrder = {
   'connection_size': 5,
 }
 
-function createLabelFormatter(valueRange) {
+function createLabelFormatter(valueRange, isCategorical) {
   const min = valueRange[0];
   const max = valueRange[1];
 
-  if (Number.isNaN(Number(min)) || Number.isNaN(Number(max))) {
+  if (isCategorical || Number.isNaN(Number(min)) || Number.isNaN(Number(max))) {
     return function (value) { return value };
   }
 
-  const extent = max - min;
-
-  const i = Math.floor(Math.log10(extent));
-  const k = Math.max(0, i >= 0 ? 2 - i : 1 - i);
-  const l = Math.pow(10, k);
-
-  return function (value) { return (Math.round(value * l) / l).toFixed(k); }
+  return format(getD3FormatSpecifier(valueRange));
 }
 
 function createValue(value) {
@@ -154,16 +151,19 @@ export function createLegend(encodings, fontColor, backgroundColor, size) {
       encoding.appendChild(createLabel(visualEncoding.variable));
 
       const valueRange = [
-        visualEncoding.values[0][0],
-        visualEncoding.values[visualEncoding.values.length - 1][0]
+        visualEncoding.values.at(0).at(0),
+        visualEncoding.values.at(-1).at(0)
       ];
 
       const encodingRange = [
-        visualEncoding.values[0][1],
-        visualEncoding.values[visualEncoding.values.length - 1][1]
+        visualEncoding.values.at(0).at(1),
+        visualEncoding.values.at(-1).at(1)
       ];
 
-      const formatter = createLabelFormatter(valueRange);
+      const formatter = createLabelFormatter(
+        valueRange,
+        visualEncoding.categorical
+      );
 
       const values = typeof visualEncoding.values[0][0] === 'number'
         ? [...visualEncoding.values].reverse()

--- a/jscatter/encodings.py
+++ b/jscatter/encodings.py
@@ -28,7 +28,11 @@ def create_legend(encoding, norm, categories, labeling=None, linspace_num=5, cat
             values[0] = (*values[0][0:2], labeling.get('minValue'))
             values[-1] = (*values[-1][0:2], labeling.get('maxValue'))
 
-    return dict(variable=variable, values=values)
+    return dict(
+        variable=variable,
+        values=values,
+        categorical=categories is not None
+    )
 
 
 class Component():

--- a/jscatter/jscatter.py
+++ b/jscatter/jscatter.py
@@ -544,7 +544,6 @@ class Scatter():
                 try:
                     self._x_scale.vmin = self._x_min
                     self._x_scale.vmax = self._x_max
-                    print(self._x_scale.vmin, self._x_scale.vmax)
                 except ValueError:
                     pass
 

--- a/jscatter/jscatter.py
+++ b/jscatter/jscatter.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 import math
 import matplotlib.pyplot as plt
-import matplotlib
 import numpy as np
 import pandas as pd
 
@@ -540,6 +539,15 @@ class Scatter():
             self._x_max = np.max(self._points[:, 0])
             self._x_domain = [self._x_min, self._x_max]
 
+            # Reset scale to new domain
+            if scale is UNDEF:
+                try:
+                    self._x_scale.vmin = self._x_min
+                    self._x_scale.vmax = self._x_max
+                    print(self._x_scale.vmin, self._x_scale.vmax)
+                except ValueError:
+                    pass
+
             # Normalize x coordinate to [-1,1]
             self._points[:, 0] = to_ndc(self._points[:, 0], self._x_scale)
 
@@ -633,6 +641,14 @@ class Scatter():
             self._y_min = np.min(self._points[:, 1])
             self._y_max = np.max(self._points[:, 1])
             self._y_domain = [self._y_min, self._y_max]
+
+            # Reset scale to new domain
+            if scale is UNDEF:
+                try:
+                    self._y_scale.vmin = self._y_min
+                    self._y_scale.vmax = self._y_max
+                except ValueError:
+                    pass
 
             # Normalize y coordinate to [-1,1]
             self._points[:, 1] = to_ndc(self._points[:, 1], self._y_scale)


### PR DESCRIPTION
This PR fixes several smaller glitches around the updating of the `color`, `opacity`, and `size` domains, the `x`/`y` data updating, and legend formatting.

## Description

> What was changed in this pull request?

1. Fix: update `color`, `opacity`, and `size` scales (on the front-end) as the respective domains update
2. Fix: reset `x` and `y` scale domains to the new min/max data values when the `x` and `y` data is updated
3. Fix: use better number formatting for the legend
4. Fix: update `regl-scatterplot` to `v1.8.4` which fixes a bug related to the opacity encoding

> Why is it necessary?

1. Previously, when the widget's `color_domain`, `opacity_domain`, or `size_domain` would upadate, the front-end would not automatically update the corresponding scale functions and the tooltip would show outdated information.
2. Previously, when one updated the `x` or `y` data and the data had different domains, one needed to explicitly reset the scales via `scatter.x(newX, scale=None)` and `scatter.y(newY, scale=None)`. This is annoying and unintuitive.
3. Previously, the formatting could make numbers have unnecessary trailing zeros like `2020.0` or `0.500`. Now, trailing zeros are removed
4. Previously, there was an edge case where the opacity encoding didn't work properly. The new version of `regl-scatterplot` fixes this.

## Checklist

- [x] Provided a concise title as a [semantic commit message](https://www.conventionalcommits.org) (e.g. "fix: correctly handle undefined properties")
- [x] `CHANGELOG.md` updated
- [ ] Tests added or updated
- [ ] Documentation in `API.md`/`README.md` added or updated
- [ ] Example(s) added or updated
- [ ] Screenshot, gif, or video attached for visual changes
