### PR TITLE
fix: view synchronization without axes, propper compose heights, tooltip value getters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Fix view synchronization when axes are _not_ shown
 - Fix y-padding size determination
+- Fix stale channel value getter for the tooltip
 
 ## v0.14.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.14.2
+
+- Fix view synchronization when axes are _not_ shown
+
 ## v0.14.1
 
 - Fix: update `color`, `opacity`, and `size` scales as the domains update

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v0.14.2
 
 - Fix view synchronization when axes are _not_ shown
+- Fix y-padding size determination
 
 ## v0.14.1
 

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -258,7 +258,8 @@ class JupyterScatterView {
 
       window.pubSub = pubSub;
 
-      this.viewSyncHandler(this.model.get('view_sync'));
+      this.viewSync = this.model.get('view_sync');
+      this.viewSyncHandler(this.viewSync);
 
       if ('ResizeObserver' in window) {
         this.canvasObserver = new ResizeObserver(this.resizeHandlerBound);
@@ -972,8 +973,6 @@ class JupyterScatterView {
     ].forEach((el) => {
       el.style.fontWeight = 'bold';
     });
-
-
   }
 
   getPoint(i) {
@@ -1395,7 +1394,7 @@ class JupyterScatterView {
   externalViewChangeHandler(event) {
     if (event.uuid === this.viewSync && event.src !== this.randomStr) {
       this.scatterplot.view(event.view, { preventEvent: true });
-      if (this.model.get('axes')) {
+      if (this.model.get('axes') && event.xScaleDomain && event.yScaleDomain) {
         this.updateAxes(event.xScaleDomain, event.yScaleDomain);
       }
     }
@@ -1409,8 +1408,8 @@ class JupyterScatterView {
           src: this.randomStr,
           uuid: this.viewSync,
           view: event.view,
-          xScaleDomain: event.xScale.domain(),
-          yScaleDomain: event.yScale.domain(),
+          xScaleDomain: event.xScale?.domain(),
+          yScaleDomain: event.yScale?.domain(),
         },
         { async: true }
       );

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -1101,7 +1101,7 @@ class JupyterScatterView {
     const contents = new Set(this.model.get('tooltip_contents'));
     const updaters = Array.from(contents).map((content) => {
       const contentTitle = toCapitalCase(content);
-      const get = this[`get${contentTitle}`];
+      const get = (pointIdx) => this[`get${contentTitle}`](pointIdx);
 
       const textElement = this[`tooltipContent${contentTitle}ValueText`];
       const badgeElement = this[`tooltipContent${contentTitle}ValueBadgeMark`];

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -20,7 +20,7 @@ import {
 
 import { version } from "../package.json";
 
-const AXES_LABEL_SIZE = 16;
+const AXES_LABEL_SIZE = 12;
 const AXES_PADDING_X = 40;
 const AXES_PADDING_X_WITH_LABEL = AXES_PADDING_X + AXES_LABEL_SIZE;
 const AXES_PADDING_Y = 20;

--- a/jscatter/compose.py
+++ b/jscatter/compose.py
@@ -75,10 +75,14 @@ def compose(
     has_titles = any([isinstance(scatter, tuple) for scatter in scatters])
 
     def get_scatter(i: int) -> Scatter:
-        return scatters[i][0] if has_titles else scatters[i]
+        if has_titles and isinstance(scatters[i], tuple):
+            return scatters[i][0]
+        return scatters[i]
 
     def get_title(i: int) -> str:
-        return scatters[i][1] if has_titles else str(i)
+        if has_titles and isinstance(scatters[i], tuple):
+            return scatters[i][1]
+        return "&nbsp;"
 
     if isinstance(match_by, list):
         assert all([match_by[i] in get_scatter(i)._data for i, _ in enumerate(scatters)])

--- a/jscatter/compose.py
+++ b/jscatter/compose.py
@@ -5,9 +5,9 @@ from typing import List, Optional, Union, Tuple
 
 from .jscatter import Scatter
 
+TITLE_HEIGHT = 28;
 AXES_LABEL_SIZE = 16;
 AXES_PADDING_Y = 20;
-AXES_PADDING_Y_WITH_LABEL = AXES_PADDING_Y + AXES_LABEL_SIZE;
 
 def compose(
     scatters: Union[List[Scatter], List[Tuple[Scatter, str]]],
@@ -72,12 +72,12 @@ def compose(
     elif match_by != 'index':
         match_by = [match_by] * len(scatters)
 
-    has_titles = len(scatters) > 0 and isinstance(scatters[0], tuple)
+    has_titles = any([isinstance(scatter, tuple) for scatter in scatters])
 
-    def get_scatter(i):
+    def get_scatter(i: int) -> Scatter:
         return scatters[i][0] if has_titles else scatters[i]
 
-    def get_title(i):
+    def get_title(i: int) -> str:
         return scatters[i][1] if has_titles else str(i)
 
     if isinstance(match_by, list):
@@ -197,8 +197,24 @@ def compose(
 
         return hover_handler
 
-    has_labels = any([get_scatter(i)._axes_labels != False for i, _ in enumerate(scatters)])
-    y_padding = AXES_PADDING_Y_WITH_LABEL if has_labels else  AXES_PADDING_Y
+    has_axes = any([
+        get_scatter(i)._axes != False
+        for i, _
+        in enumerate(scatters)
+    ])
+    y_padding = AXES_PADDING_Y if has_axes else 0
+
+    if has_axes:
+        has_labels = any([
+            get_scatter(i)._axes_labels != False
+            for i, _
+            in enumerate(scatters)
+        ])
+        y_padding = y_padding + AXES_LABEL_SIZE if has_labels else y_padding
+
+    y_padding = y_padding + TITLE_HEIGHT if has_titles else y_padding
+
+    print("y_padding", y_padding, row_height - y_padding)
 
     for i, _ in enumerate(scatters):
         scatter = get_scatter(i)

--- a/jscatter/compose.py
+++ b/jscatter/compose.py
@@ -214,8 +214,6 @@ def compose(
 
     y_padding = y_padding + TITLE_HEIGHT if has_titles else y_padding
 
-    print("y_padding", y_padding, row_height - y_padding)
-
     for i, _ in enumerate(scatters):
         scatter = get_scatter(i)
         scatter.height(row_height - y_padding)


### PR DESCRIPTION
This PR fixes three bugs:
1. make sure view synchronization works when `axes=False`
2. properly adjust scatter height when `compose()`ing scatters that have titles, axes labels, or no axes
3. make sure the tooltip doesn't use a stale channel value getter function

## Description

> What was changed in this pull request?

View sync and height adjustment works as expected:

https://github.com/flekschas/jupyter-scatter/assets/932103/c6e35059-0002-430e-befe-dc4c17f4c6c1

Tooltip getter is fresh as expected:

https://github.com/flekschas/jupyter-scatter/assets/932103/ebbeb661-69f9-4052-b875-07ee8e600b69

> Why is it necessary?

Previously,
1. view synching wouldn't due to regression from #88 (https://github.com/flekschas/jupyter-scatter/pull/88/files#diff-3aa09978cb18aff029d3dd6535a2b9ee0a8c4df561ceae68517deb6bac6ffa7aR1413-R1414)
2. when composing scatters with titles, the title height wouldn't properly be subtracted from the scatter height and so the x axis could get pushed out of the view
3. due to a closure, the tooltip could use a scale channel value getter

## Checklist

- [x] Provided a concise title as a [semantic commit message](https://www.conventionalcommits.org) (e.g. "fix: correctly handle undefined properties")
- [x] `CHANGELOG.md` updated
- [ ] Tests added or updated
- [ ] Documentation in `API.md`/`README.md` added or updated
- [ ] Example(s) added or updated
- [x] Screenshot, gif, or video attached for visual changes
