### PR TITLE
docs: add documentation site

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -17,13 +17,13 @@ export default defineConfig({
     ['meta', { name: 'og:site_name', content: 'Jupyter Scatter' }],
     [
       'meta',
-      { name: 'og:image', content: 'https://jupyter-scatter.dev/og.jpg' }
+      { name: 'og:image', content: 'https://jupyter-scatter.dev/jupyter-scatter-og.jpg' }
     ],
     [
       'meta',
       {
         name: 'twitter:image',
-        content: 'https://jupyter-scatter.dev/og.jpg'
+        content: 'https://jupyter-scatter.dev/jupyter-scatter-og.jpg'
       }
     ],
   ],

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,0 +1,96 @@
+import { defineConfig } from 'vitepress';
+
+import pkg from '../../js/package.json';
+
+// https://vitepress.dev/reference/site-config
+export default defineConfig({
+  lang: 'en-US',
+  title: 'Jupyter Scatter',
+  description: 'An interactive scatter plot widget for Jupyter Notebook, Lab, and Google Colab that can handle millions of points and supports view linking',
+  lastUpdated: true,
+  cleanUrls: true,
+  head: [
+    ['link', { rel: 'icon', href: '/favicon.svg' }],
+    ['meta', { name: 'theme-color', content: '#FEC10E' }],
+    ['meta', { name: 'og:type', content: 'website' }],
+    ['meta', { name: 'og:locale', content: 'en' }],
+    ['meta', { name: 'og:site_name', content: 'Jupyter Scatter' }],
+    [
+      'meta',
+      { name: 'og:image', content: 'https://jupyter-scatter.dev/og.jpg' }
+    ],
+    [
+      'meta',
+      {
+        name: 'twitter:image',
+        content: 'https://jupyter-scatter.dev/og.jpg'
+      }
+    ],
+  ],
+  themeConfig: {
+    logo: { src: '/favicon.svg', width: 24, height: 24 },
+
+    nav: [
+      { text: 'Home', link: '/' },
+      { text: 'Get Started', link: '/get-started' },
+      // { text: 'Examples', link: '/examples' },
+      { text: 'API', link: '/api' },
+      {
+        text: `v${pkg.version}`,
+        items: [
+          {
+            text: 'pypi',
+            link: 'https://pypi.org/project/jupyter-scatter/'
+          },
+          {
+            text: 'Changelog',
+            link: 'https://github.com/flekschas/jupyter-scatter/blob/main/CHANGELOG.md'
+          }
+        ]
+      }
+    ],
+
+    sidebar: [
+      {
+        text: 'Get Started',
+        items: [
+          { text: 'Plotting', link: '/get-started' },
+          { text: 'Interactions', link: '/interactions' },
+          { text: 'Selections', link: '/selections' },
+          { text: 'Link Multiple Scatter Plots', link: '/link-multiple-plots' },
+          { text: 'Axes, Legend, & Toolip', link: '/axes-legend-tooltip' }
+        ]
+      },
+      // {
+      //   text: 'Examples',
+      //   items: [
+      //     { text: 'Exploring LLM-based sentence embeddings', link: '/sentence-embeddings' },
+      //     { text: 'Comparing multiple embedding methods of the Fashion MNIST dataset', link: '/image-embeddings' },
+      //     { text: 'Browsing genomic data with HiGlass and loci embeddings', link: '/genomic-embeddings' },
+      //     { text: 'Comparing a pair of single-cell embeddings by their label abundance differences', link: '/single-cell-embeddings' },
+      //   ]
+      // },
+      {
+        text: 'API Reference',
+        link: '/api',
+      },
+      {
+        text: 'SciPy \'23 Tutorials',
+        link: 'https://github.com/flekschas/jupyter-scatter-tutorial',
+      }
+    ],
+
+    socialLinks: [
+      { icon: 'github', link: 'https://github.com/flekschas/jupyter-scatter' }
+    ],
+
+    search: {
+      provider: 'local'
+    },
+
+    footer: {
+      message: 'Released under the <a href="https://github.com/flekschas/jupyter-scatter/blob/main/LICENSE">Apache License Version 2.0</a>.',
+      copyright: 'Copyright © 2021-present <a href="https://lekschas.de" target="_blank" rel="noreferrer">Fritz Lekschas</a>.'
+    },
+  }
+})

--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -1,0 +1,148 @@
+<script setup>
+  import DefaultTheme from "vitepress/theme";
+
+  import { videoColorModeSrcSwitcher } from '../../utils';
+
+  videoColorModeSrcSwitcher();
+</script>
+
+<template>
+  <DefaultTheme.Layout>
+    <template #home-hero-image>
+      <video
+        autoplay
+        loop
+        muted
+        data-name="teaser"
+        poster="/images/teaser-dark.jpg"
+      >
+        <source
+          src="/videos/teaser-dark.mp4"
+          type="video/mp4"
+        />
+      </video>
+    </template>
+    <template #home-features-after>
+      <section id="scipy-talk">
+        <div class="container">
+          <h3>Learn About Jupyter Scatter</h3>
+          <div class="card">
+            <div class="youtube-container">
+              <span />
+              <iframe
+                src="https://www.youtube.com/embed/RyC5ixtQG-Q?si=Vn1EDWvx1LHGyys7"
+                title="YouTube Player Showing Jupyter Scatter talk from the SciPy 2023 conference"
+                frameborder="0"
+                scrolling="no"
+                allow="fullscreen"
+                allowfullscreen
+              />
+            </div>
+          </div>
+          <p>In this talk you'll learn how to use Jupyter Scatter for exploring large-scale datasets using geospatial, single-cell, image, and text embeddings.</p>
+        </div>
+      </section>
+    </template>
+  </DefaultTheme.Layout>
+</template>
+
+<style scoped>
+  video {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    border-radius: 0.5rem;
+    padding: 0.25rem 0.5rem;
+    box-shadow: 0 0.05rem 0.25rem 0 rgba(0, 0, 0, 0.1), 0 0.2rem 1rem 0 rgba(0, 0, 0, 0.1);
+    background: #FDFDFD;
+  }
+
+  :root.dark video {
+    box-shadow: 0 0.05rem 0.25rem 0 rgba(0, 0, 0, 0.5), 0 0.2rem 1rem 0 rgba(0, 0, 0, 0.33);
+    background: #1B1B1E;
+  }
+
+  #scipy-talk {
+    position: relative;
+    padding: 48px 24px;
+  }
+
+  #scipy-talk .container {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    max-width: 1152px;
+    margin: 0 auto;
+  }
+
+  #scipy-talk h3 {
+    font-size: 2rem;
+    line-height: 3rem;
+    font-weight: 700;
+    color: var(--vp-c-text-1);
+  }
+
+  #scipy-talk p {
+    font-size: 1rem;
+    color: var(--vp-c-text-2);
+    width: 100%;
+    text-align: center;
+  }
+
+  :root.dark #scipy-talk p {
+    color: var(--vp-c-text-3);
+  }
+
+  #scipy-talk .card {
+    position: relative;
+    margin: 1rem 0;
+    padding: 12px;
+    width: 100%;
+    border: 1px solid var(--vp-c-bg-soft);
+    border-radius: 12px;
+    background-color: var(--vp-c-bg-soft);
+  }
+
+  #scipy-talk .youtube-container {
+    position: relative;
+  }
+
+  #scipy-talk .youtube-container span {
+    display: block;
+    padding-top: 60%;
+  }
+
+  #scipy-talk .youtube-container iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
+
+  @media (min-width: 640px) {
+    #scipy-talk {
+      padding: 64px 48px;
+    }
+
+    #scipy-talk .card, #scipy-talk p {
+      width: 75%;
+    }
+
+    .video {
+      max-height: unset;
+    }
+  }
+
+  @media (min-width: 960px) {
+    #scipy-talk {
+      padding: 96px 64px;
+    }
+
+    #scipy-talk .card, #scipy-talk p {
+      width: 66%;
+    }
+  }
+</style>

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -1,0 +1,12 @@
+:root {
+  --vp-c-brand-1: #F2AA00;
+  --vp-c-brand-2: #6EB3E4;
+  --vp-c-brand-3: #D99400;
+}
+
+.dark {
+  --vp-c-bg: #1E1E20;
+  --vp-c-brand-1: #FEC10E;
+  --vp-c-brand-2: #6EB3E4;
+  --vp-c-brand-3: #CC9900;
+}

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,0 +1,9 @@
+// .vitepress/theme/index.js
+import DefaultTheme from 'vitepress/theme';
+import Layout from './Layout.vue';
+import './custom.css';
+
+export default {
+  ...DefaultTheme,
+  Layout: Layout,
+};

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,24 +1,25 @@
-# API Docs
+# API Reference
 
 - [Scatter](#scatter)
   - [Methods](#methods)
     - [x()](#scatter.x), [y()](#scatter.x), [xy()](#scatter.xy), and [data()](#scatter.data)
-    - [selection()](#scatter.selection), [filter()](#scatter.filter)
+    - [selection()](#scatter.selection) anda [filter()](#scatter.filter)
     - [color()](#scatter.color), [opacity()](#scatter.opacity), and [size()](#scatter.size)
     - [connect()](#scatter.connect), [connection_color()](#scatter.connection_color), [connection_opacity()](#scatter.connection_opacity), and [connection_size()](#scatter.connection_size)
-    - [axes()](#scatter.axes) [legend()](#scatter.legend),  and [tooltip()](#scatter.tooltip)
+    - [axes()](#scatter.axes), [legend()](#scatter.legend), and [tooltip()](#scatter.tooltip)
     - [zoom()](#scatter.zoom) and [camera()](#scatter.camera)
     - [lasso()](#scatter.lasso), [reticle()](#scatter.reticle), and [mouse()](#scatter.mouse),
     - [background()](#scatter.background) and [options()](scatter.options)
   - [Properties](#properties)
   - [Widget](#widget)
-- [Plotting](#plotting)
-- [Composing \& Linking](#composing--linking)
+- [Plotting Shorthand](#plotting)
+- [Composing \& Linking](#composing-linking)
 - [Color Maps](#color-maps)
 
-# Scatter
 
-<h3><a name="Scatter" href="#Scatter">#</a> <b>Scatter</b>(<i>x</i>, <i>y</i>, <i>data = None</i>, <i>**kwargs</i>)</h3>
+## Scatter
+
+### Scatter(_x_, _y_, _data=None_, _\*\*kwargs_) {#Scatter}
 
 **Arguments:**
 
@@ -37,9 +38,10 @@ scatter = Scatter(x='speed', y='weight', data=cars)
 scatter.show()
 ```
 
-## Methods
 
-<h3><a name="scatter.x" href="#scatter.x">#</a> scatter.<b>x</b>(<i>x=Undefined</i>, <i>scale=Undefined</i>, <i>**kwargs</i>)</h3>
+## Scatter Methods {#methods}
+
+### scatter.x(_x=Undefined_, _scale=Undefined_, _\*\*kwargs_) {#scatter.x}
 
 Get or set the x coordinate.
 
@@ -58,7 +60,8 @@ Get or set the x coordinate.
 scatter.x('price') # Triggers and animated transition of the x coordinates
 ```
 
-<h3><a name="scatter.y" href="#scatter.y">#</a> scatter.<b>y</b>(<i>y=Undefined</i>, <i>scale=Undefined</i>, <i>**kwargs</i>)</h3>
+
+### scatter.y(_y=Undefined_, _scale=Undefined_, _\*\*kwargs_) {#scatter.y}
 
 Get or set the y coordinate.
 
@@ -77,7 +80,8 @@ Get or set the y coordinate.
 scatter.y('price') # Triggers and animated transition of the y coordinates
 ```
 
-<h3><a name="scatter.xy" href="#scatter.xy">#</a> scatter.<b>xy</b>(<i>x=Undefined</i>, <i>y=Undefined</i>, <i>x_scale=Undefined</i>, <i>y_scale=Undefined</i>, <i>**kwargs</i>)</h3>
+
+### scatter.xy(_x=Undefined_, _y=Undefined_, _x_scale=Undefined_, _y_scale=Undefined_, _\*\*kwargs_) {#scatter.xy}
 
 Get or set the x and y coordinate. This is just a convenience function to animate a change in the x and y coordinate at the same time.
 
@@ -98,7 +102,8 @@ Get or set the x and y coordinate. This is just a convenience function to animat
 scatter.xy('size', 'speed') # Mirror plot along the diagonal
 ```
 
-<h3><a name="scatter.data" href="#scatter.data">#</a> scatter.<b>data</b>(<i>data=Undefined</i>, <i>use_index=Undefined</i>, <i>**kwargs</i>)</h3>
+
+### scatter.data(_data=Undefined_, _use_index=Undefined_, _\*\*kwargs_) {#scatter.data}
 
 Get or set the referenced Pandas DataFrame. This is just a convenience function to animate a change in the x and y coordinate at the same time.
 
@@ -117,7 +122,8 @@ Get or set the referenced Pandas DataFrame. This is just a convenience function 
 scatter.data(df)
 ```
 
-<h3><a name="scatter.selection" href="#scatter.selection">#</a> scatter.<b>selection</b>(<i>point_idxs=Undefined</i>)</h3>
+
+### scatter.selection(_point_idxs=Undefined_) {#scatter.selection}
 
 Get or set the selected points.
 
@@ -141,7 +147,8 @@ scatter.selection()
 # => array([0, 42, 1337], dtype=uint32)
 ```
 
-<h3><a name="scatter.filter" href="#scatter.filter">#</a> scatter.<b>filter</b>(<i>point_idxs=Undefined</i>)</h3>
+
+### scatter.filter(_point_idxs=Undefined_) {#scatter.filter}
 
 Get or set the filtered points. When filtering down to a set of points, all other points will be hidden from the view.
 
@@ -158,7 +165,8 @@ scatter.filter(cars.query('speed < 50').index)
 scatter.filter(None) # To unset filter
 ```
 
-<h3><a name="scatter.color" href="#scatter.color">#</a> scatter.<b>color</b>(<i>default=Undefined</i>, <i>selected=Undefined</i>, <i>hover=Undefined</i>, <i>by=Undefined</i>, <i>map=Undefined</i>, <i>norm=Undefined</i>, <i>order=Undefined</i>, <i>labeling=Undefined</i>, <i>**kwargs</i>)</h3>
+
+### scatter.color(_default=Undefined_, _selected=Undefined_, _hover=Undefined_, _by=Undefined_, _map=Undefined_, _norm=Undefined_, _order=Undefined_, _labeling=Undefined_, _\*\*kwargs_) {#scatter.color}
 
 Get or set the point color.
 
@@ -199,7 +207,8 @@ scatter.color(
 scatter.color(by='gpd', map='viridis')
 ```
 
-<h3><a name="scatter.opacity" href="#scatter.opacity">#</a> scatter.<b>opacity</b>(<i>default=Undefined</i>, <i>unselected=Undefined</i>, <i>by=Undefined</i>, <i>map=Undefined</i>, <i>norm=Undefined</i>, <i>order=Undefined</i>, <i>labeling=Undefined</i>, <i>**kwargs</i>)</h3>
+
+### scatter.opacity(_default=Undefined_, _unselected=Undefined_, _by=Undefined_, _map=Undefined_, _norm=Undefined_, _order=Undefined_, _labeling=Undefined_, _\*\*kwargs_) {#scatter.opacity}
 
 Get or set the point opacity.
 
@@ -228,7 +237,8 @@ scatter.opacity(by='price', map=(1, 0.25, 10))
 scatter.opacity(by='density')
 ```
 
-<h3><a name="scatter.size" href="#scatter.size">#</a> scatter.<b>size</b>(<i>default=Undefined</i>, <i>by=Undefined</i>, <i>map=Undefined</i>, <i>norm=Undefined</i>, <i>order=Undefined</i>, <i>labeling=Undefined</i>, <i>**kwargs</i>)</h3>
+
+### scatter.size(_default=Undefined_, _by=Undefined_, _map=Undefined_, _norm=Undefined_, _order=Undefined_, _labeling=Undefined_, _\*\*kwargs_) {#scatter.size}
 
 Get or set the point size.
 
@@ -251,7 +261,8 @@ Get or set the point size.
 scatter.size(by='price', map=(1, 0.25, 10))
 ```
 
-<h3><a name="scatter.connect" href="#scatter.connect">#</a> scatter.<b>connect</b>(<i>by=Undefined</i>, <i>order=Undefined</i>, <i>**kwargs</i>)</h3>
+
+### scatter.connect(_by=Undefined_, _order=Undefined_, _\*\*kwargs_) {#scatter.connect}
 
 Get or set the point connection.
 
@@ -294,22 +305,22 @@ scatter.connect(by='group', order='order')
 ```
 
 
-<h3><a name="scatter.connection_color" href="#scatter.connection_color">#</a> scatter.<b>connection_color</b>(<i>default=Undefined</i>, <i>selected=Undefined</i>, <i>hover=Undefined</i>, <i>by=Undefined</i>, <i>map=Undefined</i>, <i>norm=Undefined</i>, <i>order=Undefined</i>, <i>labeling=Undefined</i>, <i>**kwargs</i>)</h3>
+### scatter.connection_color(_default=Undefined_, _selected=Undefined_, _hover=Undefined_, _by=Undefined_, _map=Undefined_, _norm=Undefined_, _order=Undefined_, _labeling=Undefined_, _\*\*kwargs_) {#scatter.connection_color}
 
-Get or set the point connection color. This function behaves identical to [scatter.color()][scatter.color].
-
-
-<h3><a name="scatter.connection_opacity" href="#scatter.connection_opacity">#</a> scatter.<b>connection_opacity</b>(<i>default=Undefined</i>, <i>by=Undefined</i>, <i>map=Undefined</i>, <i>norm=Undefined</i>, <i>order=Undefined</i>, <i>labeling=Undefined</i>, <i>**kwargs</i>)</h3>
-
-Get or set the point connection opacity. This function behaves identical to [scatter.opacity()][scatter.opacity].
+Get or set the point connection color. This function behaves identical to [scatter.color()][#scatter.color].
 
 
-<h3><a name="scatter.connection_size" href="#scatter.connection_size">#</a> scatter.<b>connection_size</b>(<i>default=Undefined</i>, <i>by=Undefined</i>, <i>map=Undefined</i>, <i>norm=Undefined</i>, <i>order=Undefined</i>, <i>labeling=Undefined</i>, <i>**kwargs</i>)</h3>
+### scatter.connection_opacity(_default=Undefined_, _by=Undefined_, _map=Undefined_, _norm=Undefined_, _order=Undefined_, _labeling=Undefined_, _\*\*kwargs_) {#scatter.connection_opacity}
 
-Get or set the point connection size. This function behaves identical to [scatter.size()][scatter.size].
+Get or set the point connection opacity. This function behaves identical to [scatter.opacity()][#scatter.opacity].
 
 
-<h3><a name="scatter.axes" href="#scatter.axes">#</a> scatter.<b>axes</b>(<i>axes=Undefined</i>, <i>grid=Undefined</i>, <i>labels=Undefined</i>)</h3>
+### scatter.connection_size(_default=Undefined_, _by=Undefined_, _map=Undefined_, _norm=Undefined_, _order=Undefined_, _labeling=Undefined_, _\*\*kwargs_) {#scatter.connection_size}
+
+Get or set the point connection size. This function behaves identical to [scatter.size()]#[scatter.size].
+
+
+### scatter.axes(_axes=Undefined_, _grid=Undefined_, _labels=Undefined_) {#scatter.axes}
 
 Get or set the x and y axes.
 
@@ -327,7 +338,8 @@ scatter = Scatter(data=df, x='speed', y='weight')
 scatter.axes(axes=True, labels=['Speed (km/h)', 'Weight (tons)'])
 ```
 
-<h3><a name="scatter.legend" href="#scatter.legend">#</a> scatter.<b>legend</b>(<i>legend=Undefined</i>, <i>position=Undefined</i>, <i>size=Undefined</i>)</h3>
+
+### scatter.legend(_legend=Undefined_, _position=Undefined_, _size=Undefined_) {#scatter.legend}
 
 Set or get the legend settings.
 
@@ -345,7 +357,7 @@ scatter.legend(true, 'top-right', 'small')
 ```
 
 
-<h3><a name="scatter.legend" href="#scatter.tooltip">#</a> scatter.<b>tooltip</b>(<i>enable=Undefined</i>, <i>contents=Undefined</i>, <i>size=Undefined</i>)</h3>
+### scatter.tooltip(_enable=Undefined_, _contents=Undefined_, _size=Undefined_) {#scatter.tooltip}
 
 Set or get the tooltip settings.
 
@@ -363,7 +375,7 @@ scatter.tooltip(true, 'all', 'small')
 ```
 
 
-<h3><a name="scatter.zoom" href="#scatter.zoom">#</a> scatter.<b>zoom</b>(<i>target=Undefined</i>, <i>animation=Undefined</i>, <i>padding=Undefined</i>, <i>on_selection=Undefined</i>, <i>on_filter=Undefined</i>)</h3>
+### scatter.zoom(_to=Undefined_, _animation=Undefined_, _padding=Undefined_, _on_selection=Undefined_, _on_filter=Undefined_) {#scatter.zoom}
 
 Zoom to a set of points.
 
@@ -386,7 +398,7 @@ scatter.zoom(to=scatter.selection(), animation=2000, padding=0.1)
 ```
 
 
-<h3><a name="scatter.camera" href="#scatter.camera">#</a> scatter.<b>camera</b>(<i>target=Undefined</i>, <i>distance=Undefined</i>, <i>rotation=Undefined</i>, <i>view=Undefined</i>)</h3>
+### scatter.camera(_target=Undefined_, _distance=Undefined_, _rotation=Undefined_, _view=Undefined_) {#scatter.camera}
 
 Get or set the camera view.
 
@@ -405,7 +417,7 @@ scatter.camera(target=[0.5, 0.5])
 ```
 
 
-<h3><a name="scatter.mouse" href="#scatter.mouse">#</a> scatter.<b>mouse</b>(<i>mode=Undefined</i>)</h3>
+### scatter.mouse(_mode=Undefined_) {#scatter.mouse}
 
 Get or set the mouse mode.
 
@@ -421,7 +433,7 @@ scatter.mouse(mode='lasso')
 ```
 
 
-<h3><a name="scatter.lasso" href="#scatter.lasso">#</a> scatter.<b>lasso</b>(<i>color=Undefined</i>, <i>initiator=Undefined</i>, <i>min_delay=Undefined</i>, <i>min_dist=Undefined</i>, <i>on_long_press=Undefined</i>)</h3>
+### scatter.lasso(_color=Undefined_, _initiator=Undefined_, _min_delay=Undefined_, _min_dist=Undefined_, _on_long_press=Undefined_) {#scatter.lasso}
 
 Get or set the lasso for selecting multiple points.
 
@@ -441,7 +453,7 @@ scatter.lasso(initiator=True)
 ```
 
 
-<h3><a name="scatter.reticle" href="#scatter.reticle">#</a> scatter.<b>reticle</b>(<i>show=Undefined</i>, <i>color=Undefined</i>)</h3>
+### scatter.reticle(_show=Undefined_, _color=Undefined_) {#scatter.reticle}
 
 Get or set the reticle for the point hover interaction.
 
@@ -458,7 +470,7 @@ scatter.reticle(show=True, color="red")
 ```
 
 
-<h3><a name="scatter.background" href="#scatter.background">#</a> scatter.<b>background</b>(<i>color=Undefined</i>, <i>image=Undefined</i>)</h3>
+### scatter.background(_color=Undefined_, _image=Undefined_) {#scatter.background}
 
 Get or set a background color or image.
 
@@ -477,7 +489,7 @@ scatter.background(image='https://picsum.photos/640/640?random')
 ```
 
 
-<h3><a name="scatter.options" href="#scatter.options">#</a> scatter.<b>options</b>(<i>options=Undefined</i>)</h3>
+### scatter.options(_options=Undefined_) {#scatter.options}
 
 Get or set other [regl-scatterplot](https://github.com/flekschas/regl-scatterplot) options.
 
@@ -487,7 +499,7 @@ Get or set other [regl-scatterplot](https://github.com/flekschas/regl-scatterplo
 **Returns:** either the options when options are `Undefined` or `self`.
 
 
-<h3><a name="scatter.pixels" href="#scatter.pixels">#</a> scatter.<b>pixels</b>()</h3>
+### scatter.pixels() {#scatter.pixels}
 
 Gets the pixels of the current scatter plot view. Make sure to first download
 the pixels first by clicking on the button with the camera icon.
@@ -495,7 +507,7 @@ the pixels first by clicking on the button with the camera icon.
 **Returns:** a Numpy array with the pixels in RGBA format.
 
 
-## Properties
+### Properties
 
 The following is a list of all _settable_ properties of a `Scatter` instance.
 You can define those property when creating a `Scatter` instance. For example,
@@ -576,14 +588,14 @@ You can define those property when creating a `Scatter` instance. For example,
 [LinNorm]: https://matplotlib.org/3.5.0/api/_as_gen/matplotlib.colors.Normalize.html
 [Colormap]: https://matplotlib.org/3.5.0/api/_as_gen/matplotlib.colors.Colormap.html
 
-## Widget
+### Widget
 
 _So sorry, I haven't had a chance to document the widget properties yet._
 
 
-# Plotting
+## Plotting Shorthand {#plotting}
 
-<h3><a name="plot" href="#plot">#</a> jscatter.<b>plot</b>(<i>x</i>, <i>y</i>, <i>data = None</i>, <i>**kwargs</i>)</h3>
+### plot(_x=Undefined_, _y=Undefined_, _data=Undefined_, _\*\*kwargs_) {#plot}
 
 A shorthand function that creates a new scatter instance and immediately returns its widget.
 
@@ -598,9 +610,9 @@ from jscatter import plot
 plot(data=cars, x='speed', y='weight', color='black', opacity_by='density', size=4)
 ```
 
-# Composing & Linking
+## Composing & Linking
 
-<h3><a name="compose" href="#compose">#</a> jscatter.<b>compose</b>(<i>scatters</i>, <i>sync_views = False</i>, <i>sync_selection = False</i>, <i>sync_hover = False</i>, <i></h3>match_by = 'index'</i>,  <i>cols = None</i>, <i>rows = 1</i>, <i>row_height = 320</i>)
+### compose(_scatters_, _sync_views=False_, _sync_selection=False_, _sync_hover=False_, _match_by="index"_, _cols=None_, _rows=1_, _row_height=320_) {#compose}
 
 A function to compose multiple scatter plot instances in a grid and allow synchronized view, selection, and hover interactions.
 
@@ -631,7 +643,8 @@ compose(
 )
 ```
 
-<h3><a name="link" href="#link">#</a> jscatter.<b>link</b>(<i>scatters</i>, <i>match_by = 'index'</i>, <i>cols = None</i>, <i>rows = 1</i>, <i>row_height = 320</i>)</h3>
+
+### link(_scatters_, _match_by="index"_, _cols=None_, _rows=1_, _row_height=320_) {#link}
 
 A shorthand function to compose multiple scatter plot instances in a grid and synchronize their view, selection, and hover interactions.
 
@@ -647,9 +660,9 @@ from numpy.random import rand
 link([Scatter(x=rand(500), y=rand(500)) for i in range(4)], rows=2)
 ```
 
-# Color Maps
+## Color Maps
 
-<h3><a name="okabe-ito" href="#okabe-ito">#</a> jscatter.<b>okabe_ito</b></h3>
+### okabe_ito {okabe-ito}
 
 A colorblind safe categorical color map consisting of eight colors created by Okabe & Ito.
 
@@ -662,10 +675,10 @@ A colorblind safe categorical color map consisting of eight colors created by Ok
 - ![#CC79A7](https://via.placeholder.com/15/CC79A7/000000?text=+) `Reddish Purple (#CC79A7)`
 - ![#000000](https://via.placeholder.com/15/000000/000000?text=+) `Black (#000000)`
 
-<h3><a name="glasbey-light" href="#glasbey-light">#</a> jscatter.<b>glasbey_light</b></h3>
+### glasbey_light {glasbey-light}
 
 A categorical color map consisting of 256 maximally distinct colors optimized for a _bright_ background. The colors were generated with the fantastic [Colorcet](https://colorcet.holoviz.org) package, which employs an algorithm developed by [Glasbey et al., 2007](https://strathprints.strath.ac.uk/30312/1/colorpaper_2006.pdf).
 
-<h3><a name="glasbey-dark" href="#glasbey-dark">#</a> jscatter.<b>glasbey_dark</b></h3>
+### glasbey_dark {glasbey-dark}
 
 A categorical color map consisting of 256 maximally distinct colors optimized for a _dark_ background. The colors were generated with the fantastic [Colorcet](https://colorcet.holoviz.org) package, which employs an algorithm developed by [Glasbey et al., 2007](https://strathprints.strath.ac.uk/30312/1/colorpaper_2006.pdf).

--- a/docs/axes-legend-tooltip.md
+++ b/docs/axes-legend-tooltip.md
@@ -1,0 +1,217 @@
+# Axes, Legend, & Tooltip
+
+Now that we know how to create, configure, compose, and link scatter plots, it's
+time learn axes, legends, and tooltip which greatly help in making sense of the
+visualized data.
+
+## Axes
+
+You might have noticed already that axes are drawn by default. E.g.:
+
+```py{7}
+from jscatter import Scatter
+from numpy.random import rand
+
+scatter = jscatter.Scatter(x=rand(500), y=rand(500))
+scatter.show()
+```
+
+<div class="img axes"><div /></div>
+
+::: info
+You can also hide the axes via `scatter.axes(False)` in case they are not
+informative like for t-SNE or UMAP embeddings.
+:::
+
+In addition, you can also enable a grid, which can be helpful to better locate
+points.
+
+```py
+scatter.axes(grid=True)
+```
+
+<div class="img axes-grid"><div /></div>
+
+And finally, you can also label the axes
+
+```py
+scatter.axes(labels=['Speed (km/h)', 'Weight (tons)'])
+```
+
+<div class="img axes-labels"><div /></div>
+
+## Legend
+
+When you encode data properties with the point color, opacity, or size, it's
+immensly helpful to know how the encoded data properties relate to the visual
+properties by showing a legend.
+
+```py{18-20}
+import jscatter
+import numpy as np
+import pandas as pd
+
+df = pd.DataFrame({
+  # Random floats
+  "mass": np.random.rand(500),
+  "speed": np.random.rand(500),
+  "pval": np.random.rand(500),
+  # Random letters A, B, C, D, E, F, G, H
+  "cat": np.vectorize(lambda x: chr(65 + round(x * 8)))(np.random.rand(500)),
+})
+
+scatter = jscatter.Scatter(
+  data=df,
+  x="mass",
+  y="speed",
+  color_by="cat",
+  size_by="pval",
+  legend=True,
+)
+scatter.show()
+```
+
+<div class="img legend-1"><div /></div>
+
+When you encode a categorical data property (like `cat`) using color, Jupyter
+Scatter will list out each category in the legend. In contrast, for continuous
+data properties (like `pval`), only five values are shown in the legend: the
+minimum, maximum, and three equally spaced values in between.
+
+```py
+scatter.color(by="pval").opacity(by="cat").size(5)
+```
+
+<div class="img legend-2"><div /></div>
+
+Notice how the legend now only shows five entries for `color` as it encodes a
+continuous variable.
+
+In addition to just showing a mapping of data and visual properties, Jupyter
+Scatter can also label continuous properties.
+
+```py
+scatter.color(labeling={
+    "variable": "p-value",
+    "minValue": "significant",
+    "maxValue": "insignificant", 
+})
+```
+
+<div class="img legend-3"><div /></div>
+
+## Tooltip
+
+Having a legend is necessary to understand the mapping of data to visual
+properties but it requires quite a bit of eye movement from the point (you're
+currently focusing on) to the legend and back. To make this more efficient,
+Jupyter Scatter can show a tooltip explaining a point's encoded properties.
+
+```py
+scatter.tooltip(True)
+```
+
+<div class="img tooltip-1"><div /></div>
+
+By default, the tooltip has an entry for all encoded properties. You can limit
+the contents of the tooltip as follows:
+
+```py
+scatter.tooltip(contents=["color", "opacity"])
+```
+
+<div class="img tooltip-2"><div /></div>
+
+<style scoped>
+  .img {
+    max-width: 100%;
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: cover;
+  }
+
+  .img.axes {
+    width: 596px;
+    background-image: url(/images/axes-light.png)
+  }
+  .img.axes div { padding-top: 48.489933% }
+
+  :root.dark .img.axes {
+    background-image: url(/images/axes-dark.png)
+  }
+
+  .img.axes-grid {
+    width: 597px;
+    background-image: url(/images/axes-grid-light.png)
+  }
+  .img.axes-grid div { padding-top: 47.906198% }
+
+  :root.dark .img.axes-grid {
+    background-image: url(/images/axes-grid-dark.png)
+  }
+
+  .img.axes-labels {
+    width: 597px;
+    background-image: url(/images/axes-labels-light.png)
+  }
+  .img.axes-labels div { padding-top: 50.921273% }
+
+  :root.dark .img.axes-labels {
+    background-image: url(/images/axes-labels-dark.png)
+  }
+
+  .img.legend-1 {
+    width: 598px;
+    background-image: url(/images/legend-1-light.png)
+  }
+  .img.legend-1 div { padding-top: 48.829431% }
+
+  :root.dark .img.legend-1 {
+    background-image: url(/images/legend-1-dark.png)
+  }
+
+  .img.legend-2 {
+    width: 596px;
+    background-image: url(/images/legend-2-light.png)
+  }
+  .img.legend-2 div { padding-top: 49.328859% }
+
+  :root.dark .img.legend-2 {
+    background-image: url(/images/legend-2-dark.png)
+  }
+
+  .img.legend-3 {
+    width: 597px;
+    background-image: url(/images/legend-3-light.png)
+  }
+  .img.legend-3 div { padding-top: 48.911223% }
+
+  :root.dark .img.legend-3 {
+    background-image: url(/images/legend-3-dark.png)
+  }
+
+  .img.tooltip-1 {
+    width: 596px;
+    background-image: url(/images/tooltip-1-light.png)
+  }
+  .img.tooltip-1 div { padding-top: 48.489933% }
+
+  :root.dark .img.tooltip-1 {
+    background-image: url(/images/tooltip-1-dark.png)
+  }
+
+  .img.tooltip-2 {
+    width: 596px;
+    background-image: url(/images/tooltip-2-light.png)
+  }
+  .img.tooltip-2 div { padding-top: 48.489933% }
+
+  :root.dark .img.tooltip-2 {
+    background-image: url(/images/tooltip-2-dark.png)
+  }
+</style>
+
+<script setup>
+  import { videoColorModeSrcSwitcher } from './utils';
+  videoColorModeSrcSwitcher();
+</script>

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -1,0 +1,326 @@
+# Get Started
+
+Jupyter Scatter is a scalable, interactive, and interlinked scatter plot widget
+for exploring datasets with up to several million data points. It focuses on
+data-driven visual encodings and offers two-way pan+zoom and lasso interactions
+Beyond a single instance, Jupyter Scatter can compose multiple scatter plots and
+synchronize their views and selections.
+
+In the following getting started guide, we will learn about the fundamentals of
+how to create and configure a scatter plot, how to select points within it, and
+how to link multiple scatter plots.
+
+## Simplest Example
+
+In the simplest case, you can pass the x/y coordinates to the plot function as follows:
+
+```python
+import jscatter
+import numpy as np
+
+x = np.random.rand(500)
+y = np.random.rand(500)
+
+jscatter.plot(x, y)
+```
+
+<div class="img get-started-simple"><div /></div>
+
+
+## Bind a Pandas DataFrame
+
+In most cases, however, it's more convenient to work with a `DataFrame` and
+reference the x/y columns via their names.
+
+```python
+import jscatter
+import numpy as np
+import pandas as pd
+
+df = pd.DataFrame(np.random.rand(500, 2), columns=['mass', 'speed'])
+
+jscatter.plot(data=df, x='mass', y='speed')
+```
+
+<div class="img get-started-simple"><div /></div>
+
+## Point Color, Opacity, and Size
+
+Often times, we want to style the points. Jupyter Scatter allows you to do this
+as follows:
+
+```py{5-7}
+jscatter.plot(
+    data=df,
+    x='mass',
+    y='speed',
+    color='red', # static visual encoding
+    size=10, # static visual encoding
+    opacity=0.5 # static visual encoding
+)
+```
+
+<div class="img get-started-static-encoding"><div /></div>
+
+However, more commonely, one wants to use these three point attributes (color,
+opacity, and size) to visualize data properties.
+
+For instance, in the following we're extending the data frame with a continuous
+property called `pval` and a categorical property called `cat`.
+
+
+```py{5,7}
+df = pd.DataFrame({
+  # Random floats
+  "mass": np.random.rand(500),
+  "speed": np.random.rand(500),
+  "pval": np.random.rand(500),
+  # Random letters A, B, C, D, E, F, G, H
+  "cat": np.vectorize(lambda x: chr(65 + round(x * 7)))(np.random.rand(500)),
+})
+```
+
+|   | x    | y    | pval | cat |
+|---|------|------|------|-----|
+| 0 | 0.13 | 0.27 | 0.51 | G   |
+| 1 | 0.87 | 0.93 | 0.80 | B   |
+| 2 | 0.10 | 0.25 | 0.25 | F   |
+| 3 | 0.03 | 0.90 | 0.01 | G   |
+| 4 | 0.19 | 0.78 | 0.65 | D   |
+
+You can visualize the two properties by referencing their columns using the
+`color_by`, `opacity_by`, or `size_by` arguments.
+
+```py{5-6}
+jscatter.plot(
+    data=df,
+    x='mass',
+    y='speed',
+    color_by='cat', # data-driven visual encoding
+    size_by='pval', # data-driven visual encoding
+)
+```
+
+<div class="img get-started-default-encoding-1"><div /></div>
+
+Notice how `jscatter` uses a reasonable color and size map by default. Both are
+based on the properties' data types. In this examples, the `jscatter` picked the
+color blindness safe color map from [Okabe and Ito](https://jfly.uni-koeln.de/color/#pallet) as the number of
+categories is less than 9.
+
+When visualizing the `pval` via the color we see how the default color map
+switches to Viridis given that `pval` is a continuous property.
+
+```py{5}
+jscatter.plot(
+    data=df,
+    x='mass',
+    y='speed',
+    color_by='pval', # pval is continuous data
+    size_by='pval', # pval is categorical data
+)
+```
+
+<div class="img get-started-default-encoding-2"><div /></div>
+
+You can of course customize the color map and many other parameters of the visual encoding as shown next.
+
+```py{7-19}
+jscatter.plot(
+    data=df,
+    x='mass',
+    y='speed',
+    color_by='cat',
+    size_by='pval',
+    # Custom categorical color map 
+    color_map=dict(
+      A='red',    B='#00ff00', C=(0,0,1),   D='DeepSkyBlue',
+      E='orange', F='#702AF7', G='#2AF7C0', H='teal'
+    ),
+    # Custom size map (specified as a linspace)
+    size_map=(2, 20, 10),
+)
+```
+
+<div class="img get-started-custom-encoding"><div /></div>
+
+## Functional API
+
+The flat API (that we used before) can get overwhelming when we customize a lot
+of properties. Therefore, `jscatter` provides a functional API that groups
+properties by type and exposes them via meaningfully-named methods that can
+almost be read like a sentence.
+
+For instance, line three of the example below defines that the scatter plot is
+colored by the `mass` column, which maps its values to the plasma color map in
+reverse order.
+
+```py{3}
+scatter = jscatter.Scatter(data=df, x='mass', y='speed')
+scatter.color(by='mass', map='plasma', order='reverse')
+scatter.opacity(by='density')
+scatter.size(by='pval', map=[2, 4, 6, 8, 10])
+scatter.background('#1E1E20')
+scatter.show()
+```
+
+<div class="img get-started-functional-api-1"><div /></div>
+
+## Update Properties After Plotting
+
+You don't have to specify all properties upfront. Using the functional API
+you can update scatter plot instances after having plotted the scatter and the
+plot will automatically re-render.
+
+For instance, in the following we're changing the color map to `magma` in
+reverse order.
+
+```py
+scatter.color(map='magma', order='reverse')
+```
+
+<div class="img get-started-functional-api-2"><div /></div>
+
+## Chaining Method Calls
+
+Inspired by [D3](https://d3js.org/) you can also chain methods calls as follows
+to update multiple property groups at once.
+
+```py
+scatter.legend(True).axes(False)
+```
+
+<div class="img get-started-functional-api-3"><div /></div>
+
+## Animating Point Coordinates
+
+When you update the x/y coordinates dynamically and the number of points match,
+the points will animate in a smooth transition from the previous to their new
+point location.
+
+For instance, try calling [`scatter.xy('speed', 'mass')`](./api#scatter.xy) and
+you will see how the points are mirrored along the diagonal.
+
+<video autoplay loop muted width="458" data-name="get-started-xy-animation">
+  <source
+    src="/videos/get-started-xy-animation-light.mp4"
+    type="video/mp4"
+  />
+</video>
+
+## Retrieving Properties
+
+Lastly, all method arguments are optional. If you specify arguments, the methods
+will act as setters and change the properties. However, if you call a method
+without any arguments it will act as a getter and return the related properties.
+
+For example, `scatter.color()` will return the current coloring settings.
+
+```py
+{'default': (0, 0, 0, 0.66),
+ 'selected': (0, 0.55, 1, 1),
+ 'hover': (0, 0, 0, 1),
+ 'by': 'mass',
+ 'map': [[0.001462, 0.000466, 0.013866, 1.0],
+  [0.002258, 0.001295, 0.018331, 1.0],
+  ...
+  [0.987387, 0.984288, 0.742002, 1.0],
+  [0.987053, 0.991438, 0.749504, 1.0]],
+ 'norm': <matplotlib.colors.Normalize at 0x15f23feb0>,
+ 'order': 'reverse',
+ 'labeling': None}
+```
+
+<style scoped>
+  .img {
+    max-width: 100%;
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: cover;
+  }
+
+  .img.get-started-simple {
+    width: 459px;
+    background-image: url(/images/get-started-simple-light.png)
+  }
+  .img.get-started-simple div { padding-top: 57.95207% }
+
+  :root.dark .img.get-started-simple {
+    background-image: url(/images/get-started-simple-dark.png)
+  }
+
+  .img.get-started-static-encoding {
+    width: 459px;
+    background-image: url(/images/get-started-static-encoding-light.png)
+  }
+  .img.get-started-static-encoding div { padding-top: 57.51634% }
+
+  :root.dark .img.get-started-static-encoding {
+    background-image: url(/images/get-started-static-encoding-dark.png)
+  }
+
+  .img.get-started-default-encoding-1 {
+    width: 459px;
+    background-image: url(/images/get-started-default-encoding-1-light.png)
+  }
+  .img.get-started-default-encoding-1 div { padding-top: 56.862745% }
+
+  :root.dark .img.get-started-default-encoding-1 {
+    background-image: url(/images/get-started-default-encoding-1-dark.png)
+  }
+
+  .img.get-started-default-encoding-2 {
+    width: 459px;
+    background-image: url(/images/get-started-default-encoding-2-light.png)
+  }
+  .img.get-started-default-encoding-2 div { padding-top: 56.64488% }
+
+  :root.dark .img.get-started-default-encoding-2 {
+    background-image: url(/images/get-started-default-encoding-2-dark.png)
+  }
+
+  .img.get-started-custom-encoding {
+    width: 459px;
+    background-image: url(/images/get-started-custom-encoding-light.png)
+  }
+  .img.get-started-custom-encoding div { padding-top: 57.51634% }
+
+  :root.dark .img.get-started-custom-encoding {
+    background-image: url(/images/get-started-custom-encoding-dark.png)
+  }
+
+  .img.get-started-functional-api-1 {
+    width: 459px;
+    background-image: url(/images/get-started-functional-api-1-light.png)
+  }
+  .img.get-started-functional-api-1 div { padding-top: 57.51634% }
+
+  :root.dark .img.get-started-functional-api-1 {
+    background-image: url(/images/get-started-functional-api-1-dark.png)
+  }
+
+  .img.get-started-functional-api-2 {
+    width: 459px;
+    background-image: url(/images/get-started-functional-api-2-light.png)
+  }
+  .img.get-started-functional-api-2 div { padding-top: 57.51634% }
+
+  :root.dark .img.get-started-functional-api-2 {
+    background-image: url(/images/get-started-functional-api-2-dark.png)
+  }
+
+  .img.get-started-functional-api-3 {
+    width: 461px;
+    background-image: url(/images/get-started-functional-api-3-light.png)
+  }
+  .img.get-started-functional-api-3 div { padding-top: 53.594771% }
+
+  :root.dark .img.get-started-functional-api-3 {
+    background-image: url(/images/get-started-functional-api-3-dark.png)
+  }
+</style>
+
+<script setup>
+  import { videoColorModeSrcSwitcher } from './utils';
+  videoColorModeSrcSwitcher();
+</script>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,50 @@
+---
+# https://vitepress.dev/reference/default-theme-home-page
+layout: home
+
+hero:
+  name: "Jupyter Scatter"
+  text: "An interactive scatter plot widget"
+  tagline: "Explore datasets with millions of data points with ease in Jupyter Notebook, Lab, and Google Colab."
+  image:
+    src: /teaser.jpg
+    alt: Jupyter Scatter
+  actions:
+    - theme: brand
+      text: Get Started
+      link: /get-started
+    # - theme: alt
+    #   text: Examples
+    #   link: /api
+    - theme: alt
+      text: API
+      link: /api
+
+features:
+  - title: Interactive
+    details: Pan, zoom, and select data points interactively with your mouse or through the Python API.
+    icon:
+      dark: /images/icon-feature-interactive-dark.svg
+      light: /images/icon-feature-interactive-light.svg
+    
+  - title: Scalable
+    details: Plot up to several millions data points smoothly thanks to WebGL rendering.
+    icon:
+      dark: /images/icon-feature-scalable-dark.svg
+      light: /images/icon-feature-scalable-light.svg
+    
+  - title: Interlinked
+    details: Synchronize the view, hover, and selection across multiple scatter plot instances.
+    icon:
+      dark: /images/icon-feature-interlinked-dark.svg
+      light: /images/icon-feature-interlinked-light.svg
+    
+  - title: Effective Defaults
+    details: Rely on Jupyter Scatter to choose perceptually effective point colors and opacity by default.
+    
+  - title: Friendly API
+    details: Enjoy a readable API that integrates deeply with Pandas DataFrames.
+    
+  - title: Integratable
+    details: Use Jupyter Scatter in your own widgets by observing its traitlets.
+---

--- a/docs/interactions.md
+++ b/docs/interactions.md
@@ -1,0 +1,253 @@
+# Interactions
+
+Jupyter Scatter's scatter plots are interactive by default. You can pan, zoom,
+hover, click, and lasso with your mouse. Moreover, Jupyter Scatter offers APIs
+for filtering and zooming.
+
+## Pan & Zoom the View
+
+Like in Google Maps, you can pan and zoom to adjust the view and explore
+different areas of the scatter plot in detail.
+
+To pan, click and hold the primary mouse button and drag your mouse.
+
+<div class="video">
+  <video loop muted width="1256" data-name="interactions-pan">
+    <source
+      src="/videos/interactions-pan-light.mp4"
+      type="video/mp4"
+    />
+  </video>
+  <div class="overlay">Hover to play video</div>
+</div>
+
+To zoom, simply engage your mouse's scroll wheel.
+
+<div class="video">
+  <video loop muted width="1256" data-name="interactions-zoom">
+    <source
+      src="/videos/interactions-zoom-light.mp4"
+      type="video/mp4"
+    />
+  </video>
+  <div class="overlay">Hover to play video</div>
+</div>
+
+## Hover a Point
+
+To help locate a point and where it's located, when you mouse over a point, a
+reticle will appear.
+
+<div class="video">
+  <video loop muted width="1256" data-name="interactions-hover">
+    <source
+      src="/videos/interactions-hover-light.mp4"
+      type="video/mp4"
+    />
+  </video>
+  <div class="overlay">Hover to play video</div>
+</div>
+
+## Click a Point
+
+In order to select a point you can click on it.
+
+<div class="video">
+  <video loop muted width="1256" data-name="interactions-click">
+    <source
+      src="/videos/interactions-click-light.mp4"
+      type="video/mp4"
+    />
+  </video>
+  <div class="overlay">Hover to play video</div>
+</div>
+
+## Double Click into the Void
+
+To deselect points, simply double click into the background.
+
+<div class="video">
+  <video loop muted width="1256" data-name="interactions-double-click">
+    <source
+      src="/videos/interactions-double-click-light.mp4"
+      type="video/mp4"
+    />
+  </video>
+  <div class="overlay">Hover to play video</div>
+</div>
+
+## Lasso Points
+
+To select more than a single point, you can lasso multiple points.
+
+To activate the lasso, click and hold down your primary mouse button. An open
+circle will appear and slowly close in clockwise order. Once the circle is fully
+closed it'll turn blue. At this point the lasso is active.
+
+<div class="video">
+  <video loop muted width="1256" data-name="interactions-lasso">
+    <source
+      src="/videos/interactions-lasso-light.mp4"
+      type="video/mp4"
+    />
+  </video>
+  <div class="overlay">Hover to play video</div>
+</div>
+
+Alternatively, you can click on the crosshair icon in the top-left of the
+scatter plot to permanently activate the lasso.
+
+To select points once the lasso is active, keep holding down your primary mouse
+button and move your mouse cursor around the points you want to select. Finally,
+release your primary mouse key.
+
+## Filter Points
+
+Sometimes it can be useful to exclusively focus on a subset of points and
+temporarily hide other points. This can be achieved using [`scatter.filter()`](/api#scatter.filter):
+
+```py
+scatter.filter([0, 1, 2])
+```
+
+The filtering is blazing fast as it's only hiding non-filtered points. To unset
+the filter simply call the filter function with `None`:
+
+```py
+scatter.filter(None)
+```
+
+<div class="video">
+  <video loop muted width="1256" data-name="interactions-filter">
+    <source
+      src="/videos/interactions-filter-light.mp4"
+      type="video/mp4"
+    />
+  </video>
+  <div class="overlay">Hover to play video</div>
+</div>
+
+## Zoom to Points
+
+When trying to focus on a subset of points (in particular point clusters), it
+can help to zoom in. To zoom to a specific set of points, you can use
+[`scatter.zoom()`](/api#scatter.zoom):
+
+```py
+scatter.zoom([0, 1, 2])
+```
+
+<div class="video">
+  <video loop muted width="1256" data-name="interactions-zoom-to-points">
+    <source
+      src="/videos/interactions-zoom-to-points-light.mp4"
+      type="video/mp4"
+    />
+  </video>
+  <div class="overlay">Hover to play video</div>
+</div>
+
+You can customize how much padding you want to leave when you zoom in as follows:
+
+```py{3}
+scatter.zoom(
+  to=[0, 1, 2],
+  padding=1,
+)
+```
+
+In this case we're instructing our scatter plot instance to have the padding be
+the same size as the bounding box of the first, second, and third point we're
+zooming to.
+
+Lastly, a cool feature of Jupyter Scatter is the ability to automatically zoom
+to selected or filtered points to make it as simple as possible for you to focus
+on a certain set of points.
+
+```py
+scatter.zoom(on_selection=True)
+```
+
+## Overview+Detail Interface
+
+Using everything we've learned so far and combining it with Jupyter Scatter's
+ability to [synchronize/link multiple scatter plots](/link-multiple-plots)
+we can easily create an overview+detail interface as follows:
+
+```py
+from jscatter import Scatter, compose
+from numpy.random import rand
+
+x, y = rand(500), rand(500)
+
+sc_overview = Scatter(x, y)
+sc_detail = Scatter(x, y, zoom_on_filter=True, zoom_padding=1)
+
+def filter_on_select(change):
+    sc_detail.filter(change['new'] if len(change['new']) > 0 else None)
+
+sc_overview.widget.observe(filter_on_select, names='selection')
+
+compose(
+    [(sc_overview, "Overview"), (sc_detail, "Detail")],
+    sync_hover=True,
+)
+```
+
+<div class="video">
+  <video loop muted width="826" data-name="interactions-overview-and-details">
+    <source
+      src="/videos/interactions-overview-and-details-light.mp4"
+      type="video/mp4"
+    />
+  </video>
+  <div class="overlay">Hover to play video</div>
+</div>
+
+<style scoped>
+  .video {
+    position: relative;
+  }
+
+  .video video {
+    filter: blur(0.5px);
+  }
+
+  .video .overlay {
+    position: absolute;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    user-select: none;
+    pointer-events: none;
+    transition: 0.25s ease;
+    border-radius: 0.25rem;
+    font-weight: 700;
+    color: black;
+    background: rgba(255, 255, 255, 0.5);
+  }
+
+  .video:hover .overlay {
+    opacity: 0;
+  }
+
+  .video:hover video {
+    filter: blur(0);
+  }
+
+  :root.dark .video .overlay {
+    color: white;
+    background: rgba(30, 30, 32, 0.5);
+  }
+</style>
+
+<script setup>
+  import { videoColorModeSrcSwitcher, videoPlayOnHover } from './utils';
+  videoColorModeSrcSwitcher();
+  videoPlayOnHover();
+</script>

--- a/docs/link-multiple-plots.md
+++ b/docs/link-multiple-plots.md
@@ -1,0 +1,126 @@
+# Link Multiple Scatter Plots
+
+There are many use cases where one wants to create two or more scatter plot and
+potentially link the view, selection, and hover state.
+
+For instance, we might want to
+- visualize different properties of a dataset
+- compare different facets of a dataset
+- compare different embedding methods of a dataset
+- compare multiple datasets with shared labels
+
+Jupyter Scatter can help with this by composing and linking multiple scatter
+instances.
+
+## Simplest Example
+
+We'll start out with a very simple example to get familiar with the API.
+
+In the following, we'll compose two scatter plots next to each other using
+[`compose()`](./api#compose).
+
+```py{7}
+import jscatter
+import numpy as np
+
+x, y = np.random.rand(500), np.random.rand(500)
+a, b = jscatter.Scatter(x=x, y=y), Scatter(x=x, y=y)
+
+jscatter.compose([a, b])
+```
+
+<div class="img link-multiple-plots-simple-1"><div /></div>
+
+By default, jscatter arranges scatter plots into a single row but we can
+customize this of course.
+
+```py
+jscatter.compose([a, b], rows=2)
+```
+
+<div class="img link-multiple-plots-simple-2"><div /></div>
+
+We can also change the row height as follows to shrink or grow the plots.
+
+```py
+jscatter.compose([a, b], rows=2, row_height=240)
+```
+
+<div class="img link-multiple-plots-simple-3"><div /></div>
+
+## Synchronize View, Selection, & Hover
+
+So good so far but the fun part starts when we link/synchronize the scatter
+plots' views and selections.
+
+```py{3-5}
+jscatter.compose(
+    [a, b],
+    sync_view=True,
+    sync_selection=True,
+    sync_hover=True,
+)
+```
+
+<video autoplay loop muted data-name="link-multiple-plots-synced" width="1000">
+  <source
+    src="/videos/link-multiple-plots-synced-light.mp4"
+    type="video/mp4"
+  />
+</video>
+
+Since a common use case is to synchronize everything, `jscatter` offers the
+shorthand method [`link()`](./api#link):
+
+```py
+jscatter.link([a, b])
+```
+
+The result is the same as the previous [`compose()`](./api#compose) call.
+
+<style scoped>
+  .img {
+    max-width: 100%;
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: cover;
+  }
+
+  .img.link-multiple-plots-simple-1 {
+    width: 812px;
+    background-image: url(/images/link-multiple-plots-simple-1-light.png);
+  }
+
+  .img.link-multiple-plots-simple-1 div { padding-top: 40.147783% }
+
+  :root.dark .img.link-multiple-plots-simple-1 {
+    background-image: url(/images/link-multiple-plots-simple-1-dark.png);
+  }
+
+  .img.link-multiple-plots-simple-2 {
+    width: 812px;
+    background-image: url(/images/link-multiple-plots-simple-2-light.png);
+  }
+
+  .img.link-multiple-plots-simple-2 div { padding-top: 79.310345% }
+
+  :root.dark .img.link-multiple-plots-simple-2 {
+    background-image: url(/images/link-multiple-plots-simple-2-dark.png);
+  }
+
+  .img.link-multiple-plots-simple-3 {
+    width: 812px;
+    background-image: url(/images/link-multiple-plots-simple-3-light.png);
+  }
+
+  .img.link-multiple-plots-simple-3 div { padding-top: 59.852217% }
+
+  :root.dark .img.link-multiple-plots-simple-3 {
+    background-image: url(/images/link-multiple-plots-simple-3-dark.png);
+  }
+</style>
+
+<script setup>
+  import { videoColorModeSrcSwitcher } from './utils';
+  videoColorModeSrcSwitcher();
+</script>

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,0 +1,1255 @@
+{
+  "name": "docs",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "vitepress": "^1.0.0-rc.10"
+      }
+    },
+    "node_modules/@algolia/autocomplete-core": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.9.3.tgz",
+      "integrity": "sha512-009HdfugtGCdC4JdXUbVJClA0q0zh24yyePn+KUGk3rP7j8FEe/m5Yo/z65gn6nP/cM39PxpzqKrL7A6fP6PPw==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/autocomplete-plugin-algolia-insights": "1.9.3",
+        "@algolia/autocomplete-shared": "1.9.3"
+      }
+    },
+    "node_modules/@algolia/autocomplete-plugin-algolia-insights": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.9.3.tgz",
+      "integrity": "sha512-a/yTUkcO/Vyy+JffmAnTWbr4/90cLzw+CC3bRbhnULr/EM0fGNvM13oQQ14f2moLMcVDyAx/leczLlAOovhSZg==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.9.3"
+      },
+      "peerDependencies": {
+        "search-insights": ">= 1 < 3"
+      }
+    },
+    "node_modules/@algolia/autocomplete-preset-algolia": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.9.3.tgz",
+      "integrity": "sha512-d4qlt6YmrLMYy95n5TB52wtNDr6EgAIPH81dvvvW8UmuWRgxEtY0NJiPwl/h95JtG2vmRM804M0DSwMCNZlzRA==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.9.3"
+      },
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/autocomplete-shared": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.9.3.tgz",
+      "integrity": "sha512-Wnm9E4Ye6Rl6sTTqjoymD+l8DjSTHsHboVRYrKgEt8Q7UHm9nYbqhN/i0fhUYA3OAEH7WA8x3jfpnmJm3rKvaQ==",
+      "dev": true,
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/cache-browser-local-storage": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.19.1.tgz",
+      "integrity": "sha512-FYAZWcGsFTTaSAwj9Std8UML3Bu8dyWDncM7Ls8g+58UOe4XYdlgzXWbrIgjaguP63pCCbMoExKr61B+ztK3tw==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/cache-common": "4.19.1"
+      }
+    },
+    "node_modules/@algolia/cache-common": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.19.1.tgz",
+      "integrity": "sha512-XGghi3l0qA38HiqdoUY+wvGyBsGvKZ6U3vTiMBT4hArhP3fOGLXpIINgMiiGjTe4FVlTa5a/7Zf2bwlIHfRqqg==",
+      "dev": true
+    },
+    "node_modules/@algolia/cache-in-memory": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.19.1.tgz",
+      "integrity": "sha512-+PDWL+XALGvIginigzu8oU6eWw+o76Z8zHbBovWYcrtWOEtinbl7a7UTt3x3lthv+wNuFr/YD1Gf+B+A9V8n5w==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/cache-common": "4.19.1"
+      }
+    },
+    "node_modules/@algolia/client-account": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.19.1.tgz",
+      "integrity": "sha512-Oy0ritA2k7AMxQ2JwNpfaEcgXEDgeyKu0V7E7xt/ZJRdXfEpZcwp9TOg4TJHC7Ia62gIeT2Y/ynzsxccPw92GA==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/client-common": "4.19.1",
+        "@algolia/client-search": "4.19.1",
+        "@algolia/transporter": "4.19.1"
+      }
+    },
+    "node_modules/@algolia/client-analytics": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.19.1.tgz",
+      "integrity": "sha512-5QCq2zmgdZLIQhHqwl55ZvKVpLM3DNWjFI4T+bHr3rGu23ew2bLO4YtyxaZeChmDb85jUdPDouDlCumGfk6wOg==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/client-common": "4.19.1",
+        "@algolia/client-search": "4.19.1",
+        "@algolia/requester-common": "4.19.1",
+        "@algolia/transporter": "4.19.1"
+      }
+    },
+    "node_modules/@algolia/client-common": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.19.1.tgz",
+      "integrity": "sha512-3kAIVqTcPrjfS389KQvKzliC559x+BDRxtWamVJt8IVp7LGnjq+aVAXg4Xogkur1MUrScTZ59/AaUd5EdpyXgA==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/requester-common": "4.19.1",
+        "@algolia/transporter": "4.19.1"
+      }
+    },
+    "node_modules/@algolia/client-personalization": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.19.1.tgz",
+      "integrity": "sha512-8CWz4/H5FA+krm9HMw2HUQenizC/DxUtsI5oYC0Jxxyce1vsr8cb1aEiSJArQT6IzMynrERif1RVWLac1m36xw==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/client-common": "4.19.1",
+        "@algolia/requester-common": "4.19.1",
+        "@algolia/transporter": "4.19.1"
+      }
+    },
+    "node_modules/@algolia/client-search": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.19.1.tgz",
+      "integrity": "sha512-mBecfMFS4N+yK/p0ZbK53vrZbL6OtWMk8YmnOv1i0LXx4pelY8TFhqKoTit3NPVPwoSNN0vdSN9dTu1xr1XOVw==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/client-common": "4.19.1",
+        "@algolia/requester-common": "4.19.1",
+        "@algolia/transporter": "4.19.1"
+      }
+    },
+    "node_modules/@algolia/logger-common": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.19.1.tgz",
+      "integrity": "sha512-i6pLPZW/+/YXKis8gpmSiNk1lOmYCmRI6+x6d2Qk1OdfvX051nRVdalRbEcVTpSQX6FQAoyeaui0cUfLYW5Elw==",
+      "dev": true
+    },
+    "node_modules/@algolia/logger-console": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.19.1.tgz",
+      "integrity": "sha512-jj72k9GKb9W0c7TyC3cuZtTr0CngLBLmc8trzZlXdfvQiigpUdvTi1KoWIb2ZMcRBG7Tl8hSb81zEY3zI2RlXg==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/logger-common": "4.19.1"
+      }
+    },
+    "node_modules/@algolia/requester-browser-xhr": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.19.1.tgz",
+      "integrity": "sha512-09K/+t7lptsweRTueHnSnmPqIxbHMowejAkn9XIcJMLdseS3zl8ObnS5GWea86mu3vy4+8H+ZBKkUN82Zsq/zg==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/requester-common": "4.19.1"
+      }
+    },
+    "node_modules/@algolia/requester-common": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.19.1.tgz",
+      "integrity": "sha512-BisRkcWVxrDzF1YPhAckmi2CFYK+jdMT60q10d7z3PX+w6fPPukxHRnZwooiTUrzFe50UBmLItGizWHP5bDzVQ==",
+      "dev": true
+    },
+    "node_modules/@algolia/requester-node-http": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.19.1.tgz",
+      "integrity": "sha512-6DK52DHviBHTG2BK/Vv2GIlEw7i+vxm7ypZW0Z7vybGCNDeWzADx+/TmxjkES2h15+FZOqVf/Ja677gePsVItA==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/requester-common": "4.19.1"
+      }
+    },
+    "node_modules/@algolia/transporter": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.19.1.tgz",
+      "integrity": "sha512-nkpvPWbpuzxo1flEYqNIbGz7xhfhGOKGAZS7tzC+TELgEmi7z99qRyTfNSUlW7LZmB3ACdnqAo+9A9KFBENviQ==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/cache-common": "4.19.1",
+        "@algolia/logger-common": "4.19.1",
+        "@algolia/requester-common": "4.19.1"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.22.14",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.14.tgz",
+      "integrity": "sha512-1KucTHgOvaw/LzCVrEOAyXkr9rQlp0A1HiHRYnSUE9dmb8PvPW7o5sscg+5169r54n3vGlbx6GevTE/Iw/P3AQ==",
+      "dev": true,
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@docsearch/css": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.5.2.tgz",
+      "integrity": "sha512-SPiDHaWKQZpwR2siD0KQUwlStvIAnEyK6tAE2h2Wuoq8ue9skzhlyVQ1ddzOxX6khULnAALDiR/isSF3bnuciA==",
+      "dev": true
+    },
+    "node_modules/@docsearch/js": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.5.2.tgz",
+      "integrity": "sha512-p1YFTCDflk8ieHgFJYfmyHBki1D61+U9idwrLh+GQQMrBSP3DLGKpy0XUJtPjAOPltcVbqsTjiPFfH7JImjUNg==",
+      "dev": true,
+      "dependencies": {
+        "@docsearch/react": "3.5.2",
+        "preact": "^10.0.0"
+      }
+    },
+    "node_modules/@docsearch/react": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.5.2.tgz",
+      "integrity": "sha512-9Ahcrs5z2jq/DcAvYtvlqEBHImbm4YJI8M9y0x6Tqg598P40HTEkX7hsMcIuThI+hTFxRGZ9hll0Wygm2yEjng==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/autocomplete-core": "1.9.3",
+        "@algolia/autocomplete-preset-algolia": "1.9.3",
+        "@docsearch/css": "3.5.2",
+        "algoliasearch": "^4.19.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">= 16.8.0 < 19.0.0",
+        "react": ">= 16.8.0 < 19.0.0",
+        "react-dom": ">= 16.8.0 < 19.0.0",
+        "search-insights": ">= 1 < 3"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "search-insights": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
+      "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
+      "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
+      "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
+      "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
+      "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
+      "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
+      "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
+      "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
+      "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
+      "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
+      "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
+      "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
+      "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
+      "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
+      "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
+      "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
+      "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
+      "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
+      "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
+      "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+      "dev": true
+    },
+    "node_modules/@types/web-bluetooth": {
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.17.tgz",
+      "integrity": "sha512-4p9vcSmxAayx72yn70joFoL44c9MO/0+iVEBIQXe3v2h2SiAsEIo/G5v6ObFWvNKRFjbrVadNf9LqEEZeQPzdA==",
+      "dev": true
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.4.tgz",
+      "integrity": "sha512-cquyDNvZ6jTbf/+x+AgM2Arrp6G4Dzbb0R64jiG804HRMfRiFXWI6kqUVqZ6ZR0bQhIoQjB4+2bhNtVwndW15g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.21.3",
+        "@vue/shared": "3.3.4",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.0.2"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.3.4.tgz",
+      "integrity": "sha512-wyM+OjOVpuUukIq6p5+nwHYtj9cFroz9cwkfmP9O1nzH68BenTTv0u7/ndggT8cIQlnBeOo6sUT/gvHcIkLA5w==",
+      "dev": true,
+      "dependencies": {
+        "@vue/compiler-core": "3.3.4",
+        "@vue/shared": "3.3.4"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.3.4.tgz",
+      "integrity": "sha512-6y/d8uw+5TkCuzBkgLS0v3lSM3hJDntFEiUORM11pQ/hKvkhSKZrXW6i69UyXlJQisJxuUEJKAWEqWbWsLeNKQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.20.15",
+        "@vue/compiler-core": "3.3.4",
+        "@vue/compiler-dom": "3.3.4",
+        "@vue/compiler-ssr": "3.3.4",
+        "@vue/reactivity-transform": "3.3.4",
+        "@vue/shared": "3.3.4",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.0",
+        "postcss": "^8.1.10",
+        "source-map-js": "^1.0.2"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.3.4.tgz",
+      "integrity": "sha512-m0v6oKpup2nMSehwA6Uuu+j+wEwcy7QmwMkVNVfrV9P2qE5KshC6RwOCq8fjGS/Eak/uNb8AaWekfiXxbBB6gQ==",
+      "dev": true,
+      "dependencies": {
+        "@vue/compiler-dom": "3.3.4",
+        "@vue/shared": "3.3.4"
+      }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.5.0.tgz",
+      "integrity": "sha512-o9KfBeaBmCKl10usN4crU53fYtC1r7jJwdGKjPT24t348rHxgfpZ0xL3Xm/gLUYnc0oTp8LAmrxOeLyu6tbk2Q==",
+      "dev": true
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.3.4.tgz",
+      "integrity": "sha512-kLTDLwd0B1jG08NBF3R5rqULtv/f8x3rOFByTDz4J53ttIQEDmALqKqXY0J+XQeN0aV2FBxY8nJDf88yvOPAqQ==",
+      "dev": true,
+      "dependencies": {
+        "@vue/shared": "3.3.4"
+      }
+    },
+    "node_modules/@vue/reactivity-transform": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.3.4.tgz",
+      "integrity": "sha512-MXgwjako4nu5WFLAjpBnCj/ieqcjE2aJBINUNQzkZQfzIZA4xn+0fV1tIYBJvvva3N3OvKGofRLvQIwEQPpaXw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.20.15",
+        "@vue/compiler-core": "3.3.4",
+        "@vue/shared": "3.3.4",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.0"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.3.4.tgz",
+      "integrity": "sha512-R+bqxMN6pWO7zGI4OMlmvePOdP2c93GsHFM/siJI7O2nxFRzj55pLwkpCedEY+bTMgp5miZ8CxfIZo3S+gFqvA==",
+      "dev": true,
+      "dependencies": {
+        "@vue/reactivity": "3.3.4",
+        "@vue/shared": "3.3.4"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.3.4.tgz",
+      "integrity": "sha512-Aj5bTJ3u5sFsUckRghsNjVTtxZQ1OyMWCr5dZRAPijF/0Vy4xEoRCwLyHXcj4D0UFbJ4lbx3gPTgg06K/GnPnQ==",
+      "dev": true,
+      "dependencies": {
+        "@vue/runtime-core": "3.3.4",
+        "@vue/shared": "3.3.4",
+        "csstype": "^3.1.1"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.3.4.tgz",
+      "integrity": "sha512-Q6jDDzR23ViIb67v+vM1Dqntu+HUexQcsWKhhQa4ARVzxOY2HbC7QRW/ggkDBd5BU+uM1sV6XOAP0b216o34JQ==",
+      "dev": true,
+      "dependencies": {
+        "@vue/compiler-ssr": "3.3.4",
+        "@vue/shared": "3.3.4"
+      },
+      "peerDependencies": {
+        "vue": "3.3.4"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.4.tgz",
+      "integrity": "sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ==",
+      "dev": true
+    },
+    "node_modules/@vueuse/core": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.4.1.tgz",
+      "integrity": "sha512-DkHIfMIoSIBjMgRRvdIvxsyboRZQmImofLyOHADqiVbQVilP8VVHDhBX2ZqoItOgu7dWa8oXiNnScOdPLhdEXg==",
+      "dev": true,
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.17",
+        "@vueuse/metadata": "10.4.1",
+        "@vueuse/shared": "10.4.1",
+        "vue-demi": ">=0.14.5"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/core/node_modules/vue-demi": {
+      "version": "0.14.6",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.6.tgz",
+      "integrity": "sha512-8QA7wrYSHKaYgUxDA5ZC24w+eHm3sYCbp0EzcDwKqN3p6HqtTCGR/GVsPyZW92unff4UlcSh++lmqDWN3ZIq4w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vueuse/integrations": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-10.4.1.tgz",
+      "integrity": "sha512-uRBPyG5Lxoh1A/J+boiioPT3ELEAPEo4t8W6Mr4yTKIQBeW/FcbsotZNPr4k9uz+3QEksMmflWloS9wCnypM7g==",
+      "dev": true,
+      "dependencies": {
+        "@vueuse/core": "10.4.1",
+        "@vueuse/shared": "10.4.1",
+        "vue-demi": ">=0.14.5"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "async-validator": "*",
+        "axios": "*",
+        "change-case": "*",
+        "drauu": "*",
+        "focus-trap": "*",
+        "fuse.js": "*",
+        "idb-keyval": "*",
+        "jwt-decode": "*",
+        "nprogress": "*",
+        "qrcode": "*",
+        "sortablejs": "*",
+        "universal-cookie": "*"
+      },
+      "peerDependenciesMeta": {
+        "async-validator": {
+          "optional": true
+        },
+        "axios": {
+          "optional": true
+        },
+        "change-case": {
+          "optional": true
+        },
+        "drauu": {
+          "optional": true
+        },
+        "focus-trap": {
+          "optional": true
+        },
+        "fuse.js": {
+          "optional": true
+        },
+        "idb-keyval": {
+          "optional": true
+        },
+        "jwt-decode": {
+          "optional": true
+        },
+        "nprogress": {
+          "optional": true
+        },
+        "qrcode": {
+          "optional": true
+        },
+        "sortablejs": {
+          "optional": true
+        },
+        "universal-cookie": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vueuse/integrations/node_modules/vue-demi": {
+      "version": "0.14.6",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.6.tgz",
+      "integrity": "sha512-8QA7wrYSHKaYgUxDA5ZC24w+eHm3sYCbp0EzcDwKqN3p6HqtTCGR/GVsPyZW92unff4UlcSh++lmqDWN3ZIq4w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vueuse/metadata": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.4.1.tgz",
+      "integrity": "sha512-2Sc8X+iVzeuMGHr6O2j4gv/zxvQGGOYETYXEc41h0iZXIRnRbJZGmY/QP8dvzqUelf8vg0p/yEA5VpCEu+WpZg==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/shared": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-10.4.1.tgz",
+      "integrity": "sha512-vz5hbAM4qA0lDKmcr2y3pPdU+2EVw/yzfRsBdu+6+USGa4PxqSQRYIUC9/NcT06y+ZgaTsyURw2I9qOFaaXHAg==",
+      "dev": true,
+      "dependencies": {
+        "vue-demi": ">=0.14.5"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/shared/node_modules/vue-demi": {
+      "version": "0.14.6",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.6.tgz",
+      "integrity": "sha512-8QA7wrYSHKaYgUxDA5ZC24w+eHm3sYCbp0EzcDwKqN3p6HqtTCGR/GVsPyZW92unff4UlcSh++lmqDWN3ZIq4w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/algoliasearch": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.19.1.tgz",
+      "integrity": "sha512-IJF5b93b2MgAzcE/tuzW0yOPnuUyRgGAtaPv5UUywXM8kzqfdwZTO4sPJBzoGz1eOy6H9uEchsJsBFTELZSu+g==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/cache-browser-local-storage": "4.19.1",
+        "@algolia/cache-common": "4.19.1",
+        "@algolia/cache-in-memory": "4.19.1",
+        "@algolia/client-account": "4.19.1",
+        "@algolia/client-analytics": "4.19.1",
+        "@algolia/client-common": "4.19.1",
+        "@algolia/client-personalization": "4.19.1",
+        "@algolia/client-search": "4.19.1",
+        "@algolia/logger-common": "4.19.1",
+        "@algolia/logger-console": "4.19.1",
+        "@algolia/requester-browser-xhr": "4.19.1",
+        "@algolia/requester-common": "4.19.1",
+        "@algolia/requester-node-http": "4.19.1",
+        "@algolia/transporter": "4.19.1"
+      }
+    },
+    "node_modules/ansi-sequence-parser": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.1.tgz",
+      "integrity": "sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg==",
+      "dev": true
+    },
+    "node_modules/csstype": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
+      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
+      "dev": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
+      "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.18.20",
+        "@esbuild/android-arm64": "0.18.20",
+        "@esbuild/android-x64": "0.18.20",
+        "@esbuild/darwin-arm64": "0.18.20",
+        "@esbuild/darwin-x64": "0.18.20",
+        "@esbuild/freebsd-arm64": "0.18.20",
+        "@esbuild/freebsd-x64": "0.18.20",
+        "@esbuild/linux-arm": "0.18.20",
+        "@esbuild/linux-arm64": "0.18.20",
+        "@esbuild/linux-ia32": "0.18.20",
+        "@esbuild/linux-loong64": "0.18.20",
+        "@esbuild/linux-mips64el": "0.18.20",
+        "@esbuild/linux-ppc64": "0.18.20",
+        "@esbuild/linux-riscv64": "0.18.20",
+        "@esbuild/linux-s390x": "0.18.20",
+        "@esbuild/linux-x64": "0.18.20",
+        "@esbuild/netbsd-x64": "0.18.20",
+        "@esbuild/openbsd-x64": "0.18.20",
+        "@esbuild/sunos-x64": "0.18.20",
+        "@esbuild/win32-arm64": "0.18.20",
+        "@esbuild/win32-ia32": "0.18.20",
+        "@esbuild/win32-x64": "0.18.20"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true
+    },
+    "node_modules/focus-trap": {
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.5.2.tgz",
+      "integrity": "sha512-p6vGNNWLDGwJCiEjkSK6oERj/hEyI9ITsSwIUICBoKLlWiTWXJRfQibCwcoi50rTZdbi87qDtUlMCmQwsGSgPw==",
+      "dev": true,
+      "dependencies": {
+        "tabbable": "^6.2.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+      "dev": true
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.3",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.3.tgz",
+      "integrity": "sha512-B7xGbll2fG/VjP+SWg4sX3JynwIU0mjoTc6MPpKNuIvftk6u6vqhDnk1R80b8C2GBR6ywqy+1DcKBrevBg+bmw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mark.js": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
+      "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
+      "dev": true
+    },
+    "node_modules/minisearch": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-6.1.0.tgz",
+      "integrity": "sha512-PNxA/X8pWk+TiqPbsoIYH0GQ5Di7m6326/lwU/S4mlo4wGQddIcf/V//1f9TB0V4j59b57b+HZxt8h3iMROGvg==",
+      "dev": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
+    },
+    "node_modules/postcss": {
+      "version": "8.4.29",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.29.tgz",
+      "integrity": "sha512-cbI+jaqIeu/VGqXEarWkRCCffhjgXc0qjBtXpqJhTBohMUjUQnbBr0xqX3vEKudc4iviTewcJo5ajcec5+wdJw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.17.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.17.1.tgz",
+      "integrity": "sha512-X9BODrvQ4Ekwv9GURm9AKAGaomqXmip7NQTZgY7gcNmr7XE83adOMJvd3N42id1tMFU7ojiynRsYnY6/BRFxLA==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "3.28.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.28.1.tgz",
+      "integrity": "sha512-R9OMQmIHJm9znrU3m3cpE8uhN0fGdXiawME7aZIpQqvpS/85+Vt1Hq1/yVIcYfOmaQiHjvXkQAoJukvLpau6Yw==",
+      "dev": true,
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=14.18.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/search-insights": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.8.0.tgz",
+      "integrity": "sha512-VzI4PMktJbydkbrF3/n40vFfRxdwg+o3CkQt0F3mHRSXVuv0PsVxQvB6mQQq/e9MCXAemcmp/GP9CNHpayFoCw==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/shiki": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.3.tgz",
+      "integrity": "sha512-U3S/a+b0KS+UkTyMjoNojvTgrBHjgp7L6ovhFVZsXmBGnVdQ4K4U9oK0z63w538S91ATngv1vXigHCSWOwnr+g==",
+      "dev": true,
+      "dependencies": {
+        "ansi-sequence-parser": "^1.1.0",
+        "jsonc-parser": "^3.2.0",
+        "vscode-oniguruma": "^1.7.0",
+        "vscode-textmate": "^8.0.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tabbable": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
+      "dev": true
+    },
+    "node_modules/vite": {
+      "version": "4.4.9",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.9.tgz",
+      "integrity": "sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.18.10",
+        "postcss": "^8.4.27",
+        "rollup": "^3.27.1"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "@types/node": ">= 14",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitepress": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.0.0-rc.10.tgz",
+      "integrity": "sha512-+MsahIWqq5WUEmj6MR4obcKYbT7im07jZPCQPdNJExkeOSbOAJ4xypSLx88x7rvtzWHhHc5aXbOhCRvGEGjFrw==",
+      "dev": true,
+      "dependencies": {
+        "@docsearch/css": "^3.5.2",
+        "@docsearch/js": "^3.5.2",
+        "@vue/devtools-api": "^6.5.0",
+        "@vueuse/core": "^10.4.1",
+        "@vueuse/integrations": "^10.4.1",
+        "focus-trap": "^7.5.2",
+        "mark.js": "8.11.1",
+        "minisearch": "^6.1.0",
+        "shiki": "^0.14.3",
+        "vite": "^4.4.9",
+        "vue": "^3.3.4"
+      },
+      "bin": {
+        "vitepress": "bin/vitepress.js"
+      }
+    },
+    "node_modules/vscode-oniguruma": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
+      "dev": true
+    },
+    "node_modules/vscode-textmate": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
+      "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
+      "dev": true
+    },
+    "node_modules/vue": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.3.4.tgz",
+      "integrity": "sha512-VTyEYn3yvIeY1Py0WaYGZsXnz3y5UnGi62GjVEqvEGPl6nxbOrCXbVOTQWBEJUqAyTUk2uJ5JLVnYJ6ZzGbrSw==",
+      "dev": true,
+      "dependencies": {
+        "@vue/compiler-dom": "3.3.4",
+        "@vue/compiler-sfc": "3.3.4",
+        "@vue/runtime-dom": "3.3.4",
+        "@vue/server-renderer": "3.3.4",
+        "@vue/shared": "3.3.4"
+      }
+    }
+  }
+}

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,0 +1,11 @@
+{
+  "type": "module",
+  "devDependencies": {
+    "vitepress": "^1.0.0-rc.10"
+  },
+  "scripts": {
+    "docs:dev": "vitepress dev",
+    "docs:build": "vitepress build",
+    "docs:preview": "vitepress preview"
+  }
+}

--- a/docs/public/.gitattributes
+++ b/docs/public/.gitattributes
@@ -1,0 +1,3 @@
+*.mp4 filter=lfs diff=lfs merge=lfs -text
+*.png filter=lfs diff=lfs merge=lfs -text
+*.jpg filter=lfs diff=lfs merge=lfs -text

--- a/docs/public/_header
+++ b/docs/public/_header
@@ -1,0 +1,3 @@
+/assets/*
+  cache-control: max-age=31536000
+  cache-control: immutable

--- a/docs/public/favicon.svg
+++ b/docs/public/favicon.svg
@@ -1,0 +1,18 @@
+<svg width="100%" height="100%" viewBox="0 0 32 32" version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .b { fill: red; }
+    .y { fill: green; }
+    @media (prefers-color-scheme: dark) {
+      .b { fill: #6FB2E4; }
+      .y { fill: #FEC10E; }
+    }
+  </style>
+  <circle cx="10" cy="4.5" r="3" class="b"/>
+  <circle cx="5.2" cy="9.9" r="3" class="b"/>
+  <circle cx="7" cy="16.7" r="3" class="b"/>
+  <circle cx="13.8" cy="19" r="3" class="b"/>
+  <circle cx="18.2" cy="13" r="3" class="y"/>
+  <circle cx="25" cy="15.3" r="3" class="y"/>
+  <circle cx="26.8" cy="22.1" r="3" class="y"/>
+  <circle cx="22" cy="27.5" r="3" class="y"/>
+</svg>

--- a/docs/public/images/.gitattributes
+++ b/docs/public/images/.gitattributes
@@ -1,0 +1,1 @@
+*.svg filter=lfs diff=lfs merge=lfs -text

--- a/docs/public/images/axes-dark.png
+++ b/docs/public/images/axes-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4c6baf3b22e40861ce108cfd6c70d421c80881fd646bf895e4b900d724ffd800
+size 55625

--- a/docs/public/images/axes-grid-dark.png
+++ b/docs/public/images/axes-grid-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:15131d4af024fb1cda1927e9a62add0367a10e542c2a8baa6d40e35c37d14f3b
+size 68073

--- a/docs/public/images/axes-grid-light.png
+++ b/docs/public/images/axes-grid-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ab7da5fdd300e9522eb6c6ebcab2765af0e1840633ebd1c7587bc5a6f00a063f
+size 68341

--- a/docs/public/images/axes-labels-dark.png
+++ b/docs/public/images/axes-labels-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:47024d75e4feed0c90d6ae50b5dd3a60846c7849184e46de38efb6bd2e8d4205
+size 74361

--- a/docs/public/images/axes-labels-light.png
+++ b/docs/public/images/axes-labels-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c1f0987c9e56653ba8dc54f526859605a2a396f3b67991180207afe5b53a2f87
+size 62721

--- a/docs/public/images/axes-light.png
+++ b/docs/public/images/axes-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8dc4175e21cb2f5bc3e07e3c0b75ab98bc2c9cddd139156059251f5f04f4d600
+size 52014

--- a/docs/public/images/get-started-custom-encoding-dark.png
+++ b/docs/public/images/get-started-custom-encoding-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bfb952b51b74b210d5c8c051aabdd7ccf11c26fbff4c2b2e5b01553bc3eb19c7
+size 63360

--- a/docs/public/images/get-started-custom-encoding-light.png
+++ b/docs/public/images/get-started-custom-encoding-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bfce87eb3eca1643c5b5cfb411fb1fcc85a43c91d23358e3423ff540000affe5
+size 65146

--- a/docs/public/images/get-started-default-encoding-1-dark.png
+++ b/docs/public/images/get-started-default-encoding-1-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:803da1ebdad29ec3c72dbfc86357ab4d80ff06fe8948d042438c2dc36fff7a90
+size 49530

--- a/docs/public/images/get-started-default-encoding-1-light.png
+++ b/docs/public/images/get-started-default-encoding-1-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6725c5fb1f278b38b7f267c67d3caa947707ccc16778a123db3cc1872bc3dac1
+size 50201

--- a/docs/public/images/get-started-default-encoding-2-dark.png
+++ b/docs/public/images/get-started-default-encoding-2-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:554819a6d825bbde193c9b4e48630700fde2a7e791a7330be8a0f14fa23b4ad7
+size 53119

--- a/docs/public/images/get-started-default-encoding-2-light.png
+++ b/docs/public/images/get-started-default-encoding-2-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:77a5e3e0c201b457a4e316ece7211662b59895b6205942ee779d77c0df117035
+size 54269

--- a/docs/public/images/get-started-functional-api-1-dark.png
+++ b/docs/public/images/get-started-functional-api-1-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6a5699f5cd75b2b0d4d9928038e1ebdd6c788e40a973128f24360b87972018ca
+size 52107

--- a/docs/public/images/get-started-functional-api-1-light.png
+++ b/docs/public/images/get-started-functional-api-1-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:40530c1cb1906df619c05b21c92d066a607dbb3a8e6a3d391f0a28bd4bd78ed4
+size 50393

--- a/docs/public/images/get-started-functional-api-2-dark.png
+++ b/docs/public/images/get-started-functional-api-2-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:44399f1b6a28c4c41b169fe60d3f80bc41a12f385c7c0e15a057569cbcfb5586
+size 52066

--- a/docs/public/images/get-started-functional-api-2-light.png
+++ b/docs/public/images/get-started-functional-api-2-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e3c53bde625f57142b4c119c5fa8688c3126da3c34812d719b3c0e7e7ea869c0
+size 50492

--- a/docs/public/images/get-started-functional-api-3-dark.png
+++ b/docs/public/images/get-started-functional-api-3-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c2adcd0ebca1c77b491c44572677dae052ea7f98a7178ec0518c033060c75cfe
+size 53489

--- a/docs/public/images/get-started-functional-api-3-light.png
+++ b/docs/public/images/get-started-functional-api-3-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5beaf745eda0b144e44d4fcc58767fc1404b114e095992f3ffac81b1b2a6a678
+size 52363

--- a/docs/public/images/get-started-simple-dark.png
+++ b/docs/public/images/get-started-simple-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ef755763c5470f550fe9ce4905795f453ca0f0b883c8ab42be2575b1e40da4bd
+size 33543

--- a/docs/public/images/get-started-simple-light.png
+++ b/docs/public/images/get-started-simple-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:936f464dcffdb97bf6d28f562cbd8e65d758978c8578d1d71efebe8544ba5b71
+size 32351

--- a/docs/public/images/get-started-static-encoding-dark.png
+++ b/docs/public/images/get-started-static-encoding-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:df60f0926121042c72f2ec426e7f1ed3a1edbd3071fcea7423ce86ec63aa2281
+size 64590

--- a/docs/public/images/get-started-static-encoding-light.png
+++ b/docs/public/images/get-started-static-encoding-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:47caabbe492971efa313338d3e26cb46d5a8181fadf084e444495aab2c7c711c
+size 70331

--- a/docs/public/images/icon-feature-interactive-dark.svg
+++ b/docs/public/images/icon-feature-interactive-dark.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d4510e42d9e3dc1e85138658c9204348808b641532a57221cba068565675767
+size 572

--- a/docs/public/images/icon-feature-interactive-light.svg
+++ b/docs/public/images/icon-feature-interactive-light.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:63079f217c8719918e3d4a198b0e37eea75e1d847b11e4569f4f2271d5f15aa8
+size 572

--- a/docs/public/images/icon-feature-interlinked-dark.svg
+++ b/docs/public/images/icon-feature-interlinked-dark.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7ad7c8b38582dfb6ebd90446c0ee87e439e5315baf32615e38b90788b2a4da25
+size 777

--- a/docs/public/images/icon-feature-interlinked-light.svg
+++ b/docs/public/images/icon-feature-interlinked-light.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:811d1e5854f92e2348837979f750b3189ba42b67a0fd7e2ba121750788f04fdf
+size 777

--- a/docs/public/images/icon-feature-scalable-dark.svg
+++ b/docs/public/images/icon-feature-scalable-dark.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a3558cac11596562895a541fc38ade9bdbc979040c023534f7e05e24ef46c8ea
+size 501

--- a/docs/public/images/icon-feature-scalable-light.svg
+++ b/docs/public/images/icon-feature-scalable-light.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9c212141f73bac5b1a33cf235244d8f8329cfd79f3cbcccfe3e7539e9d89a0a7
+size 501

--- a/docs/public/images/jupyter-scatter-og.jpg
+++ b/docs/public/images/jupyter-scatter-og.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:27217079bf77d429a421955d24bbd0bf2d495ea97bc6f95a0957e79667e0f6cb
+size 146204

--- a/docs/public/images/legend-1-dark.png
+++ b/docs/public/images/legend-1-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dd94de9772f4a211b826aa25fd22ada63a11c6e09bb7d347f647008f8ae88442
+size 89043

--- a/docs/public/images/legend-1-light.png
+++ b/docs/public/images/legend-1-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a1637610b27c0ecad17cc72c4a5978b03a3d8387cb2c08c7f0f97e46f25fc11
+size 88620

--- a/docs/public/images/legend-2-dark.png
+++ b/docs/public/images/legend-2-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:97b123b033cee09faea00195ed3cf7e8137db83dcece394c45155c0a4a076858
+size 87452

--- a/docs/public/images/legend-2-light.png
+++ b/docs/public/images/legend-2-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e2dafa1aee4f8048d4426fe944dc967f76342afec52973e5cc8aa671a348bffe
+size 88424

--- a/docs/public/images/legend-3-dark.png
+++ b/docs/public/images/legend-3-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1217236b777806735b6d65fbcac13d4717116a793c7df9f9c7afd23d5bf28360
+size 90456

--- a/docs/public/images/legend-3-light.png
+++ b/docs/public/images/legend-3-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5b6abed63427ef0149054504942a3a06b961062094fc1eabac0b5047a9d2b55d
+size 93138

--- a/docs/public/images/link-multiple-plots-simple-1-dark.png
+++ b/docs/public/images/link-multiple-plots-simple-1-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d66eb03351a710109dd5cc738782d8a7b37ec8fb348c734ae44881e43fac295
+size 43798

--- a/docs/public/images/link-multiple-plots-simple-1-light.png
+++ b/docs/public/images/link-multiple-plots-simple-1-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:45b64a66e80b6689e9345c557e2bdc2b8e230c04a835c4f23c7fc11dba2b66c4
+size 42033

--- a/docs/public/images/link-multiple-plots-simple-2-dark.png
+++ b/docs/public/images/link-multiple-plots-simple-2-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d46319ddae26a650ee929b4fff3522d703cbaa4efabd25d5ba32d4714257a893
+size 79101

--- a/docs/public/images/link-multiple-plots-simple-2-light.png
+++ b/docs/public/images/link-multiple-plots-simple-2-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b7904578dfe491c37fb4e426778cd0b8d28599c6f17e0830f221974f26039efb
+size 75717

--- a/docs/public/images/link-multiple-plots-simple-3-dark.png
+++ b/docs/public/images/link-multiple-plots-simple-3-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e107c00c721e7f92e0d2bedd0adeb7c313ca1495410c797cd94a654b57396e67
+size 71382

--- a/docs/public/images/link-multiple-plots-simple-3-light.png
+++ b/docs/public/images/link-multiple-plots-simple-3-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f5d660ec01073ff304d0f7f36bb4872923d78077a86a9f80be5a407376c8f580
+size 68462

--- a/docs/public/images/teaser-dark.jpg
+++ b/docs/public/images/teaser-dark.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:092d1b8a1f50a27b95017b9f7e5f712d2bd3a902e06ac557ec2109523d3d11d5
+size 44187

--- a/docs/public/images/teaser-light.jpg
+++ b/docs/public/images/teaser-light.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c5dace7deba25ca5dfebfc0f70bdfbf507c5de822725940fa0f4e9d30b3c3bf4
+size 45041

--- a/docs/public/images/tooltip-1-dark.png
+++ b/docs/public/images/tooltip-1-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3013a7c89d26e5024032bca5a5d0cde53173c1ae9e52ab3e55413a51aa9a7f02
+size 94517

--- a/docs/public/images/tooltip-1-light.png
+++ b/docs/public/images/tooltip-1-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa09ab390771ef6b7f023e1075a618c7d63f586482f96ebfae4e0c20ba790292
+size 93378

--- a/docs/public/images/tooltip-2-dark.png
+++ b/docs/public/images/tooltip-2-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b8d9ee98adf891f8b07d23b00ddf74892ae0347dd639b1b9fab574c762dba4b
+size 94980

--- a/docs/public/images/tooltip-2-light.png
+++ b/docs/public/images/tooltip-2-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dbf8aaf488cc19395f3515917a793a1f24c1c2c064850e086071199ca63995de
+size 95734

--- a/docs/public/videos/get-started-xy-animation-dark.mp4
+++ b/docs/public/videos/get-started-xy-animation-dark.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e358d33bdfa9fcd5cc5c5d1d4a115e046fe36e4aa03fca3f5566f9bb24a8151
+size 459946

--- a/docs/public/videos/get-started-xy-animation-light.mp4
+++ b/docs/public/videos/get-started-xy-animation-light.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b365a3a5e5443d0c9c929bdb2e91ec41d8f70a564151a46867a9476455f698b0
+size 452345

--- a/docs/public/videos/interactions-click-dark.mp4
+++ b/docs/public/videos/interactions-click-dark.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:19a7ab2e8d6b65b4be6d629cdd70a7eb041a31c1e218b6fd3d15f6bd770c5e03
+size 152211

--- a/docs/public/videos/interactions-click-light.mp4
+++ b/docs/public/videos/interactions-click-light.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bdc02e86bf621ef3ef93a5e57677774c71c3180475909d89cb594a7eabbda78b
+size 161990

--- a/docs/public/videos/interactions-double-click-dark.mp4
+++ b/docs/public/videos/interactions-double-click-dark.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:06139691e6c8dd248c346d97ba2bc2eb2143f4752e493e28d781ad9ce3e6dca2
+size 134908

--- a/docs/public/videos/interactions-double-click-light.mp4
+++ b/docs/public/videos/interactions-double-click-light.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:863ae047665e3f68503f702756d3c3dfab35b3db5ac3373309212863628fe4a5
+size 166288

--- a/docs/public/videos/interactions-filter-dark.mp4
+++ b/docs/public/videos/interactions-filter-dark.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f0bdf0c11cd576d0b42ff98348952fdd506c899deceaa68843b313b35af2f8b1
+size 247205

--- a/docs/public/videos/interactions-filter-light.mp4
+++ b/docs/public/videos/interactions-filter-light.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2dcd3f1ab86e63096e31f175a29bf71bc179706a71a7b14f7d8886e8a5b4d55
+size 125378

--- a/docs/public/videos/interactions-hover-dark.mp4
+++ b/docs/public/videos/interactions-hover-dark.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d9c8e5be9df3011bd9c08cb654c98062152eb94cee919e1796d3fcee74eea541
+size 180470

--- a/docs/public/videos/interactions-hover-light.mp4
+++ b/docs/public/videos/interactions-hover-light.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:365d4b48f8cbb2fe2d134a2ff0d01f62ab1b9cb962101290e50fb4836468bc91
+size 148646

--- a/docs/public/videos/interactions-lasso-dark.mp4
+++ b/docs/public/videos/interactions-lasso-dark.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09d54a5be3a4832fe9d2a85fb2a5258c99b35a5186f5fd180074d496674b1fde
+size 154834

--- a/docs/public/videos/interactions-lasso-light.mp4
+++ b/docs/public/videos/interactions-lasso-light.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a1031d6148cb539aae62ebe961c4716a5be6179c8c168050c6f7439dfd3360ae
+size 161573

--- a/docs/public/videos/interactions-overview-and-details-dark.mp4
+++ b/docs/public/videos/interactions-overview-and-details-dark.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d64a10afce79fd94334ac404ad59a3c6ec9a703bb39689964e4d16a6e572e5a0
+size 811198

--- a/docs/public/videos/interactions-overview-and-details-light.mp4
+++ b/docs/public/videos/interactions-overview-and-details-light.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fc3dd3db21ee4f8a06bc3c742535de92f566cbb9efb4359d4615ee9505c53710
+size 493106

--- a/docs/public/videos/interactions-pan-dark.mp4
+++ b/docs/public/videos/interactions-pan-dark.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:05e746fed3f8387e90c1489d9267e63aac5fa26971068a3c47d7614ba6b62eda
+size 531245

--- a/docs/public/videos/interactions-pan-light.mp4
+++ b/docs/public/videos/interactions-pan-light.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d72b9e0d1e36e908689e6f90253fed4e368ac965e46fad81eada6b0dc093e636
+size 731658

--- a/docs/public/videos/interactions-zoom-dark.mp4
+++ b/docs/public/videos/interactions-zoom-dark.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:df8e26214c1711b2fce17df6ea8f325e1735a77ac4ad917d58e819098394a542
+size 2341567

--- a/docs/public/videos/interactions-zoom-light.mp4
+++ b/docs/public/videos/interactions-zoom-light.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d6defdff2a026e751a22f305f413955d800ee022d4030cf99bcb838dbff3ef9d
+size 2625190

--- a/docs/public/videos/interactions-zoom-to-points-dark.mp4
+++ b/docs/public/videos/interactions-zoom-to-points-dark.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:383dc6219fa03f0d62d89a65fb68f0579fc30d1e6e80d5a4339bc4f79f8d0b9e
+size 704914

--- a/docs/public/videos/interactions-zoom-to-points-light.mp4
+++ b/docs/public/videos/interactions-zoom-to-points-light.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d6d7e2c098cdb445e0f6537528a5333aeb93a8880fc3cf743f8f60d358717041
+size 937051

--- a/docs/public/videos/link-multiple-plots-synced-dark.mp4
+++ b/docs/public/videos/link-multiple-plots-synced-dark.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a3dbdc96ec9d7eb4fbf746a93203b62685c2f0728c88b7c6213b2420b0906503
+size 712903

--- a/docs/public/videos/link-multiple-plots-synced-light.mp4
+++ b/docs/public/videos/link-multiple-plots-synced-light.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a1ba6008716d659f037dff82b51c3f2a8a79aebdfd4bb00be748d24fa7b93dde
+size 805000

--- a/docs/public/videos/selections-observe-dark.mp4
+++ b/docs/public/videos/selections-observe-dark.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6f6d6d9fc92a54556039beababdeeefff086a8da6e765f2323423bff15df7032
+size 226940

--- a/docs/public/videos/selections-observe-light.mp4
+++ b/docs/public/videos/selections-observe-light.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b0e84b0f7840a973b4d8805027bf0ac1419e05f67fb85f8e32e421d1c10ac6b7
+size 144628

--- a/docs/public/videos/teaser-dark.mp4
+++ b/docs/public/videos/teaser-dark.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:47e10a3e0c7eb4a9634f39b6275f85823be3ae220cc91c9b655b77f3a0b4b40f
+size 2244891

--- a/docs/public/videos/teaser-light.mp4
+++ b/docs/public/videos/teaser-light.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5658a70f066611a6e61b9613bfb93a5e1497bdf079dcf241eadc9cfde7757c29
+size 2395491

--- a/docs/selections.md
+++ b/docs/selections.md
@@ -1,0 +1,155 @@
+# Selections
+
+A primary way to interact with a scatter plot is through selections.
+Jupyter Scatter makes this easy by offering selections that synchronize
+between the Python and JavaScript kernel.
+
+There are two ways to select points in a scatter plot:
+
+1. [Programmatically using the `scatter.selection()` method](#set-programmatic)
+2. [Interactively using the mouse-based lasso](#set-interactive)
+
+Similarly, to act upon selected data points, you can
+
+1. [Use the `scatter.selection()` method](#get-programmatic)
+2. [Observe `scatter.widget.selection`](#get-interactive)
+
+---
+
+To demonstrate how these approaches work, we're going to use the following
+DataFrame of random value:
+
+```python
+import jscatter
+import numpy as np
+import pandas as pd
+
+df = pd.DataFrame({
+  # Random floats
+  "mass": np.random.rand(500),
+  "speed": np.random.rand(500),
+  "pval": np.random.rand(500),
+  # Random letters A, B, C, D, E, F, G, H
+  "cat": np.vectorize(lambda x: chr(65 + round(x * 8)))(np.random.rand(500)),
+})
+
+scatter = jscatter.Scatter(data=df, x="mass", y="speed", color_by="cat")
+scatter.show()
+```
+
+## Programmatically Select Points {#set-programmatic}
+
+To select a specific set of points, you can use the [`scatter.selection()`](./api#scatter.selection) method
+which accepts as input a list of point indices.
+
+```py
+scatter.selection([1, 2, 3])
+```
+
+With the help of Panda's `query` method, we can easily select specific points
+matching some criteria as follows:
+
+```py
+scatter.selection(df.query("cat == 'A'").index)
+```
+
+With the above call, for instance, we would select all points that belong to
+category `A`.
+
+::: info
+By default, Jupyter Scatter references points by their range index. Meaning,
+`scatter.selection([0, 1, 2])` will select the first, second, and third point.
+
+Alternatively, if you're binding a DataFrame to a `Scatter` instance via
+`Scatter(data=df)` and your DataFrame has a custom index, you can make the
+`Scatter` instance reference data points by the DataFrame's index via
+`Scatter(data=df, data_use_index=True)`.
+:::
+
+## Lasso Select Points {#set-interactive}
+
+As you might have seen already in the [interactions guide](./interactions), we
+can also select points interactively using the lasso tool.
+
+<video autoplay loop muted width="1256" data-name="interactions-lasso">
+  <source
+    src="/videos/interactions-lasso-dark.mp4"
+    type="video/mp4"
+  />
+</video>
+
+## Get Selected Points {#get-programmatic}
+
+Importantly, once you have selected some points, you can retrieve the
+interaction using the same method [`scatter.selection()`](./api#scatter.selection)
+that we used earlier. This time just don't pass any arguments to the function.
+
+```py
+scatter.selection()
+# => [0, 1, 2]
+```
+
+This will return a the indices of the selected points.
+
+If you have bound a DataFrame to the scatter instance, you can use these indices
+to retrieve the original data records.
+
+```py{2}
+scatter.selection(df.query("cat == 'A'").index)
+df.loc[scatter.selection()]
+```
+
+|      | x    | y    | pval | cat |
+|------|------|------|------|-----|
+| 0    | 0.13 | 0.27 | 0.51 | A   |
+| 42   | 0.87 | 0.93 | 0.80 | A   |
+| …    | …    | …    | …    | …   |
+| 1337 | 0.10 | 0.25 | 0.25 | A   |
+
+## Observe Selected Points {#get-interactive}
+
+Real _magic_ can about to happen when you react to selections automatically. You
+can do this by observing scatter widget's `selection` property:
+
+```py{1,17-23}
+import ipywidgets
+import jscatter
+import numpy as np
+import pandas as pd
+
+df = pd.DataFrame({
+  # Random floats
+  "mass": np.random.rand(500),
+  "speed": np.random.rand(500),
+  "pval": np.random.rand(500),
+  # Random letters A, B, C, D, E, F, G, H
+  "cat": np.vectorize(lambda x: chr(65 + round(x * 8)))(np.random.rand(500)),
+})
+
+scatter = jscatter.Scatter(data=df, x="mass", y="speed", color_by="cat")
+
+output = ipywidgets.Output()
+
+@output.capture(clear_output=True)
+def selection_change_handler(change):
+    display(df.loc[change.new].style.hide(axis='index'))
+            
+scatter.widget.observe(selection_change_handler, names=["selection"])
+
+ipywidgets.HBox([scatter.show(), output])
+````
+
+<video autoplay loop muted width="1258" data-name="selections-observe">
+  <source
+    src="/videos/selections-observe-dark.mp4"
+    type="video/mp4"
+  />
+</video>
+
+If you want to learn how the point selections can be used to help you explore
+large-scale datasets, check out our [in-depth talk+tutorial from SciPy '23](https://github.com/flekschas/jupyter-scatter-tutorial).
+
+<script setup>
+  import { videoColorModeSrcSwitcher } from './utils';
+  videoColorModeSrcSwitcher();
+</script>

--- a/docs/utils.ts
+++ b/docs/utils.ts
@@ -1,0 +1,62 @@
+import { onMounted, onUnmounted } from 'vue';
+
+export const videoColorModeSrcSwitcher = () => {
+  const switchSrc = () => {
+    const suffix = document.documentElement.classList.contains('dark')
+      ? 'dark'
+      : 'light';
+
+    const videos = document.body.querySelectorAll('video');
+
+    for (const video of videos) {
+      const name = video.dataset.name;
+
+      video
+        .querySelector('source')
+        ?.setAttribute('src', `/videos/${name}-${suffix}.mp4`);
+
+      if (video.getAttribute('poster')) {
+        video.setAttribute('poster', `/images/${name}-${suffix}.jpg`);
+      }
+
+      video.pause();
+      video.currentTime = 0;
+      video.load();
+    }
+  }
+
+  const classObserver = new MutationObserver((mutations) => {
+    mutations.forEach((mu) => {
+      if (mu.type !== 'attributes' && mu.attributeName !== 'class') return;
+      switchSrc();
+    });
+  });
+
+  onMounted(() => {
+    classObserver.observe(document.documentElement, {attributes: true});
+    switchSrc();
+  });
+
+  onUnmounted(() => {
+    classObserver.disconnect();
+  });
+}
+
+export const videoPlayOnHover = () => {
+  function mouseEnterHandler() { this.play(); }
+  function mouseLeaveHandler() { this.pause(); }
+
+  onMounted(() => {
+    for (const video of document.body.querySelectorAll('video')) {
+      video.addEventListener('mouseenter', mouseEnterHandler);
+      video.addEventListener('mouseleave', mouseLeaveHandler);
+    }
+  });
+
+  onUnmounted(() => {
+    for (const video of document.body.querySelectorAll('video')) {
+      video.removeEventListener('mouseenter', mouseEnterHandler);
+      video.removeEventListener('mouseleave', mouseLeaveHandler);
+    }
+  });
+}


### PR DESCRIPTION
This PR adds a documentation site

## Description

> What was changed in this pull request?

Under the `docs` folder we will now have more comprehensive documentation. Once merged and deployed, the page will be accessible at https://jupyter-scatter.dev

> Why is it necessary?

Previously we only relied on GitHub markdown. This was a bit limiting.

## Checklist

- [x] Provided a concise title as a [semantic commit message](https://www.conventionalcommits.org) (e.g. "fix: correctly handle undefined properties")
- [ ] `CHANGELOG.md` updated
- [ ] Tests added or updated
- [x] Documentation in `API.md`/`README.md` added or updated
- [ ] Example(s) added or updated
- [ ] Screenshot, gif, or video attached for visual changes
