### PR TITLE
fix: address several issues regarding the axis rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.15.1
+
+- Fix: Use custom regl-scatterplot option on creating a `Scatter` instance ([#106](https://github.com/flekschas/jupyter-scatter/issues/106))
+
 ## v0.15.0
 
 - Feat: Add support for histograms in the tooltip ([#96](https://github.com/flekschas/jupyter-scatter/pull/96))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## v0.15.1
 
+- Fix: Improve the tooltip positioning to avoid the tooltip being cut off unnecessarily
+- Fix: Properly redraw axes on resize ([#108](https://github.com/flekschas/jupyter-scatter/issues/108))
 - Fix: Incorrect axes scale domain ([#107](https://github.com/flekschas/jupyter-scatter/issues/107))
 - Fix: Use custom regl-scatterplot option on creating a `Scatter` instance ([#106](https://github.com/flekschas/jupyter-scatter/issues/106))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,13 @@
-## v0.15.1
-
-- Fix: Improve the tooltip positioning to avoid the tooltip being cut off unnecessarily
-- Fix: Properly redraw axes on resize ([#108](https://github.com/flekschas/jupyter-scatter/issues/108))
-- Fix: Incorrect axes scale domain ([#107](https://github.com/flekschas/jupyter-scatter/issues/107))
-- Fix: Use custom regl-scatterplot option on creating a `Scatter` instance ([#106](https://github.com/flekschas/jupyter-scatter/issues/106))
-- Fix: Broken link to properties in docstrings ([#110](https://github.com/flekschas/jupyter-scatter/issues/110))
-
 ## v0.15.0
 
 - Feat: Add support for histograms in the tooltip ([#96](https://github.com/flekschas/jupyter-scatter/pull/96))
 - Feat: Add support for non-visualized properties in the toolip ([#96](https://github.com/flekschas/jupyter-scatter/pull/96))
 - Fix: Allow mixing custom and DataFrame-based data ([#89](https://github.com/flekschas/jupyter-scatter/issues/89))
+- Fix: Improve the tooltip positioning to avoid the tooltip being cut off unnecessarily
+- Fix: Properly redraw axes on resize ([#108](https://github.com/flekschas/jupyter-scatter/issues/108))
+- Fix: Incorrect axes scale domain ([#107](https://github.com/flekschas/jupyter-scatter/issues/107))
+- Fix: Use custom regl-scatterplot option on creating a `Scatter` instance ([#106](https://github.com/flekschas/jupyter-scatter/issues/106))
+- Fix: Broken link to properties in docstrings ([#110](https://github.com/flekschas/jupyter-scatter/issues/110))
 
 ## v0.14.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fix: Properly redraw axes on resize ([#108](https://github.com/flekschas/jupyter-scatter/issues/108))
 - Fix: Incorrect axes scale domain ([#107](https://github.com/flekschas/jupyter-scatter/issues/107))
 - Fix: Use custom regl-scatterplot option on creating a `Scatter` instance ([#106](https://github.com/flekschas/jupyter-scatter/issues/106))
+- Fix: Broken link to properties in docstrings ([#110](https://github.com/flekschas/jupyter-scatter/issues/110))
 
 ## v0.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## v0.15.1
 
+- Fix: Incorrect axes scale domain ([#107](https://github.com/flekschas/jupyter-scatter/issues/107))
 - Fix: Use custom regl-scatterplot option on creating a `Scatter` instance ([#106](https://github.com/flekschas/jupyter-scatter/issues/106))
 
 ## v0.15.0

--- a/README.md
+++ b/README.md
@@ -202,20 +202,29 @@ While jscatter is primarily developed for Jupyter Lab and Notebook, it also runs
 
 **Requirements:**
 
-- [Conda](https://docs.conda.io/en/latest/) >= 4.8
+- [Hatch](https://hatch.pypa.io/latest/) >= 1.7.0
 
 **Installation:**
 
 ```bash
 git clone https://github.com/flekschas/jupyter-scatter/ jscatter && cd jscatter
-conda env create -f environment.yml && conda activate jscatter
-pip install -e ".[test]"
+hatch shell
+pip install -e ".[dev]"
 ```
 
-**After Changing Python code:** simply restart the kernel.
+**After Changing Python code:** restart the kernel.
+
+Alternatively, you can enable auto reloading by enabling the `autoreload`
+extension. To do so, run the following code at the beginning of a notebook:
+
+```py
+%load_ext autoreload
+%autoreload 2
+```
 
 **After Changing JavaScript code:** do `cd js && npm run build`.
-Alternatively you can run `npm run watch` and rebundle the code on the fly.
+
+Alternatively, you can run `npm run watch` and rebundle the code on the fly.
 
 </p>
 </details>
@@ -223,7 +232,7 @@ Alternatively you can run `npm run watch` and rebundle the code on the fly.
 <details><summary>Setting up a test environment</summary>
 <p>
 
-Go to [test-environment](test-environment) and follow the detailed instructions
+Go to [test-environments](test-environments) and follow the instructions.
 
 </p>
 </details>

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -254,8 +254,14 @@ class JupyterScatterView {
       Object.entries(properties).forEach((property) => {
         const pyName = property[0];
         const jsName = property[1];
-        if (this[pyName] !== null && reglScatterplotProperty.has(jsName))
+        if (this[pyName] !== null && reglScatterplotProperty.has(jsName)) {
           initialOptions[jsName] = this[pyName];
+        }
+        if (this[pyName] !== null && jsName === 'otherOptions') {
+          Object.entries(this[pyName]).forEach(([key, value]) => {
+            initialOptions[key] = value;
+          })
+        }
       });
 
       this.scatterplot = createScatterplot(initialOptions);

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -21,6 +21,7 @@ import {
   getTooltipFontSize,
   createNumericalBinGetter,
   createElementWithClass,
+  remToPx,
 } from "./utils";
 
 import { version } from "../package.json";
@@ -48,6 +49,7 @@ const TOOLTIP_HISTOGRAM_HEIGHT = (/** @type {const} */ ({
   medium: '1.25em',
   large: '1.5em',
 }));
+const TOOLTIP_OFFSET_REM = 0.5;
 
 /**
  * This dictionary maps between the camelCased Python property names and their
@@ -713,7 +715,6 @@ class JupyterScatterView {
     }
 
     this.styleTooltip();
-    this.tooltipBbox = this.tooltip.getBoundingClientRect();
   }
 
   createTooltipContents() {
@@ -787,7 +788,7 @@ class JupyterScatterView {
     this.tooltipArrow.style.boxShadow = `0 0 1px rgba(0, 0, 0, ${this.tooltipOpacity}), -1px 1px 2px rgba(0, 0, 0, ${this.tooltipOpacity})`;
 
     this.moveTooltip = (x, y) => {
-      this.tooltip.style.transform = `translate(calc(${x}px - 50%), calc(${y}px - 0.5rem - 100%))`;
+      this.tooltip.style.transform = `translate(calc(${x}px - 50%), calc(${y}px - ${TOOLTIP_OFFSET_REM}rem - 100%))`;
     }
   }
 
@@ -800,7 +801,7 @@ class JupyterScatterView {
     this.tooltipArrow.style.boxShadow = `0 0 1px rgba(0, 0, 0, ${this.tooltipOpacity}), -1px 1px 2px rgba(0, 0, 0, ${this.tooltipOpacity})`;
 
     this.moveTooltip = (x, y) => {
-      this.tooltip.style.transform = `translate(calc(${x}px - 100% + 0.625rem), calc(${y}px - 0.5rem - 100%))`;
+      this.tooltip.style.transform = `translate(calc(${x}px - 100% + ${TOOLTIP_OFFSET_REM}rem), calc(${y}px - ${TOOLTIP_OFFSET_REM}rem - 100%))`;
     }
   }
 
@@ -813,7 +814,7 @@ class JupyterScatterView {
     this.tooltipArrow.style.boxShadow = `0 0 1px rgba(0, 0, 0, ${this.tooltipOpacity}), -1px 1px 2px rgba(0, 0, 0, ${this.tooltipOpacity})`;
 
     this.moveTooltip = (x, y) => {
-      this.tooltip.style.transform = `translate(calc(${x}px - 0.5rem), calc(${y}px - 0.5rem - 100%))`;
+      this.tooltip.style.transform = `translate(calc(${x}px - ${TOOLTIP_OFFSET_REM}rem), calc(${y}px - ${TOOLTIP_OFFSET_REM}rem - 100%))`;
     }
   }
 
@@ -826,7 +827,7 @@ class JupyterScatterView {
     this.tooltipArrow.style.boxShadow = `0 0 1px rgba(0, 0, 0, ${this.tooltipOpacity}), -1px -1px 2px rgba(0, 0, 0, ${this.tooltipOpacity})`;
 
     this.moveTooltip = (x, y) => {
-      this.tooltip.style.transform = `translate(calc(${x}px - 50%), calc(${y}px + 0.5rem))`;
+      this.tooltip.style.transform = `translate(calc(${x}px - 50%), calc(${y}px + ${TOOLTIP_OFFSET_REM}rem))`;
     }
   }
 
@@ -839,7 +840,7 @@ class JupyterScatterView {
     this.tooltipArrow.style.boxShadow = `0 0 1px rgba(0, 0, 0, ${this.tooltipOpacity}), -1px -1px 2px rgba(0, 0, 0, ${this.tooltipOpacity})`;
 
     this.moveTooltip = (x, y) => {
-      this.tooltip.style.transform = `translate(calc(${x}px - 100% + 0.625rem), calc(${y}px + 0.5rem))`;
+      this.tooltip.style.transform = `translate(calc(${x}px - 100% + ${TOOLTIP_OFFSET_REM}rem), calc(${y}px + ${TOOLTIP_OFFSET_REM}rem))`;
     }
   }
 
@@ -852,7 +853,7 @@ class JupyterScatterView {
     this.tooltipArrow.style.boxShadow = `0 0 1px rgba(0, 0, 0, ${this.tooltipOpacity}), -1px -1px 2px rgba(0, 0, 0, ${this.tooltipOpacity})`;
 
     this.moveTooltip = (x, y) => {
-      this.tooltip.style.transform = `translate(calc(${x}px - 0.5rem), calc(${y}px + 0.5rem))`;
+      this.tooltip.style.transform = `translate(calc(${x}px - ${TOOLTIP_OFFSET_REM}rem), calc(${y}px + ${TOOLTIP_OFFSET_REM}rem))`;
     }
   }
 
@@ -865,7 +866,7 @@ class JupyterScatterView {
     this.tooltipArrow.style.boxShadow = `0 0 1px rgba(0, 0, 0, ${this.tooltipOpacity}), -1px -1px 2px rgba(0, 0, 0, ${this.tooltipOpacity})`;
 
     this.moveTooltip = (x, y) => {
-      this.tooltip.style.transform = `translate(calc(${x}px - 0.5rem - 100%), calc(${y}px - 50%))`;
+      this.tooltip.style.transform = `translate(calc(${x}px - ${TOOLTIP_OFFSET_REM}rem - 100%), calc(${y}px - 50%))`;
     }
   }
 
@@ -877,7 +878,7 @@ class JupyterScatterView {
     this.tooltipArrow.style.transform = 'translate(calc(-50% + 1px), -50%) rotate(-45deg)';
     this.tooltipArrow.style.boxShadow = `0 0 1px rgba(0, 0, 0, ${this.tooltipOpacity}), 1px 1px 2px rgba(0, 0, 0, ${this.tooltipOpacity})`;
     this.moveTooltip = (x, y) => {
-      this.tooltip.style.transform = `translate(calc(${x}px + 0.5rem), calc(${y}px - 50%))`;
+      this.tooltip.style.transform = `translate(calc(${x}px + ${TOOLTIP_OFFSET_REM}rem), calc(${y}px - 50%))`;
     }
   }
 
@@ -903,22 +904,24 @@ class JupyterScatterView {
   }
 
   getTooltipPosition(x, y) {
-    const xCutoff = (this.tooltipBbox?.width / 2) || 120;
-    const yCutoff = this.tooltipBbox?.height || 120;
+    const { width, height } = this.tooltip.getBoundingClientRect();
+    const xCutoff = width / 2;
+    const yCutoff = height;
+    const tooltipOffset = remToPx(TOOLTIP_OFFSET_REM);
 
-    if (x < xCutoff) {
-      if (y < yCutoff) return 'bottom-right';
-      if (y > this.outerHeight - yCutoff) return 'top-right';
+    if (x < xCutoff + tooltipOffset) {
+      if (y < yCutoff + tooltipOffset) return 'bottom-right';
+      if (y > this.outerHeight - yCutoff - tooltipOffset) return 'top-right';
       return 'right-center';
     }
 
-    if (x > this.outerWidth - xCutoff) {
-      if (y < yCutoff) return 'bottom-left';
-      if (y > this.outerHeight - yCutoff) return 'top-left';
+    if (x > this.outerWidth - xCutoff - tooltipOffset) {
+      if (y < yCutoff + tooltipOffset) return 'bottom-left';
+      if (y > this.outerHeight - yCutoff - tooltipOffset) return 'top-left';
       return 'left-center';
     }
 
-    if (y < yCutoff) return 'bottom-center';
+    if (y < yCutoff + tooltipOffset) return 'bottom-center';
 
     return 'top-center';
   }

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -1531,6 +1531,14 @@ class JupyterScatterView {
     const xPadding = labels ? AXES_PADDING_X_WITH_LABEL : AXES_PADDING_X;
     const yPadding = labels ? AXES_PADDING_Y_WITH_LABEL : AXES_PADDING_Y;
 
+    const xScaleDomain = this.scatterplot.get('xScale').domain();
+    const yScaleDomain = this.scatterplot.get('yScale').domain();
+    this.xScaleAxis.domain(xScaleDomain.map(this.xScaleRegl2Axis.invert));
+    this.yScaleAxis.domain(yScaleDomain.map(this.yScaleRegl2Axis.invert));
+
+    this.xAxisContainer.call(this.xAxis.scale(this.xScaleAxis));
+    this.yAxisContainer.call(this.yAxis.scale(this.yScaleAxis));
+
     this.xScaleAxis.range([0, width - xPadding]);
     this.yScaleAxis.range([height - yPadding, 0]);
     this.xAxis.scale(this.xScaleAxis);

--- a/js/src/utils.js
+++ b/js/src/utils.js
@@ -94,3 +94,7 @@ export function createElementWithClass(tagName, className) {
 
   return element;
 }
+
+export function remToPx(rem) {
+  return rem * parseFloat(getComputedStyle(document.documentElement).fontSize);
+}

--- a/jscatter/jscatter.py
+++ b/jscatter/jscatter.py
@@ -145,7 +145,7 @@ class Scatter():
             encoding.
         kwargs : optional
             Options to customize the scatter instance and the visual encoding.
-            See https://github.com/flekschas/jupyter-scatter/blob/master/API.md#properties
+            See https://jupyter-scatter.dev/api#properties
             for a complete list of all properties.
 
         Returns
@@ -3807,7 +3807,7 @@ def plot(
         encoding.
     kwargs : optional
         Options to customize the scatter instance and the visual encoding.
-        See https://github.com/flekschas/jupyter-scatter/blob/master/API.md#properties
+        See https://jupyter-scatter.dev/api#properties
         for a complete list of all properties.
 
     Returns

--- a/jscatter/jscatter.py
+++ b/jscatter/jscatter.py
@@ -604,6 +604,8 @@ class Scatter():
                 except ValueError:
                     pass
 
+            self._x_scale_domain = [self._x_scale.vmin, self._x_scale.vmax]
+
             # Normalize x coordinate to [-1,1]
             self._points[:, 0] = to_ndc(self._points[:, 0], self._x_scale)
 
@@ -714,6 +716,8 @@ class Scatter():
                     self._y_scale.vmax = self._y_max
                 except ValueError:
                     pass
+
+            self._y_scale_domain = [self._y_scale.vmin, self._y_scale.vmax]
 
             # Normalize y coordinate to [-1,1]
             self._points[:, 1] = to_ndc(self._points[:, 1], self._y_scale)
@@ -3736,11 +3740,13 @@ class Scatter():
             x_histogram=self._x_histogram,
             x_histogram_range=self.get_histogram_range("x"),
             x_scale=to_scale_type(self._x_scale),
+            x_scale_domain=self._x_scale_domain,
             x_title=self._x_by,
             y_domain=self._y_domain,
             y_histogram=self._y_histogram,
             y_histogram_range=self.get_histogram_range("y"),
             y_scale=to_scale_type(self._y_scale),
+            y_scale_domain=self._y_scale_domain,
             y_title=self._y_by,
             zoom_animation=self._zoom_animation,
             zoom_on_filter=self._zoom_on_filter,

--- a/jscatter/widget.py
+++ b/jscatter/widget.py
@@ -83,6 +83,10 @@ class JupyterScatter(anywidget.AnyWidget):
     opacity_domain = Union([Dict(), List(minlen=2, maxlen=2)], allow_none=True).tag(sync=True)
     size_domain = Union([Dict(), List(minlen=2, maxlen=2)], allow_none=True).tag(sync=True)
 
+    # Scale domains
+    x_scale_domain = List(minlen=2, maxlen=2).tag(sync=True)
+    y_scale_domain = List(minlen=2, maxlen=2).tag(sync=True)
+
     # Histograms
     x_histogram = List(None, allow_none=True).tag(sync=True)
     y_histogram = List(None, allow_none=True).tag(sync=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,9 +61,9 @@ dev = [
 path = "js/package.json"
 pattern = "\"version\": \"(?P<version>.+?)\""
 
-[tool.hatch.build]
+[tool.hatch.build.targets.wheel]
+packages = ["jscatter"]
 artifacts = ["jscatter/bundle.js"]
-
 
 [tool.hatch.build.hooks.jupyter-builder]
 build-function = "hatch_jupyter_builder.npm_builder"


### PR DESCRIPTION
This PR addresses two bugs around axis rendering, another bug regarding `options`, and improves the tooltip positioning.

## Description

> What was changed in this pull request?

1. When initializing a `Scatter` instance, the `options` are properly used by `regl-scatterplot` (previously `options` were only applied after the initialization of a `Scatter` instance) (#106)
2. The x/y axis now use the appropriate x/y scale domain instead of the x/y data domain. (#107)
3. Upon resizing the browser window, the x/y axes are now properly rerendered. (#108)
4. The tooltip position incorporates the most up to date bounding box and offset to avoid cutting the tooltip off

> Why is it necessary?

Fixes #106
Fixes #107
Fixes #108
Improves the tooltip positioning

> Testing

I used the following example for testing

```py
import jscatter
import numpy as np
import pandas as pd

df = pd.DataFrame({
    "x": np.concatenate((np.linspace(start=-10, stop=10, num=15), np.linspace(start=-10, stop=10, num=15))),
    "y": np.concatenate((np.linspace(start=-1, stop=5, num=15), np.linspace(start=1, stop=-1, num=15))),
})

common_scale = (df[['x', 'y']].min().min(), df[['x', 'y']].max().max())

scatter = jscatter.Scatter(
    data=df,
    x="x",
    y="y",
    x_scale=common_scale,
    y_scale=common_scale,
    tooltip=True,
    tooltip_histograms_bins={"x": 15, "y": 15}
)
scatter.show()
```

https://github.com/flekschas/jupyter-scatter/assets/932103/478c11b4-4894-4ca2-90f1-035a1188d807

The below demo shows how the x axis now re-renders properly upon resizing the window. You can also see how the y axis is rendered at the appropriate scale domain (`[-10, 10]`) instead of the data domain (`[-1, 5]`).

## Checklist

- [x] Provided a concise title as a [semantic commit message](https://www.conventionalcommits.org) (e.g. "fix: correctly handle undefined properties")
- [x] `CHANGELOG.md` updated
- [ ] Tests added or updated
- [ ] Documentation in `API.md`/`README.md` added or updated
- [ ] Example(s) added or updated
- [x] Screenshot, gif, or video attached for visual changes
