### PR TITLE
fix: Remove JupyterScatter.hovering_widget

### DIFF
--- a/jscatter/widget.py
+++ b/jscatter/widget.py
@@ -283,21 +283,6 @@ class JupyterScatter(anywidget.AnyWidget):
         return with_left_label('Selected points', widget)
 
     @property
-    def hovering_widget(self):
-        widget = widgets.Text(
-            value=f'{self.hovered_point}',
-            placeholder='The index of the hovered point will be shown here',
-            disabled=True
-        )
-
-        def change_handler(change):
-            widget.value = f'{change.new}'
-
-        self.observe(change_handler, names='hovered_point')
-
-        return with_left_label('Hovered point', widget)
-
-    @property
     def color_widgets(self):
         color_by_widget = widgets.RadioButtons(
             options=[


### PR DESCRIPTION
> Write one to two sentences summarizing this PR

Removes `JupyterScatter.hovering_widget`. The `JupyterScatter.hovered_point`
property is not defined anywhere on the widget. I believe this traitlet was
likely added at some time but was removed, and this bug hasn't popped up due to
lack of accessing this field from others.

A recent release of `anywidget` inspects the fields on the widget class within
`__init__`, which invokes the `@property` decorator on the `hovering_widget`.
This led to an attribute error.

## Description

> What was changed in this pull request?

> Why is it necessary?

Fixes #115

## Checklist

- [ ] Provided a concise title as a [semantic commit message](https://www.conventionalcommits.org) (e.g. "fix: correctly handle undefined properties")
- [ ] `CHANGELOG.md` updated
- [ ] Tests added or updated
- [ ] Documentation in `API.md`/`README.md` added or updated
- [ ] Example(s) added or updated
- [ ] Screenshot, gif, or video attached for visual changes
