### PR TITLE
fix: tooltip typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ Additionally, the following helper methods are removed as they are unnecessary.
 ## v0.15.0
 
 - Feat: Add support for histograms in the tooltip ([#96](https://github.com/flekschas/jupyter-scatter/pull/96))
-- Feat: Add support for non-visualized properties in the toolip ([#96](https://github.com/flekschas/jupyter-scatter/pull/96))
+- Feat: Add support for non-visualized properties in the tooltip ([#96](https://github.com/flekschas/jupyter-scatter/pull/96))
 - Fix: Allow mixing custom and DataFrame-based data ([#89](https://github.com/flekschas/jupyter-scatter/issues/89))
 - Fix: Improve the tooltip positioning to avoid the tooltip being cut off unnecessarily
 - Fix: Properly redraw axes on resize ([#108](https://github.com/flekschas/jupyter-scatter/issues/108))

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -71,7 +71,7 @@ export default defineConfig({
           { text: 'Selections', link: '/selections' },
           { text: 'Link Multiple Scatter Plots', link: '/link-multiple-plots' },
           { text: 'Axes & Legends', link: '/axes-legends' },
-          { text: 'Toolip', link: '/tooltip' }
+          { text: 'Tooltip', link: '/tooltip' }
         ]
       },
       // {

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -1525,7 +1525,7 @@ class JupyterScatterView {
     this.tooltip.style.opacity = 1;
   }
 
-  hideToolip() {
+  hideTooltip() {
     this.tooltipPointIdx = undefined;
     this.tooltip.style.opacity = 0;
     if (this.tooltipPreviewValue.nodeName === 'AUDIO') {
@@ -1535,7 +1535,7 @@ class JupyterScatterView {
   }
 
   tooltipEnableHandler(tooltip) {
-    if (!tooltip) this.hideToolip;
+    if (!tooltip) this.hideTooltip;
   }
 
   tooltipSizeHandler(newSize) {
@@ -1738,7 +1738,7 @@ class JupyterScatterView {
   pointoutHandler() {
     this.hoveringChangedByJs = true;
     this.showTooltipDebounced.cancel();
-    this.hideToolip();
+    this.hideTooltip();
     this.model.set('hovering', null);
     this.model.save_changes();
   }


### PR DESCRIPTION
> Write one to two sentences summarizing this PR

Fixes a common typo of Tooltip (Toolip), which is for example in the docs.
