### PR TITLE
fix: reset scale & norm ranges in `scatter.data()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.16.1
+
+- Fix: reset scale & norm ranges upon updating the data via `scatter.data()`
+
 ## v0.16.0
 
 **BREAKING CHANGES**:

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -22,7 +22,7 @@
         "gl-matrix": "~3.3.0",
         "pub-sub-es": "~3.0.0",
         "regl": "~2.1.0",
-        "regl-scatterplot": "~1.9.4"
+        "regl-scatterplot": "~1.9.6"
       },
       "devDependencies": {
         "esbuild": "^0.19.5",
@@ -2348,9 +2348,9 @@
       }
     },
     "node_modules/regl-scatterplot": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/regl-scatterplot/-/regl-scatterplot-1.9.4.tgz",
-      "integrity": "sha512-hS/NtmYcJfCJxYBr9w9tHM0j4OTVKRZMwSxajz0T/kTWusOqC6VN5Uo64t6ZvwnymXJbBQTwhDC+9gTVwww2KA==",
+      "version": "1.9.6",
+      "resolved": "https://registry.npmjs.org/regl-scatterplot/-/regl-scatterplot-1.9.6.tgz",
+      "integrity": "sha512-hvroIbBmvLkPoTRgX99DKc3eg2Q6Ex7BwMb6Ih16wfBdJ651NQKu4n6TC/USUc+m89MjBZuA2csySi0Q8z/T3w==",
       "dependencies": {
         "@flekschas/utils": "^0.31.0",
         "dom-2d-camera": "~2.2.5",

--- a/js/package.json
+++ b/js/package.json
@@ -30,7 +30,7 @@
     "gl-matrix": "~3.3.0",
     "pub-sub-es": "~3.0.0",
     "regl": "~2.1.0",
-    "regl-scatterplot": "~1.9.4"
+    "regl-scatterplot": "~1.9.6"
   },
   "devDependencies": {
     "esbuild": "^0.19.5",

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -2397,7 +2397,7 @@ function modelWithSerializers(model, serializers) {
   }
 }
 
-export async function render({ model, el }) {
+async function render({ model, el }) {
   const view = new JupyterScatterView({
     el: el,
     model: modelWithSerializers(model, {
@@ -2411,3 +2411,5 @@ export async function render({ model, el }) {
   view.render();
   return () => view.destroy();
 }
+
+export default { render };

--- a/jscatter/jscatter.py
+++ b/jscatter/jscatter.py
@@ -504,6 +504,24 @@ class Scatter():
 
             self._points = np.zeros((self._n, 6))
 
+            # Reset scale & norm ranges
+            self._x_scale.vmin = None
+            self._x_scale.vmax = None
+            self._y_scale.vmin = None
+            self._y_scale.vmax = None
+            self._color_norm.vmin = None
+            self._color_norm.vmax = None
+            self._opacity_norm.vmin = None
+            self._opacity_norm.vmax = None
+            self._size_norm.vmin = None
+            self._size_norm.vmax = None
+            self._connection_color_norm.vmin = None
+            self._connection_color_norm.vmax = None
+            self._connection_opacity_norm.vmin = None
+            self._connection_opacity_norm.vmax = None
+            self._connection_size_norm.vmin = None
+            self._connection_size_norm.vmax = None
+
             self.x(skip_widget_update=True, **self.x())
             self.y(skip_widget_update=True, **self.y())
             self.color(skip_widget_update=True, **self.color())

--- a/jscatter/jscatter.py
+++ b/jscatter/jscatter.py
@@ -535,6 +535,10 @@ class Scatter():
             if 'skip_widget_update' not in kwargs:
                 self.update_widget('prevent_filter_reset', False)
                 self.update_widget('points', self.get_point_list())
+                self.update_widget('x_domain', self._x_domain)
+                self.update_widget('x_scale_domain', self._x_scale_domain)
+                self.update_widget('y_domain', self._y_domain)
+                self.update_widget('y_scale_domain', self._y_scale_domain)
 
         if use_index is not UNDEF:
             self._data_use_index = use_index
@@ -622,7 +626,8 @@ class Scatter():
                 self._x_by = 'Custom X Data'
 
         if x is not UNDEF or scale is not UNDEF:
-            self.update_widget('prevent_filter_reset', True)
+            if 'skip_widget_update' not in kwargs:
+                self.update_widget('prevent_filter_reset', True)
             self._points[:, 0] = zerofy_missing_values(self.x_data.values, 'X')
 
             self._x_min = np.min(self._points[:, 0])

--- a/jscatter/utils.py
+++ b/jscatter/utils.py
@@ -56,8 +56,8 @@ class TimeNormalize(Normalize):
 
 def create_default_norm(is_time=False):
     if is_time:
-        return TimeNormalize(clip=True)
-    return Normalize(clip=True)
+        return TimeNormalize()
+    return Normalize()
 
 def to_ndc(X, norm):
     return (norm(X).data * 2) - 1

--- a/jscatter/widget.py
+++ b/jscatter/widget.py
@@ -384,7 +384,7 @@ class JupyterScatter(anywidget.AnyWidget):
 
 class Button(anywidget.AnyWidget):
     _esm = """
-    export function render({ model, el }) {
+    function render({ model, el }) {
       const button = document.createElement('button');
 
       button.classList.add('jupyter-widgets');
@@ -446,6 +446,7 @@ class Button(anywidget.AnyWidget):
         button.removeEventListener('dblclick', dblclickHandler);
       };
     }
+    export default { render }
     """
 
     description = Unicode().tag(sync=True)

--- a/jscatter/widget.py
+++ b/jscatter/widget.py
@@ -13,7 +13,7 @@ from traittypes import Array
 from .utils import to_hex, with_left_label
 
 SELECTION_DTYPE = 'uint32'
-EVENTS = {
+EVENT_TYPES = {
     "TOOLTIP": "tooltip",
     "VIEW_RESET": "view_reset",
 }
@@ -60,6 +60,7 @@ class JupyterScatter(anywidget.AnyWidget):
 
     # Data
     points = Array(default_value=None).tag(sync=True, **ndarray_serialization)
+    transition_points = Bool(False).tag(sync=True)
     prevent_filter_reset = Bool(False).tag(sync=True)
     selection = Array(default_value=None, allow_none=True).tag(sync=True, **ndarray_serialization)
     filter = Array(default_value=None, allow_none=True).tag(sync=True, **ndarray_serialization)
@@ -223,7 +224,7 @@ class JupyterScatter(anywidget.AnyWidget):
     # For synchronyzing view changes across scatter plot instances
     view_sync = Unicode(None, allow_none=True).tag(sync=True)
 
-    events = Dict(EVENTS, read_only=True).tag(sync=True)
+    event_types = Dict(EVENT_TYPES, read_only=True).tag(sync=True)
 
     def __init__(self, data, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -232,10 +233,10 @@ class JupyterScatter(anywidget.AnyWidget):
         self.on_msg(self._handle_custom_msg)
 
     def _handle_custom_msg(self, event: dict, buffers):
-        if event["type"] == EVENTS["TOOLTIP"] and isinstance(self.data, pd.DataFrame):
+        if event["type"] == EVENT_TYPES["TOOLTIP"] and isinstance(self.data, pd.DataFrame):
             data = self.data.iloc[event["index"]]
             self.send({
-                "type": EVENTS["TOOLTIP"],
+                "type": EVENT_TYPES["TOOLTIP"],
                 "index": event["index"],
                 "preview": data[event["preview"]] if event["preview"] is not None else None,
                 "properties": data[event["properties"]].to_dict()
@@ -271,28 +272,33 @@ class JupyterScatter(anywidget.AnyWidget):
         button.on_click(click_handler)
         return button
 
-    def reset_view(self):
-        self.send({
-            "type": EVENTS["VIEW_RESET"],
-            "data_extent": {
-                "x": self.points[:, 0].min(),
-                "width": self.points[:, 0].max() - self.points[:, 0].min(),
-                "y": self.points[:, 1].min(),
-                "height": self.points[:, 1].max() - self.points[:, 1].min(),
-            }
-        })
+    def reset_view(self, animation: int = 0, data_extent: bool = False):
+        if data_extent:
+            self.send({
+                "type": EVENT_TYPES["VIEW_RESET"],
+                "area": {
+                    "x": self.points[:, 0].min(),
+                    "width": self.points[:, 0].max() - self.points[:, 0].min(),
+                    "y": self.points[:, 1].min(),
+                    "height": self.points[:, 1].max() - self.points[:, 1].min(),
+                },
+                "animation": animation
+            })
+        else:
+            self.send({
+                "type": EVENT_TYPES["VIEW_RESET"],
+                "animation": animation
+            })
 
     def create_reset_view_button(self, icon_only=False, width=None):
-        button = widgets.Button(
+        button = Button(
             description='' if icon_only else 'Reset View',
-            icon='refresh'
+            icon='refresh',
+            width=width,
         )
 
-        if width is not None:
-            button.layout.width = f'{width}px'
-
-        def click_handler(b):
-            self.reset_view()
+        def click_handler(event):
+            self.reset_view(500, event["alt_key"])
 
         button.on_click(click_handler)
         return button
@@ -375,3 +381,90 @@ class JupyterScatter(anywidget.AnyWidget):
         )
 
         return widgets.HBox([buttons, plots])
+
+class Button(anywidget.AnyWidget):
+    _esm = """
+    export function render({ model, el }) {
+      const button = document.createElement('button');
+
+      button.classList.add('jupyter-widgets');
+      button.classList.add('jupyter-button');
+      button.classList.add('widget-button');
+
+      const update = () => {
+        const description = model.get('description');
+        const icon = model.get('icon');
+        const width = model.get('width');
+
+        button.textContent = '';
+
+        if (icon) {
+          const i = document.createElement('i');
+          i.classList.add('fa', `fa-${icon}`);
+
+          if (!description) {
+            i.classList.add('center');
+          }
+
+          button.appendChild(i);
+        }
+
+        if (description) {
+          button.appendChild(document.createTextNode(description));
+        }
+
+        if (width) {
+          button.style.width = `${width}px`;
+        }
+      }
+
+      const createEventHandler = (eventType) => (event) => {
+        model.send({
+          type: eventType,
+          alt_key: event.altKey,
+          shift_key: event.shiftKey,
+          meta_key: event.metaKey,
+        });
+      }
+
+      const clickHandler = createEventHandler('click');
+      const dblclickHandler = createEventHandler('dblclick');
+
+      button.addEventListener('click', clickHandler);
+      button.addEventListener('dblclick', dblclickHandler);
+
+      model.on('change:description', update);
+      model.on('change:icon', update);
+      model.on('change:width', update);
+
+      update();
+
+      el.appendChild(button);
+
+      return () => {
+        button.removeEventListener('click', clickHandler);
+        button.removeEventListener('dblclick', dblclickHandler);
+      };
+    }
+    """
+
+    description = Unicode().tag(sync=True)
+    icon = Unicode().tag(sync=True)
+    width = Int(allow_none=True).tag(sync=True)
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._click_handler = None
+        self.on_msg(self._handle_custom_msg)
+
+    def _handle_custom_msg(self, event: dict, buffers):
+        if event["type"] == "click" and self._click_handler is not None:
+            self._click_handler(event)
+        if event["type"] == "dblclick" and self._dblclick_handler is not None:
+            self._dblclick_handler(event)
+
+    def on_click(self, callback):
+        self._click_handler = callback
+
+    def on_dblclick(self, callback):
+        self._dblclick_handler = callback

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ keywords = [
     "widgets",
 ]
 dependencies = [
-    "anywidget>=0.2.0",
+    "anywidget>=0.9.0",
     "ipywidgets>=7.6,<9",
     "ipython",
     "matplotlib",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,11 +15,11 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
     "Topic :: Multimedia :: Graphics",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 keywords = [
     "scatter",
@@ -81,7 +81,7 @@ path = "js"
 
 [tool.hatch.envs.default]
 features = ["dev"]
-python = "3.11"
+python = "3.12"
 
 [tool.hatch.envs.default.scripts]
 test = "pytest ."

--- a/tests/test_jscatter.py
+++ b/tests/test_jscatter.py
@@ -95,15 +95,21 @@ def test_scatter_pandas(df):
 
 
 def test_scatter_pandas_update(df, df2):
-    scatter = Scatter(data=df, x='a', y='b')
+    x = 'a'
+    y = 'b'
+    scatter = Scatter(data=df, x=x, y=y)
+    assert np.allclose(np.array([df[x].min(), df[x].max()]), np.array(scatter._x_scale_domain))
+    assert np.allclose(np.array([df[y].min(), df[y].max()]), np.array(scatter._y_scale_domain))
+
     scatter.data(df2)
-    widget_data = np.asarray(scatter.widget.points)
+    assert np.allclose(np.array([df2[x].min(), df2[x].max()]), np.array(scatter._x_scale_domain))
+    assert np.allclose(np.array([df2[y].min(), df2[y].max()]), np.array(scatter._y_scale_domain))
 
-    assert df['a'].max() != df2['a'].max()
-    assert df['b'].max() != df2['b'].max()
+    assert df[x].max() != df2[x].max()
+    assert df[y].max() != df2[y].max()
 
-    assert np.allclose(to_ndc(df2['a'].values, create_default_norm()), widget_data[:, 0])
-    assert np.allclose(to_ndc(df2['b'].values, create_default_norm()), widget_data[:, 1])
+    assert np.allclose(to_ndc(df2[x].values, create_default_norm()), scatter.widget.points[:, 0])
+    assert np.allclose(to_ndc(df2[y].values, create_default_norm()), scatter.widget.points[:, 1])
 
 
 def test_xy_scale_shorthands(df):

--- a/tests/test_jscatter.py
+++ b/tests/test_jscatter.py
@@ -98,12 +98,16 @@ def test_scatter_pandas_update(df, df2):
     x = 'a'
     y = 'b'
     scatter = Scatter(data=df, x=x, y=y)
-    assert np.allclose(np.array([df[x].min(), df[x].max()]), np.array(scatter._x_scale_domain))
-    assert np.allclose(np.array([df[y].min(), df[y].max()]), np.array(scatter._y_scale_domain))
+    assert np.allclose(np.array([df[x].min(), df[x].max()]), np.array(scatter.widget.x_domain))
+    assert np.allclose(np.array([df[y].min(), df[y].max()]), np.array(scatter.widget.y_domain))
+    assert np.allclose(np.array([df[x].min(), df[x].max()]), np.array(scatter.widget.x_scale_domain))
+    assert np.allclose(np.array([df[y].min(), df[y].max()]), np.array(scatter.widget.y_scale_domain))
 
     scatter.data(df2)
-    assert np.allclose(np.array([df2[x].min(), df2[x].max()]), np.array(scatter._x_scale_domain))
-    assert np.allclose(np.array([df2[y].min(), df2[y].max()]), np.array(scatter._y_scale_domain))
+    assert np.allclose(np.array([df2[x].min(), df2[x].max()]), np.array(scatter.widget.x_domain))
+    assert np.allclose(np.array([df2[y].min(), df2[y].max()]), np.array(scatter.widget.y_domain))
+    assert np.allclose(np.array([df2[x].min(), df2[x].max()]), np.array(scatter.widget.x_scale_domain))
+    assert np.allclose(np.array([df2[y].min(), df2[y].max()]), np.array(scatter.widget.y_scale_domain))
 
     assert df[x].max() != df2[x].max()
     assert df[y].max() != df2[y].max()

--- a/tests/test_jscatter.py
+++ b/tests/test_jscatter.py
@@ -117,7 +117,7 @@ def test_scatter_pandas_update(df, df2):
     assert np.allclose(prev_y_scale_domain, np.array(scatter.widget.y_scale_domain))
 
     scatter.data(df)
-    scatter.data(df2, reset_view=True)
+    scatter.data(df2, reset_scales=True)
 
     # Now that we reset the view, both the data and scale domain updated properly
     assert np.allclose(np.array([df2[x].min(), df2[x].max()]), np.array(scatter.widget.x_domain))


### PR DESCRIPTION
Reset scale and norm ranges upon updating the associated dataframe.

## Description

> What was changed in this pull request?

Upon updating the referenced dataframe, all scale and norm ranges are reset such that they get re-computed with the new data.

E.g., first run

```py
import jscatter
import numpy as np
import pandas as pd

data1 = pd.DataFrame({
    "x": np.random.rand(1000),
    "y": np.random.rand(1000),
})
data2 = pd.DataFrame({
    "x": 2*np.random.rand(1000),
    "y": 2*np.random.rand(1000),
})
scatter = jscatter.Scatter(data=data1, x="x", y="y", width=500, height=500)
scatter.show()
```

Then

```py
scatter.data(data2)
```

https://github.com/flekschas/jupyter-scatter/assets/932103/f8878787-aa17-46d4-8607-ad625cc86024


> Why is it necessary?

Fixes #131 

## Checklist

- [x] Provided a concise title as a [semantic commit message](https://www.conventionalcommits.org) (e.g. "fix: correctly handle undefined properties")
- [x] `CHANGELOG.md` updated
- [x] Tests added or updated
- [ ] Documentation in `API.md`/`README.md` added or updated
- [ ] Example(s) added or updated
- [x] Screenshot, gif, or video attached for visual changes
