### PR TITLE
feat: add `scatter.show_tooltip()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.17.0
+
+- Feat: Add `scatter.show_tooltip(point_idx)`
+
 ## v0.16.0
 
 **BREAKING CHANGES**:

--- a/docs/api.md
+++ b/docs/api.md
@@ -6,7 +6,8 @@
     - [selection()](#scatter.selection) and [filter()](#scatter.filter)
     - [color()](#scatter.color), [opacity()](#scatter.opacity), and [size()](#scatter.size)
     - [connect()](#scatter.connect), [connection_color()](#scatter.connection_color), [connection_opacity()](#scatter.connection_opacity), and [connection_size()](#scatter.connection_size)
-    - [axes()](#scatter.axes), [legend()](#scatter.legend), and [tooltip()](#scatter.tooltip)
+    - [axes()](#scatter.axes) and [legend()](#scatter.legend)
+    - [tooltip()](#scatter.tooltip) and [show_tooltip()](#scatter.show_tooltip)
     - [zoom()](#scatter.zoom) and [camera()](#scatter.camera)
     - [lasso()](#scatter.lasso), [reticle()](#scatter.reticle), and [mouse()](#scatter.mouse),
     - [background()](#scatter.background) and [options()](#scatter.options)
@@ -421,6 +422,30 @@ scatter.tooltip(
   preview_image_size="cover",
   size="small",
 )
+```
+
+
+### scatter.show_tooltip(_point_idx_) {#scatter.show_tooltip}
+
+Programmatically show a tooltip for a point.
+
+::: info
+The tooltip is not permanent and will go away as soon as you mouse over some
+other points in the plot.
+:::
+
+::: warning
+If the widget has not been instantiated yet or the tooltip has not been
+activated via `scatter.tooltip(True)`, this method is a noop.
+:::
+
+**Arguments:**
+- `point_idx` is a point index.
+
+**Example:**
+
+```python
+scatter.show_tooltip(42)
 ```
 
 

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -386,8 +386,9 @@ class JupyterScatterView {
 
   customEventHandler(event) {
     if (event.type === TOOLTIP_EVENT_TYPE) {
-      if (event.index !== this.tooltipPointIdx) return;
+      if (event.index !== this.tooltipPointIdx && event.show !== true) return;
       this.tooltipDataHandlers(event)
+      if (event.show) this.showTooltip(event.index);
     }
   }
 

--- a/jscatter/jscatter.py
+++ b/jscatter/jscatter.py
@@ -4025,6 +4025,28 @@ class Scatter():
         """
         return self.widget.show()
 
+    def show_tooltip(self, pointIdx: int):
+        """
+        Programmatically show the tooltip for a point.
+
+        If the widget has not been instantiated yet or the tooltip is not
+        activated, this method is a noop.
+
+        Returns
+        -------
+        self
+            The Scatter instance itself is returned.
+
+        Examples
+        --------
+        >>> scatter.show_tooltip(42)
+        """
+
+        if self._widget is not None and self._tooltip == True:
+            self._widget.show_tooltip(pointIdx)
+
+        return self
+
 
 def plot(
     x: Union[str, List[float], np.ndarray],

--- a/jscatter/widget.py
+++ b/jscatter/widget.py
@@ -237,6 +237,16 @@ class JupyterScatter(anywidget.AnyWidget):
                 "properties": data[event["properties"]].to_dict()
             })
 
+    def show_tooltip(self, point_idx):
+        data = self.data.iloc[point_idx]
+        self.send({
+            "type": TOOLTIP_EVENT_TYPE,
+            "show": True,
+            "index": point_idx,
+            "preview": data[self.tooltip_preview] if self.tooltip_preview is not None else None,
+            "properties": data[self.tooltip_properties_non_visual_info.keys()].to_dict() if self.tooltip_properties_non_visual_info is not None else {}
+        })
+
     def create_download_view_button(self, icon_only=False, width=None):
         button = widgets.Button(
             description='' if icon_only else 'Download View',

--- a/paper/examples.ipynb
+++ b/paper/examples.ipynb
@@ -1,0 +1,629 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "ec73f233-b8a4-4af9-a564-02ad7df8192c",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# Examples\n",
+    "\n",
+    "This notebook allows to recreate the figures presented in the usage scenario section."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4e6ee199-139a-48e8-b533-5414c421a57c",
+   "metadata": {},
+   "source": [
+    "## Teaser"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d9f882f3-657c-4075-a193-bbb5f35053f8",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Market Capitelization\n",
+    "\n",
+    "Source: https://ycharts.com (Retrieved June 2, 2024)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "2f9b91ce-0980-45fb-8359-b1112e320162",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Symbol</th>\n",
+       "      <th>Name</th>\n",
+       "      <th>Sector</th>\n",
+       "      <th>Industry</th>\n",
+       "      <th>Date</th>\n",
+       "      <th>Market Capitalization</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>MSFT</td>\n",
+       "      <td>Microsoft Corporation</td>\n",
+       "      <td>Technology</td>\n",
+       "      <td>Software - Infrastructure</td>\n",
+       "      <td>1559260800000</td>\n",
+       "      <td>947737317</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>MSFT</td>\n",
+       "      <td>Microsoft Corporation</td>\n",
+       "      <td>Technology</td>\n",
+       "      <td>Software - Infrastructure</td>\n",
+       "      <td>1559520000000</td>\n",
+       "      <td>918312097</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  Symbol                   Name      Sector                   Industry   \n",
+       "0   MSFT  Microsoft Corporation  Technology  Software - Infrastructure  \\\n",
+       "1   MSFT  Microsoft Corporation  Technology  Software - Infrastructure   \n",
+       "\n",
+       "            Date  Market Capitalization  \n",
+       "0  1559260800000              947737317  \n",
+       "1  1559520000000              918312097  "
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import pandas as pd\n",
+    "market_cap = pd.read_parquet('https://paper.jupyter-scatter.dev/market-capitalization.pq')\n",
+    "market_cap.head(2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "id": "e522f6ca-6d55-4f30-9816-f61f50d843ca",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6c1c807fdc6d48fd9d8437915e3e2704",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(VBox(children=(Button(button_style='primary', icon='arrows', layout=Layout(width='36px'), style…"
+      ]
+     },
+     "execution_count": 39,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import jscatter\n",
+    "\n",
+    "scatter = jscatter.Scatter(data=market_cap, x='Date', x_scale='time', y='Market Capitalization')\n",
+    "scatter.axes(grid=True)\n",
+    "scatter.legend(True)\n",
+    "scatter.color(by='Sector')\n",
+    "scatter.connect(by='Symbol')\n",
+    "scatter.connection_color('inherit')\n",
+    "scatter.connection_size(3)\n",
+    "scatter.connection_opacity(0.5)\n",
+    "scatter.tooltip(True, preview='Name', properties=['x', 'y', 'color', 'Industry'])\n",
+    "scatter.width(640)\n",
+    "scatter.height(640)\n",
+    "scatter.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eeb98f98-368b-4c6d-86ee-194ad1945061",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "373a0c18-b8d1-46c5-bc7a-8e7fcaa3ade1",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "43e1b780-3318-4224-8847-17aae9b1120c",
+   "metadata": {},
+   "source": [
+    "## GeoNames City Dataset\n",
+    "\n",
+    "Source: https://geonames.org (Retrieved May 1, 2024)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "9124535f-2aba-44c3-9d8b-3337e4585ef6",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Name</th>\n",
+       "      <th>Longitude</th>\n",
+       "      <th>Latitude</th>\n",
+       "      <th>Mercator X</th>\n",
+       "      <th>Mercator Y</th>\n",
+       "      <th>Population</th>\n",
+       "      <th>Continent</th>\n",
+       "      <th>Country</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Powidz</td>\n",
+       "      <td>17.91926</td>\n",
+       "      <td>52.41362</td>\n",
+       "      <td>1994762.875</td>\n",
+       "      <td>6875261.5</td>\n",
+       "      <td>1000</td>\n",
+       "      <td>Europe</td>\n",
+       "      <td>Poland</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Janowiec</td>\n",
+       "      <td>21.88940</td>\n",
+       "      <td>51.32359</td>\n",
+       "      <td>2436716.750</td>\n",
+       "      <td>6678734.0</td>\n",
+       "      <td>1000</td>\n",
+       "      <td>Europe</td>\n",
+       "      <td>Poland</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "       Name  Longitude  Latitude   Mercator X  Mercator Y  Population   \n",
+       "0    Powidz   17.91926  52.41362  1994762.875   6875261.5        1000  \\\n",
+       "1  Janowiec   21.88940  51.32359  2436716.750   6678734.0        1000   \n",
+       "\n",
+       "  Continent Country  \n",
+       "0    Europe  Poland  \n",
+       "1    Europe  Poland  "
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import pandas as pd\n",
+    "geonames = pd.read_parquet('https://paper.jupyter-scatter.dev/geonames.pq')\n",
+    "geonames.head(2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "d7bf9605-1a0c-4341-8630-91c611e0c024",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8046c0cb9e4c472f9db0aa78ef6e51a5",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(VBox(children=(Button(button_style='primary', icon='arrows', layout=Layout(width='36px'), style…"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import jscatter\n",
+    "\n",
+    "scatter = jscatter.Scatter(\n",
+    "    data=geonames,\n",
+    "    x='Longitude',\n",
+    "    y='Latitude',\n",
+    "    color_by='Continent',\n",
+    "    width=800,\n",
+    "    height=800\n",
+    ")\n",
+    "scatter.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "000dd0f7-6cd8-4abb-8759-c82048037d54",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<jscatter.jscatter.Scatter at 0x14f92ce50>"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from matplotlib.colors import AsinhNorm, LogNorm\n",
+    "\n",
+    "scatter.opacity(0.5)\n",
+    "scatter.size(by='Population', map=(1, 8, 10), norm=AsinhNorm())\n",
+    "scatter.color(by='Population', map='magma', norm=LogNorm(), order='reverse')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "dc73e4ce-b063-46d9-bfc6-81b504cf9675",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<jscatter.jscatter.Scatter at 0x14f92ce50>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "scatter.legend(True)\n",
+    "scatter.axes(True, labels=True)\n",
+    "scatter.tooltip(True, properties=['color', 'Latitude', 'Country'], preview='Name')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "749b61c2-bc79-42ae-8772-efbb2cbbfff7",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "scatter.widget.show_tooltip(114395)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a5380bed-51ed-4b33-aed7-fae1bd4e808f",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "scatter.xy(x='Mercator X', y='Mercator Y')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "945c66e5-4ad1-4bb1-94fc-f1326155b5e0",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<jscatter.jscatter.Scatter at 0x14f92ce50>"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "scatter.selection(geonames.query('Population > 10_000_000').index)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aee62f63-b9de-4ec6-93e4-5c399b6c54c4",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "geonames.iloc[scatter.selection()]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c2748d59-106c-43bb-a7cb-fc3cc8a0a474",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Fashion MNIST Embeddings\n",
+    "\n",
+    "Source: Fashion-MNIST: a Novel Image Dataset for Benchmarking Machine Learning Algorithms. Han Xiao, Kashif Rasul, Roland Vollgraf. [doi:10.48550/arXiv.1708.07747](https://doi.org/10.48550/arXiv.1708.07747)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "0009c368-933b-4dcb-9e32-d35a5a596e53",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "fashion_mnist = pd.read_parquet('https://paper.jupyter-scatter.dev/fashion-mnist-embeddings.pq')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "a16e1edd-1408-422b-aeb5-1ba0912f613d",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import anywidget\n",
+    "import traitlets\n",
+    "import traittypes\n",
+    "\n",
+    "class ImagesWidget(anywidget.AnyWidget):\n",
+    "    _esm = \"\"\"\n",
+    "    const baseUrl = 'https://paper.jupyter-scatter.dev/fashion-mnist-images/';\n",
+    "    export function render({ model, el }) {\n",
+    "      const container = document.createElement('div');\n",
+    "      container.classList.add('images-container');\n",
+    "      el.appendChild(container);\n",
+    "\n",
+    "      const grid = document.createElement('div');\n",
+    "      grid.classList.add('images-grid');\n",
+    "      container.appendChild(grid);\n",
+    "\n",
+    "      function renderImages() {\n",
+    "        grid.textContent = '';\n",
+    "        \n",
+    "        model.get('images').forEach((image) => {\n",
+    "          const imgId = String(image).padStart(5, '0');\n",
+    "        \n",
+    "          const img = document.createElement('div');\n",
+    "          img.classList.add('images-fashion-mnist');\n",
+    "          img.style.backgroundImage = `url(${baseUrl}${imgId}.png)`;\n",
+    "        \n",
+    "          grid.appendChild(img);\n",
+    "        });\n",
+    "      }\n",
+    "\n",
+    "      model.on(\"change:images\", renderImages);\n",
+    "      \n",
+    "      renderImages();\n",
+    "    }\n",
+    "    \"\"\"\n",
+    "\n",
+    "    _css = \"\"\"\n",
+    "    .images-container {\n",
+    "      position: absolute;\n",
+    "      inset: 0;\n",
+    "      overflow: auto;\n",
+    "      background: black;\n",
+    "    }\n",
+    "    \n",
+    "    .images-grid {\n",
+    "      display: grid;\n",
+    "      grid-template-columns: repeat(auto-fit, minmax(32px, 1fr));\n",
+    "      align-content: flex-start;\n",
+    "      gap: 8px;\n",
+    "    }\n",
+    "    \n",
+    "    .images-fashion-mnist {\n",
+    "      width: 32px;\n",
+    "      height: 32px;\n",
+    "      background-repeat: no-repeat;\n",
+    "      background-position: center;\n",
+    "    }\n",
+    "    \"\"\"\n",
+    "\n",
+    "    images = traittypes.Array(default_value=[]).tag(sync=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "07c93134-e1fe-4073-99c3-01c4a85ed17c",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0f6d38f7f3254a808fb40c1d31bd03ee",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "AppLayout(children=(ImagesWidget(layout=Layout(grid_area='right-sidebar')), HBox(children=(VBox(children=(Butt…"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import ipywidgets\n",
+    "import jscatter\n",
+    "\n",
+    "images = ImagesWidget()\n",
+    "\n",
+    "scatter = jscatter.Scatter(\n",
+    "    data=fashion_mnist,\n",
+    "    x='umapX',\n",
+    "    y='umapY',\n",
+    "    color_by='class',\n",
+    "    background_color='black',\n",
+    "    axes=False,\n",
+    "    width=800,\n",
+    "    height=800\n",
+    ")\n",
+    "\n",
+    "ipywidgets.link((scatter.widget, 'selection'), (images, 'images'))\n",
+    "\n",
+    "ipywidgets.AppLayout(center=scatter.show(), right_sidebar=images)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "666e30f7-f6f2-4153-a0fd-a21c558be727",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f44a01cba7c54da6bf42f76f8aa6d4ec",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "GridBox(children=(VBox(children=(HTML(value='<b style=\"display: flex; justify-content: center; margin: 0 0 0 3…"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "config = dict(\n",
+    "    data=fashion_mnist,\n",
+    "    background_color='black',\n",
+    "    color_by='class',\n",
+    "    legend=True,\n",
+    "    axes=False,\n",
+    "    zoom_on_selection=True,\n",
+    ")\n",
+    "\n",
+    "pca = jscatter.Scatter(x='pcaX', y='pcaY', **config)\n",
+    "tsne = jscatter.Scatter(x='tsneX', y='tsneY', **config)\n",
+    "umap = jscatter.Scatter(x='umapX', y='umapY', **config)\n",
+    "cae = jscatter.Scatter(x='caeX', y='caeY', **config)\n",
+    "\n",
+    "jscatter.compose(\n",
+    "    [(pca, \"PCA\"), (tsne, \"t-SNE\"), (umap, \"UMAP\"), (cae, \"CAE\")],\n",
+    "    sync_selection=True,\n",
+    "    sync_hover=True,\n",
+    "    rows=2,\n",
+    "    row_height=400,\n",
+    ")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
I added a function for programmatically showing the tooltip via `scatter.show_tooltip()`

## Description

> What was changed in this pull request?

Added `scatter.show_tooltip(point_index)`. Note that this function only shows a tooltip if the tooltip was activated via `scatter.tooltip(True)`.

> Why is it necessary?

Programmatically showing the tooltip can help guide the user to locate a specific point.

## Checklist

- [x] Provided a concise title as a [semantic commit message](https://www.conventionalcommits.org) (e.g. "fix: correctly handle undefined properties")
- [x] `CHANGELOG.md` updated
- [ ] Tests added or updated
- [x] Documentation in `API.md`/`README.md` added or updated
- [ ] Example(s) added or updated
- [ ] Screenshot, gif, or video attached for visual changes
