### PR TITLE
fix: `scatter.axes(labels=['x_label', 'y_label'])`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v0.16.2
 
 - Fix: reset scale & norm ranges upon updating the data via `scatter.data()`
+- Fix: ensure `scatter.axes(labels=['x_label', 'y_label'])` works properly ([#137](https://github.com/flekschas/jupyter-scatter/issues/137]))
 
 ## v0.16.1
 

--- a/jscatter/jscatter.py
+++ b/jscatter/jscatter.py
@@ -4049,15 +4049,13 @@ class Scatter():
         return get_histogram_range(self._tooltip_histograms_ranges, property)
 
     def get_axes_labels(self):
-        if self._axes_labels == False:
-            return self._axes_labels
-        elif self._axes_labels == True:
+        if self._axes_labels == True:
             if self._data is None:
                 return ['x', 'y']
             else:
                 return [self._x_by, self._y_by]
-        else:
-            self._axes_labels = labels
+
+        return self._axes_labels
 
     def show(self):
         """

--- a/tests/test_jscatter.py
+++ b/tests/test_jscatter.py
@@ -309,3 +309,16 @@ def test_missing_values_handling():
         )
         assert np.isfinite(scatter.widget.points).all()
         assert scatter.widget.points[3, 2] == 0
+
+
+def test_scatter_axes_labels(df: pd.DataFrame):
+    scatter = Scatter(data=df, x='a', y='b')
+
+    scatter.axes(labels=True)
+    assert scatter.widget.axes_labels == ['a', 'b']
+
+    scatter.axes(labels=False)
+    assert scatter.widget.axes_labels == False
+
+    scatter.axes(labels=['axis 1', 'axis 2'])
+    assert scatter.widget.axes_labels == ['axis 1', 'axis 2']


### PR DESCRIPTION
This PR fixes an issue in setting custom axes labels.

## Description

> What was changed in this pull request?

This PR ensures that custom axes labels are returned properly.

> Why is it necessary?

Fixes #137

## Checklist

- [x] Provided a concise title as a [semantic commit message](https://www.conventionalcommits.org) (e.g. "fix: correctly handle undefined properties")
- [x] `CHANGELOG.md` updated
- [x] Tests added or updated
- [ ] Documentation in `API.md`/`README.md` added or updated
- [ ] Example(s) added or updated
- [ ] Screenshot, gif, or video attached for visual changes
