### PR TITLE
fix: bump regl-scatterplot to v1.10.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,13 +46,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.x'
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm ci
+      - run: |
+          npm cache verify
+          npm ci
         working-directory: js

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,6 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: |
-          npm cache verify
+          npm update
           npm ci
         working-directory: js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
           node-version: "20.x"
       - run: |
           cd js
+          npm cache verify
           npm ci
 
       - uses: actions/setup-python@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           node-version: "20.x"
       - run: |
           cd js
-          npm cache verify
+          npm update
           npm ci
 
       - uses: actions/setup-python@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
+## v0.17.2
+
+- Fix: bump regl-scatterplot to v1.10.2 for a [hotfix related to rendering more than 1M points](https://github.com/flekschas/regl-scatterplot/pull/190)
+
 ## v0.17.1
 
-- Fix: fix regression preventing tooltip from showing up ([#141](https://github.com/flekschas/jupyter-scatter/issues/141))
+- Fix: regression preventing tooltip from showing up ([#141](https://github.com/flekschas/jupyter-scatter/issues/141))
 
 ## v0.17.0
 

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -22,7 +22,7 @@
         "gl-matrix": "~3.3.0",
         "pub-sub-es": "~3.0.0",
         "regl": "~2.1.0",
-        "regl-scatterplot": "~1.9.6"
+        "regl-scatterplot": "~1.10.2"
       },
       "devDependencies": {
         "esbuild": "^0.19.5",
@@ -2348,9 +2348,9 @@
       }
     },
     "node_modules/regl-scatterplot": {
-      "version": "1.9.6",
-      "resolved": "https://registry.npmjs.org/regl-scatterplot/-/regl-scatterplot-1.9.6.tgz",
-      "integrity": "sha512-hvroIbBmvLkPoTRgX99DKc3eg2Q6Ex7BwMb6Ih16wfBdJ651NQKu4n6TC/USUc+m89MjBZuA2csySi0Q8z/T3w==",
+      "version": "1.10.2",
+      "resolved": "file:../../regl-scatterplot/regl-scatterplot-1.10.2.tgz",
+      "integrity": "sha512-TDvv/c2ij5eEMgr0k4EsQQ1KgZMQjDDsw+DfriDFkfvF6CnWmwSAT40+FTb0EddvlA13CsLbCgSOGvB3pigFXg==",
       "dependencies": {
         "@flekschas/utils": "^0.31.0",
         "dom-2d-camera": "~2.2.5",

--- a/js/package.json
+++ b/js/package.json
@@ -30,7 +30,7 @@
     "gl-matrix": "~3.3.0",
     "pub-sub-es": "~3.0.0",
     "regl": "~2.1.0",
-    "regl-scatterplot": "~1.9.6"
+    "regl-scatterplot": "~1.10.2"
   },
   "devDependencies": {
     "esbuild": "^0.19.5",


### PR DESCRIPTION
There was an issue with rendering more than 1M points with regl-scatterplot due to a bug introduced in v1.9.0.

> Write one to two sentences summarizing this PR

## Description

> What was changed in this pull request?

Bumped regl-scatterplot from v1.9.8 to v1.10.2

> Why is it necessary?

The new version of regl-scatterplot contains a critical bug fix for rendering more than 1M points. For details see https://github.com/flekschas/regl-scatterplot/pull/190

## Checklist

- [x] Provided a concise title as a [semantic commit message](https://www.conventionalcommits.org) (e.g. "fix: correctly handle undefined properties")
- [x] `CHANGELOG.md` updated
- [ ] Tests added or updated
- [ ] Documentation in `API.md`/`README.md` added or updated
- [ ] Example(s) added or updated
- [ ] Screenshot, gif, or video attached for visual changes
