### PR TITLE
fix: add missing `pyarrow` dependency

### DIFF
--- a/notebooks/linking.ipynb
+++ b/notebooks/linking.ipynb
@@ -41,7 +41,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "60b1a82ba1824fd4afafa52894196357",
+       "model_id": "e55a37b33a36495380fb82d2bb3c9063",
        "version_major": 2,
        "version_minor": 0
       },
@@ -49,8 +49,9 @@
        "GridBox(children=(HBox(children=(VBox(children=(Button(button_style='primary', icon='arrows', layout=Layout(wi…"
       ]
      },
+     "execution_count": 2,
      "metadata": {},
-     "output_type": "display_data"
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -79,6 +80,27 @@
   {
    "cell_type": "code",
    "execution_count": 3,
+   "id": "195bbcf0-80cd-4070-9082-434a35a95770",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m24.0\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m24.2\u001b[0m\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpip install --upgrade pip\u001b[0m\n",
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
+   "source": [
+    "%pip install pyarrow --quiet"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
    "id": "39e401a5-1346-4da5-b8df-4131cdf8836e",
    "metadata": {},
    "outputs": [],
@@ -104,14 +126,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "9138e2aa-8276-4e94-a1b2-51de0da01d41",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f25d739621284cab882a19be456d89d1",
+       "model_id": "b91f28727d164fb6bf7fd3790040fa84",
        "version_major": 2,
        "version_minor": 0
       },
@@ -119,8 +141,9 @@
        "GridBox(children=(HBox(children=(VBox(children=(Button(button_style='primary', icon='arrows', layout=Layout(wi…"
       ]
      },
+     "execution_count": 5,
      "metadata": {},
-     "output_type": "display_data"
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -164,7 +187,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "automated-producer",
    "metadata": {},
    "outputs": [],
@@ -214,7 +237,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "ffbb9853-d792-4537-8e97-102b7a8be0e4",
    "metadata": {},
    "outputs": [
@@ -295,7 +318,7 @@
        "5  1  1     1"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -314,7 +337,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "signed-hello",
    "metadata": {},
    "outputs": [],
@@ -334,14 +357,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "9211d947-93fd-4ce0-ad1b-6f1461a34101",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "13b640a715e148fdad5ddd8f2acbb3ce",
+       "model_id": "2c5f9bd424bf4138be9eb0a7e7595032",
        "version_major": 2,
        "version_minor": 0
       },
@@ -349,8 +372,9 @@
        "GridBox(children=(HBox(children=(VBox(children=(Button(button_style='primary', icon='arrows', layout=Layout(wi…"
       ]
      },
+     "execution_count": 9,
      "metadata": {},
-     "output_type": "display_data"
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -381,14 +405,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "christian-factor",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "6d9d2e3d995a458d859dbd74e538287d",
+       "model_id": "b129dde5017b4c21b82d01099b695c61",
        "version_major": 2,
        "version_minor": 0
       },
@@ -396,8 +420,9 @@
        "GridBox(children=(HBox(children=(VBox(children=(Button(button_style='primary', icon='arrows', layout=Layout(wi…"
       ]
      },
+     "execution_count": 10,
      "metadata": {},
-     "output_type": "display_data"
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -434,7 +459,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.2"
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR adds `pyarrow` as a dependency to `linking.ipynb` as identified by https://github.com/openjournals/joss-reviews/issues/7059#issuecomment-2263459949

## Description

> What was changed in this pull request?

This PR adds missing `pip install pyarrow` statement to the `linking.ipynb`.

> Why is it necessary?

pyarrow is used for an example in the notebook so we should add it as a dependency

## Checklist

- [x] Provided a concise title as a [semantic commit message](https://www.conventionalcommits.org) (e.g. "fix: correctly handle undefined properties")
- [ ] `CHANGELOG.md` updated
- [ ] Tests added or updated
- [ ] Documentation in `API.md`/`README.md` added or updated
- [x] Example(s) added or updated
- [ ] Screenshot, gif, or video attached for visual changes
