### PR TITLE
feat: improve view save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.18.0
+
+- Refactor: When saving the current view as an image via the camera button on the left side bar, the image gets saved in `scatter.widget.view_data` as a 3D Numpy array (shape: `[height, width, 4]`) instead of a 1D Numpy array. Since the shape is now encoded by the 3D numpy array, `scatter.widget.view_shape` is no longer needed and is removed.
+
 ## v0.17.2
 
 - Fix: bump regl-scatterplot to v1.10.2 for a [hotfix related to rendering more than 1M points](https://github.com/flekschas/regl-scatterplot/pull/190)

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -73,7 +73,8 @@ export default defineConfig({
           { text: 'Axes & Legends', link: '/axes-legends' },
           { text: 'Tooltip', link: '/tooltip' },
           { text: 'Scales', link: '/scales' },
-          { text: 'Connected Scatterplots', link: '/connected-scatterplots' }
+          { text: 'Connected Scatterplots', link: '/connected-scatterplots' },
+          { text: 'Export as Image', link: '/export-image' },
         ]
       },
       // {

--- a/docs/export-image.md
+++ b/docs/export-image.md
@@ -1,0 +1,117 @@
+# Export View as Image
+
+There are two ways to export a scatter plot as an image. You can either download
+it as a PNG or save it to the widget's `view_data` property.
+
+::: info
+Image exports follow [WYSIWYG](https://en.wikipedia.org/wiki/WYSIWYG), meaning
+that the exported image will have the exact same size and viewport as the
+widget. Hence, if you want to export a higher resolution image you have to
+increase the scatter's width and height.
+:::
+
+## Export as PNG
+
+To download the current scatter plot view as a PNG click on the download icon.
+
+For instance, given the following scatter.
+
+```py
+import jscatter
+import numpy as np
+
+x = np.random.normal(0, 0.1, 1000)
+y = np.random.normal(0, 0.1, 1000)
+
+scatter = jscatter.Scatter(x, y)
+scatter.show()
+```
+
+<div class="img export-download"><div /></div>
+
+The downloaded image will look as follows:
+
+<div class="img export-download-png"><div /></div>
+
+
+## Export to `widget.view_data`
+
+When you click on the camera icon, the current view will be exported and saved
+to the widget's `view_data` property. You can use that property to print the
+image or manipulate it in some way if you like.
+
+For instance, given the following scatter.
+
+```py
+import jscatter
+import numpy as np
+
+x = np.random.rand(500)
+y = np.random.rand(500)
+
+scatter = jscatter.Scatter(x, y)
+scatter.show()
+```
+
+<div class="img export-save"><div /></div>
+
+After having clicked on the camera icon button on the left of the plot, you can
+access the exported image via `scatter.widget.view_data` and, for instance, plot
+it with Matplotlib as follows:
+
+```py
+from matplotlib import pyplot as plt
+plt.imshow(scatter.widget.view_data, interpolation='nearest')
+plt.show()
+```
+
+<div class="img export-save-matplotlib"><div /></div>
+
+<style scoped>
+  .img {
+    max-width: 100%;
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: cover;
+  }
+
+  .img.export-download {
+    width: 1108px;
+    background-image: url(/images/export-download-light.png)
+  }
+  .img.export-download div { padding-top: 48.55595668% }
+
+  :root.dark .img.export-download {
+    background-image: url(/images/export-download-dark.png)
+  }
+
+  .img.export-download-png {
+    width: 900px;
+    background-image: url(/images/export-download-png-light.png)
+  }
+  .img.export-download-png div { padding-top: 53.33333333% }
+
+  :root.dark .img.export-download-png {
+    background-image: url(/images/export-download-png-dark.png)
+  }
+
+  .img.export-save {
+    width: 1108px;
+    background-image: url(/images/export-save-light.png)
+  }
+  .img.export-save div { padding-top: 48.55595668% }
+
+  :root.dark .img.export-save {
+    background-image: url(/images/export-save-dark.png)
+  }
+
+  .img.export-save-matplotlib {
+    width: 552px;
+    background-image: url(/images/export-save-matplotlib-light.png)
+  }
+  .img.export-save-matplotlib div { padding-top: 56.70289855% }
+
+  :root.dark .img.export-save-matplotlib {
+    background-image: url(/images/export-save-matplotlib-dark.png)
+  }
+</style>

--- a/docs/public/images/export-download-dark.png
+++ b/docs/public/images/export-download-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5639bcb656927cbac8a32e698936669740ac2d668bb7bdf2482bd860b118c1ea
+size 45878

--- a/docs/public/images/export-download-light.png
+++ b/docs/public/images/export-download-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0fbed94ff192b182f0a5dff3bb5ce898d6d62f4cf52f1dbfd2898eb35d39f7b9
+size 44501

--- a/docs/public/images/export-download-png-dark.png
+++ b/docs/public/images/export-download-png-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:23c001679e8aa70cf63683427ca8b13a107a6d84966f0d2593025e19ab8fd31b
+size 16626

--- a/docs/public/images/export-download-png-light.png
+++ b/docs/public/images/export-download-png-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:169d785ae3604f06a10242e331cc878517d429419c19554ae9f72e81bebe91d0
+size 16634

--- a/docs/public/images/export-save-dark.png
+++ b/docs/public/images/export-save-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:200aaee600fdf55413a1a349a779974a8a09f140c71d864f807e1ee24c4e4007
+size 35444

--- a/docs/public/images/export-save-light.png
+++ b/docs/public/images/export-save-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad8d287ad65e759fe0078309a44aeee561778994628b1954b811ea1e1df63a5e
+size 34030

--- a/docs/public/images/export-save-matplotlib-dark.png
+++ b/docs/public/images/export-save-matplotlib-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e808969910d7a8f1b784404ade163638a16e6ccffdb090eafcc49a18ff961024
+size 6994

--- a/docs/public/images/export-save-matplotlib-light.png
+++ b/docs/public/images/export-save-matplotlib-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1d6862372c1a0e615c990f00b59072cd0aa726d277eeeaea94361055374e1a0c
+size 6266

--- a/js/src/codecs.js
+++ b/js/src/codecs.js
@@ -16,7 +16,41 @@ const DTYPES = {
  * @prop {keyof typeof DTYPES} dtype
  * @prop {Shape} shape
  */
+export function NumpyImage() {
+  return {
+    /**
+     * @param {SerializedArray<[number, number, number]>} data
+     * @returns {ImageData | null}
+     */
+    deserialize(data) {
+      if (data == null) return null;
+      // Take full view of data buffer
+      const dataArray = new Uint8ClampedArray(data.view.buffer);
+      // Chunk single TypedArray into nested Array of points
+      const [height, width] = data.shape;
+      return new ImageData(dataArray, width, height);
+    },
+    /**
+     * @param {ImageData} data
+     * @returns {SerializedArray<[number, number, number]>}
+     */
+    serialize(imageData) {
+      return {
+        view: new DataView(imageData.data.buffer),
+        dtype: 'uint8',
+        shape: [imageData.height, imageData.width, 4],
+      };
+    }
+  }
+}
 
+/**
+ * @template {number[]} Shape
+ * @typedef SerializedArray
+ * @prop {DataView} view
+ * @prop {keyof typeof DTYPES} dtype
+ * @prop {Shape} shape
+ */
 export function Numpy2D(dtype) {
   if (!(dtype in DTYPES)) {
     throw Error(`Dtype not supported, got ${JSON.stringify(dtype)}.`);

--- a/jscatter/widget.py
+++ b/jscatter/widget.py
@@ -15,7 +15,9 @@ from .utils import to_hex, with_left_label
 SELECTION_DTYPE = 'uint32'
 EVENT_TYPES = {
     "TOOLTIP": "tooltip",
+    "VIEW_DOWNLOAD": "view_download",
     "VIEW_RESET": "view_reset",
+    "VIEW_SAVE": "view_save",
 }
 
 def component_idx_to_name(idx):
@@ -219,7 +221,6 @@ class JupyterScatter(anywidget.AnyWidget):
 
     view_download = Unicode(None, allow_none=True).tag(sync=True) # Used for triggering a download
     view_data = Array(default_value=None, allow_none=True, read_only=True).tag(sync=True, **ndarray_serialization)
-    view_shape = List(None, allow_none=True, read_only=True).tag(sync=True)
 
     # For synchronyzing view changes across scatter plot instances
     view_sync = Unicode(None, allow_none=True).tag(sync=True)
@@ -255,6 +256,7 @@ class JupyterScatter(anywidget.AnyWidget):
     def create_download_view_button(self, icon_only=False, width=None):
         button = widgets.Button(
             description='' if icon_only else 'Download View',
+            tooltip='Download View as PNG',
             icon='download'
         )
 
@@ -262,7 +264,9 @@ class JupyterScatter(anywidget.AnyWidget):
             button.layout.width = f'{width}px'
 
         def click_handler(b):
-            self.download_view('file')
+            self.send({
+                "type": EVENT_TYPES["VIEW_DOWNLOAD"]
+            })
 
         button.on_click(click_handler)
         return button
@@ -270,6 +274,7 @@ class JupyterScatter(anywidget.AnyWidget):
     def create_save_view_button(self, icon_only=False, width=None):
         button = widgets.Button(
             description='' if icon_only else 'Save View',
+            tooltip='Save View to Widget Property',
             icon='camera'
         )
 
@@ -277,7 +282,9 @@ class JupyterScatter(anywidget.AnyWidget):
             button.layout.width = f'{width}px'
 
         def click_handler(b):
-            self.download_view('property')
+            self.send({
+                "type": EVENT_TYPES["VIEW_SAVE"]
+            })
 
         button.on_click(click_handler)
         return button
@@ -304,6 +311,7 @@ class JupyterScatter(anywidget.AnyWidget):
         button = Button(
             description='' if icon_only else 'Reset View',
             icon='refresh',
+            tooltip='Reset View',
             width=width,
         )
 
@@ -312,9 +320,6 @@ class JupyterScatter(anywidget.AnyWidget):
 
         button.on_click(click_handler)
         return button
-
-    def download_view(self, target = 'file'):
-        self.view_download = target
 
     def create_mouse_mode_toggle_button(
         self,


### PR DESCRIPTION
This PR improves view saving by saving a 3D numpy array

## Description

> What was changed in this pull request?

1. I've consolidated `scatter.widget.view_data` (1D Numpy array) and `scatter.widget.view_shape` (tuple) into one by turning `scatter.widget.view_data` into a 3D Numpy array ([height, width, 4]) and removing `scatter.widget.view_shape`.
2. I've documented how to export a view
3. I've also added tooltips to the view download, save, and reset buttons.

> Why is it necessary?

Address #146

## Checklist

- [x] Provided a concise title as a [semantic commit message](https://www.conventionalcommits.org) (e.g. "fix: correctly handle undefined properties")
- [x] `CHANGELOG.md` updated
- [ ] Tests added or updated
- [x] Documentation in `API.md`/`README.md` added or updated
- [ ] Example(s) added or updated
- [x] Screenshot, gif, or video attached for visual changes
