### PR TITLE
fix: VSCode rendering bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.17.3
+
+- Fix: VSCode integration by updating regl-scatterplot to v1.10.4 ([#37](https://github.com/flekschas/jupyter-scatter/issues/37))
+
 ## v0.17.2
 
 - Fix: bump regl-scatterplot to v1.10.2 for a [hotfix related to rendering more than 1M points](https://github.com/flekschas/regl-scatterplot/pull/190)

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -22,7 +22,7 @@
         "gl-matrix": "~3.3.0",
         "pub-sub-es": "~3.0.0",
         "regl": "~2.1.0",
-        "regl-scatterplot": "~1.10.2"
+        "regl-scatterplot": "~1.10.4"
       },
       "devDependencies": {
         "esbuild": "^0.19.5",
@@ -2348,11 +2348,11 @@
       }
     },
     "node_modules/regl-scatterplot": {
-      "version": "1.10.2",
-      "resolved": "file:../../regl-scatterplot/regl-scatterplot-1.10.2.tgz",
-      "integrity": "sha512-TDvv/c2ij5eEMgr0k4EsQQ1KgZMQjDDsw+DfriDFkfvF6CnWmwSAT40+FTb0EddvlA13CsLbCgSOGvB3pigFXg==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/regl-scatterplot/-/regl-scatterplot-1.10.4.tgz",
+      "integrity": "sha512-+OVTDUYQKdMCR0ODqfKLsBbi/CrulpFVVkvTCGNrS7TjXsiX7KhtPBkftOs1iC840uWeA0rFo8t+ovGNyeAefQ==",
       "dependencies": {
-        "@flekschas/utils": "^0.31.0",
+        "@flekschas/utils": "^0.32.2",
         "dom-2d-camera": "~2.2.5",
         "gl-matrix": "~3.4.3",
         "pub-sub-es": "~3.0.0",
@@ -2360,18 +2360,13 @@
         "regl-line": "~1.1.1"
       },
       "engines": {
-        "node": ">=16.0.0",
+        "node": ">=20.0.0",
         "npm": ">=7.0.0"
       },
       "peerDependencies": {
-        "pub-sub-es": "~2.1.2",
+        "pub-sub-es": "~3.0.0",
         "regl": "~2.1.0"
       }
-    },
-    "node_modules/regl-scatterplot/node_modules/@flekschas/utils": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@flekschas/utils/-/utils-0.31.0.tgz",
-      "integrity": "sha512-ejl+9LrhyTbKjokbTHFqlwBZjqMBttD3R4M5t6p6sKcLRBKVn4gDporO76b/yIGQ0esN90G6/+uGNgjpf/AzXA=="
     },
     "node_modules/regl-scatterplot/node_modules/gl-matrix": {
       "version": "3.4.3",

--- a/js/package.json
+++ b/js/package.json
@@ -30,7 +30,7 @@
     "gl-matrix": "~3.3.0",
     "pub-sub-es": "~3.0.0",
     "regl": "~2.1.0",
-    "regl-scatterplot": "~1.10.2"
+    "regl-scatterplot": "~1.10.4"
   },
   "devDependencies": {
     "esbuild": "^0.19.5",


### PR DESCRIPTION
This PR fixed the rendering issue in VSCode

## Description

> What was changed in this pull request?

I've updated regl-scatterplot to v1.10.4 which contains the actual fix for the issue. See https://github.com/flekschas/regl-scatterplot/blob/master/CHANGELOG.md#1104 for details.

> Why is it necessary?

Fixes #37

> Demo

https://github.com/user-attachments/assets/43500f2f-effb-4ca7-9a2b-02930f3dd61b

## Checklist

- [x] Provided a concise title as a [semantic commit message](https://www.conventionalcommits.org) (e.g. "fix: correctly handle undefined properties")
- [x] `CHANGELOG.md` updated
- [ ] Tests added or updated
- [ ] Documentation in `API.md`/`README.md` added or updated
- [ ] Example(s) added or updated
- [x] Screenshot, gif, or video attached for visual changes
