### PR TITLE
fix: re-enable point transition and make it explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.18.1
+
+- Fix: re-enable point transition and make it explicit via `scatter.options(transition_points=True, transition_points_duration=3000)`
+
 ## v0.18.0
 
 - Feat: add support for line-based annotations via `scatter.annotations()`

--- a/docs/api.md
+++ b/docs/api.md
@@ -578,12 +578,14 @@ scatter.background(image='https://picsum.photos/640/640?random')
 ```
 
 
-### scatter.options(_options=Undefined_) {#scatter.options}
+### scatter.options(_transition_points=Undefined_, _transition_points_duration=Undefined_, _regl_scatterplot_options=Undefined_) {#scatter.options}
 
-Get or set other [regl-scatterplot](https://github.com/flekschas/regl-scatterplot) options.
+Get or set other Jupyter Scatter and [regl-scatterplot](https://github.com/flekschas/regl-scatterplot) options.
 
 **Arguments:**
-- `options` is a dictionary of [regl-scatterplot properties](https://github.com/flekschas/regl-scatterplot/#properties).
+- `transition_points` is a Boolean value to enable or disable the potential animated transitioning of points as their coordinates update. If `False`, points will never be animated.
+- `transition_points_duration` is an Integer value determining the time of the animated point transition in milliseconds. The default value is `3000`.
+- `regl_scatterplot_options` is a dictionary of [regl-scatterplot properties](https://github.com/flekschas/regl-scatterplot/#properties).
 
 **Returns:** either the options when options are `Undefined` or `self`.
 

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -81,7 +81,7 @@ const properties = {
   opacity: 'opacity',
   opacityBy: 'opacityBy',
   opacityUnselected: 'opacityInactiveScale',
-  otherOptions: 'otherOptions',
+  reglScatterplotOptions: 'reglScatterplotOptions',
   points: 'points',
   reticle: 'showReticle',
   reticleColor: 'reticleColor',
@@ -271,7 +271,7 @@ class JupyterScatterView {
         if (this[pyName] !== null && reglScatterplotProperty.has(jsName)) {
           initialOptions[jsName] = this[pyName];
         }
-        if (this[pyName] !== null && jsName === 'otherOptions') {
+        if (this[pyName] !== null && jsName === 'reglScatterplotOptions') {
           Object.entries(this[pyName]).forEach(([key, value]) => {
             initialOptions[key] = value;
           })
@@ -335,8 +335,8 @@ class JupyterScatterView {
         }, this);
       });
 
-      this.model.on('change:other_options', () => {
-        this.options = this.model.get('other_options');
+      this.model.on('change:regl_scatterplot_options', () => {
+        this.options = this.model.get('regl_scatterplot_options');
         this.optionsHandler.call(this, this.options);
       }, this);
 
@@ -2059,7 +2059,7 @@ class JupyterScatterView {
       // We assume point correspondence
       this.scatterplot.draw(newPoints, {
         transition: this.model.get('transition_points'),
-        transitionDuration: 3000,
+        transitionDuration: this.model.get('transition_points_duration'),
         transitionEasing: 'quadInOut',
         preventFilterReset: this.model.get('prevent_filter_reset'),
       });

--- a/jscatter/widget.py
+++ b/jscatter/widget.py
@@ -69,6 +69,7 @@ class JupyterScatter(anywidget.AnyWidget):
     # Data
     points = Array(default_value=None).tag(sync=True, **ndarray_serialization)
     transition_points = Bool(False).tag(sync=True)
+    transition_points_duration = Int(3000).tag(sync=True)
     prevent_filter_reset = Bool(False).tag(sync=True)
     selection = Array(default_value=None, allow_none=True).tag(sync=True, **ndarray_serialization)
     filter = Array(default_value=None, allow_none=True).tag(sync=True, **ndarray_serialization)
@@ -228,9 +229,7 @@ class JupyterScatter(anywidget.AnyWidget):
     reticle = Bool().tag(sync=True)
     reticle_color = Union([Unicode(), List(minlen=4, maxlen=4)]).tag(sync=True)
 
-    # For any kind of options. Note that whatever is defined in options will
-    # be overwritten by the short-hand options
-    other_options = Dict(dict()).tag(sync=True)
+    regl_scatterplot_options = Dict(dict()).tag(sync=True)
 
     view_download = Unicode(None, allow_none=True).tag(sync=True) # Used for triggering a download
     view_data = Array(default_value=None, allow_none=True, read_only=True).tag(sync=True, **ndarray_serialization)

--- a/tests/test_jscatter.py
+++ b/tests/test_jscatter.py
@@ -65,6 +65,33 @@ def df2() -> pd.DataFrame:
     return df
 
 
+@pytest.fixture
+def df3() -> pd.DataFrame:
+    num_groups = 8
+
+    data = np.zeros((1000, 7))
+    data[:, 0] = np.linspace(0, 1, 1000)
+    data[:, 1] = np.linspace(0, 1, 1000)
+    data[:, 2] = np.random.rand(1000) * 100
+    data[:, 3] = (np.random.rand(1000) * 100).astype(int)
+    data[:, 4] = np.round(np.random.rand(1000) * (num_groups - 1)).astype(int)
+    data[:, 5] = np.repeat(np.arange(100), 10).astype(int)
+    data[:, 6] = np.resize(np.arange(5), 1000).astype(int)
+
+    df = pd.DataFrame(
+        data, columns=['a', 'b', 'c', 'd', 'group', 'connect', 'connect_order']
+    )
+    df['group'] = (
+        df['group']
+        .astype('int')
+        .astype('category')
+        .map(lambda c: chr(65 + c), na_action=None)
+    )
+    df['connect'] = df['connect'].astype('int')
+    df['connect_order'] = df['connect_order'].astype('int')
+
+    return df
+
 def test_component_idx_to_name():
     assert component_idx_to_name(2) == 'valueA'
     assert component_idx_to_name(3) == 'valueB'
@@ -322,3 +349,89 @@ def test_scatter_axes_labels(df: pd.DataFrame):
 
     scatter.axes(labels=['axis 1', 'axis 2'])
     assert scatter.widget.axes_labels == ['axis 1', 'axis 2']
+
+
+def test_scatter_transition_points(df: pd.DataFrame, df2: pd.DataFrame, df3: pd.DataFrame):
+    scatter = Scatter(data=df, x='a', y='b')
+
+    # Default settings
+    assert scatter._transition_points == True
+    assert scatter._transition_points_duration == 3000
+
+    scatter = Scatter(data=df, x='a', y='b', transition_points=False, transition_points_duration=500)
+    assert scatter._transition_points == False
+    assert scatter._transition_points_duration == 500
+
+    scatter = Scatter(data=df, x='a', y='b')
+
+    # Default widget state
+    assert scatter.widget.transition_points == False
+    assert scatter.widget.transition_points_duration == 3000
+
+    # Since `scatter._transition_points` is `True` and `animate` is undefined,
+    # points should be transitioned by default if the x or y channel changes
+    scatter.x('c')
+    assert scatter.widget.transition_points == True
+
+    scatter.y('d')
+    assert scatter.widget.transition_points == True
+
+    scatter.xy(x='a', y='b')
+    assert scatter.widget.transition_points == True
+
+    # Even though `scatter._transition_points` is still `True` but `animate` is
+    # now `False`, points should **not** be transitioned if the x or y channel
+    # changes
+    scatter.x('c', animate=False)
+    assert scatter.widget.transition_points == False
+
+    scatter.y('d', animate=False)
+    assert scatter.widget.transition_points == False
+
+    scatter.xy(x='a', y='b', animate=False)
+    assert scatter.widget.transition_points == False
+
+    # By changing the
+    scatter.options(transition_points=False)
+
+    # Since `scatter._transition_points` is now `False` and `animate` is still
+    # undefined, points should **not** be transitioned by default if the x or y
+    # channel changes
+    scatter.x('c')
+    assert scatter.widget.transition_points == False
+
+    scatter.y('d')
+    assert scatter.widget.transition_points == False
+
+    scatter.xy(x='a', y='b')
+    assert scatter.widget.transition_points == False
+
+    # Even though `scatter._transition_points` is still `False` but `animate` is
+    # now `True`, points should be transitioned if the x or y channel changes
+    scatter.x('c', animate=True)
+    assert scatter.widget.transition_points == True
+
+    scatter.y('d', animate=True)
+    assert scatter.widget.transition_points == True
+
+    scatter.xy(x='a', y='b', animate=True)
+    assert scatter.widget.transition_points == True
+
+    scatter.options(transition_points=True)
+
+    # When changing the data, the animated point transition has to be
+    # explicitely activated. By default, even if `scatter._transition_points` is
+    # `True`, points will not be animated.
+    scatter.data(df2)
+    assert scatter.widget.transition_points == False
+
+    scatter.data(df, animate=True)
+    assert scatter.widget.transition_points == True
+
+    # And even if the animation is explicitely actived, it'll only work if the
+    # number of points is the same.
+    scatter.data(df3, animate=True)
+    assert scatter.widget.transition_points == False
+
+    scatter.options(transition_points_duration=500)
+    assert scatter.widget.transition_points_duration == 500


### PR DESCRIPTION
This PR fixes a regression from #132 which accidentally disabled point transitions when the x or y channels were changed.

## Description

> What was changed in this pull request?

The animated point transition is based on a widget property called `transition_points`, which was introduced to make the animation behavior clearer when the data source was changed via `scatter.data()` in #132. Unfortunately, I accidentally forgot to set this property to true when `scatter.x()`, `scatter.y()`, or `scatter.xy()` was used. I've fixed the issue.

Additionally, to offer more control over when points are transitioned and the transition speed, I've added two options to the `Scatter` class that can either be set during initialization or via `scatter.options()`:
- `transition_points`: is a Boolean value to enable or disable the potential animated transitioning of points as their coordinates update. If `False`, points will never be animated.
- `transition_points_duration`: is an Integer value determining the time of the animated point transition in milliseconds. The default value is `3000`.

Also, for clarity, I've renamed the following option:
- from `scatter._options` to `scatter._regl_scatterplot_options`
- from `scatter.widget.other_options` to `scatter.widget.regl_scatterplot_options`

> Why is it necessary?

Fixes #153
Fixes #154

> Demo

https://github.com/user-attachments/assets/3b9830f7-1435-429b-b318-4b698b96f4b6

## Checklist

- [x] Provided a concise title as a [semantic commit message](https://www.conventionalcommits.org) (e.g. "fix: correctly handle undefined properties")
- [x] `CHANGELOG.md` updated
- [x] Tests added or updated
- [x] Documentation in `API.md`/`README.md` added or updated
- [ ] Example(s) added or updated
- [x] Screenshot, gif, or video attached for visual changes
