### PR TITLE
test: fix pandas deprecation warning and remove unused `tooltip_histograms_bins` argument

### DIFF
--- a/jscatter/jscatter.py
+++ b/jscatter/jscatter.py
@@ -18,8 +18,8 @@ COMPONENT_CONNECT_ORDER = 5
 VALID_ENCODING_TYPES = [
     pd.api.types.is_float_dtype,
     pd.api.types.is_integer_dtype,
-    pd.api.types.is_categorical_dtype,
-    pd.api.types.is_string_dtype,
+    pd.CategoricalDtype.is_dtype,
+    pd.StringDtype.is_dtype,
 ]
 DEFAULT_HISTOGRAM_BINS = 20
 
@@ -44,14 +44,14 @@ def check_encoding_dtype(series):
         raise ValueError(f'{series.name} is of an unsupported data type: {series.dtype}. Must be one of float*, int*, category, or string.')
 
 def is_categorical_data(data):
-    return pd.api.types.is_categorical_dtype(data) or pd.api.types.is_string_dtype(data)
+    return pd.CategoricalDtype.is_dtype(data) or pd.StringDtype.is_dtype(data)
 
 def get_categorical_data(data):
     categorical_data = None
 
-    if pd.api.types.is_categorical_dtype(data):
+    if pd.CategoricalDtype.is_dtype(data):
         categorical_data = data
-    elif pd.api.types.is_string_dtype(data):
+    elif pd.StringDtype.is_dtype(data):
         categorical_data = data.copy().astype('category')
 
     return categorical_data
@@ -4002,7 +4002,6 @@ class Scatter():
             tooltip_properties=self._tooltip_properties,
             tooltip_properties_non_visual_info=self._tooltip_properties_non_visual_info,
             tooltip_histograms=self._tooltip_histograms,
-            tooltip_histograms_bins=self._tooltip_histograms_bins,
             tooltip_histograms_ranges=self._tooltip_histograms_ranges,
             tooltip_histograms_size=self._tooltip_histograms_size,
             tooltip_preview=self._tooltip_preview,

--- a/jscatter/utils.py
+++ b/jscatter/utils.py
@@ -3,7 +3,7 @@ import warnings
 
 from matplotlib.colors import LogNorm, PowerNorm, Normalize
 from numpy import histogram, isnan, sum
-from pandas.api.types import is_categorical_dtype, is_string_dtype
+from pandas import CategoricalDtype, StringDtype
 from urllib.parse import urlparse
 from typing import List, Union
 
@@ -78,13 +78,13 @@ def to_scale_type(norm = None):
     return 'categorical'
 
 def get_scale_type_from_df(data):
-    if is_categorical_dtype(data) or is_string_dtype(data):
+    if isinstance(data.dtype, CategoricalDtype) or isinstance(data.dtype, StringDtype):
         return 'categorical'
 
     return 'linear'
 
 def get_domain_from_df(data):
-    if is_categorical_dtype(data) or is_string_dtype(data):
+    if isinstance(data.dtype, CategoricalDtype) or isinstance(data.dtype, StringDtype):
         # We need to recreate the categorization in case the data is just a
         # filtered view, in which case it might contain "missing" indices
         _data = data.copy().astype(str).astype('category')
@@ -120,7 +120,7 @@ def create_labeling(partial_labeling, column: Union[str, None] = None) -> Labeli
     return labeling
 
 def get_histogram_from_df(data, bins=20, range=None):
-    if is_categorical_dtype(data) or is_string_dtype(data):
+    if isinstance(data.dtype, CategoricalDtype) or isinstance(data.dtype, StringDtype):
         # We need to recreate the categorization in case the data is just a
         # filtered view, in which case it might contain "missing" indices
         value_counts = data.copy().astype(str).astype('category').cat.codes.value_counts()


### PR DESCRIPTION
This PR fixes several warnings thrown in pytest.

## Description

> What was changed in this pull request?

☝️ 

> Why is it necessary?

The warning are just annoying to look at :)

## Checklist

- [x] Provided a concise title as a [semantic commit message](https://www.conventionalcommits.org) (e.g. "fix: correctly handle undefined properties")
- [ ] `CHANGELOG.md` updated
- [ ] Tests added or updated
- [ ] Documentation in `API.md`/`README.md` added or updated
- [ ] Example(s) added or updated
- [ ] Screenshot, gif, or video attached for visual changes
