### PR TITLE
fix: regressions and smaller visual glitches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.18.1
+
+- Fix: Correctly render axes grid lines upon resizing
+- Fix: Reapply point color map when setting `color_by`
+- Fix: Do not set tooltip titles if the corresponding elements are undefined.
+
 ## v0.18.0
 
 - Feat: add support for line-based annotations via `scatter.annotations()`

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -245,10 +245,7 @@ class JupyterScatterView {
 
     this.canvasWrapper = document.createElement('div');
     this.canvasWrapper.style.position = 'absolute';
-    this.canvasWrapper.style.top = '0';
-    this.canvasWrapper.style.left = '0';
-    this.canvasWrapper.style.right = '0';
-    this.canvasWrapper.style.bottom = '0';
+    this.canvasWrapper.style.inset = '0';
     this.container.appendChild(this.canvasWrapper);
 
     this.canvas = document.createElement('canvas');
@@ -318,7 +315,9 @@ class JupyterScatterView {
       this.viewSyncHandler(this.viewSync);
 
       if ('ResizeObserver' in window) {
-        this.canvasObserver = new ResizeObserver(this.resizeHandlerBound);
+        this.canvasObserver = new ResizeObserver(() => {
+          window.requestAnimationFrame(() => { this.resizeHandlerBound(); });
+        });
         this.canvasObserver.observe(this.canvas);
       } else {
         window.addEventListener('resize', this.resizeHandlerBound);
@@ -448,7 +447,7 @@ class JupyterScatterView {
     this.outerWidth = outerWidth;
     this.outerHeight = outerHeight;
 
-    return [outerWidth, outerHeight]
+    return [Math.max(1, outerWidth), Math.max(1, outerHeight)];
   }
 
   createAxes() {
@@ -579,6 +578,8 @@ class JupyterScatterView {
     if (this.model.get('axes_grid')) this.createAxesGrid();
 
     this.updateLegendWrapperPosition();
+
+    this.updateAxes(this.xScaleRegl.domain(), this.yScaleRegl.domain());
   }
 
   removeAxes() {
@@ -1682,7 +1683,7 @@ class JupyterScatterView {
       : (width + xPadding) + 'px';
     this.container.style.height = (height + yPadding) + 'px';
 
-    window.requestAnimationFrame(() => { this.resizeHandler(); });
+    window.requestAnimationFrame(() => { this.resizeHandlerBound(); });
   }
 
   resizeHandler() {
@@ -1723,6 +1724,9 @@ class JupyterScatterView {
     if (this.model.get('axes_grid')) {
       this.xAxis.tickSizeInner(-(height - yPadding));
       this.yAxis.tickSizeInner(-(width - xPadding));
+      this.axesSvg.selectAll('line')
+        .attr('stroke-opacity', 0.2)
+        .attr('stroke-dasharray', 2);
     }
 
     if (xLabel) {
@@ -2199,8 +2203,8 @@ class JupyterScatterView {
   }
 
   opacityByHandler(newValue) {
-    // this.createOpacityScale();
-    // this.createOpacityGetter();
+    this.createOpacityScale();
+    this.createOpacityGetter();
     this.withPropertyChangeHandler('opacityBy', newValue);
   }
 

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -2151,11 +2151,15 @@ class JupyterScatterView {
   }
 
   xTitleHandler(newTitle) {
-    this.tooltipPropertyXTitle.textContent = toTitleCase(newTitle || '');
+    if (this.tooltipPropertyXTitle) {
+      this.tooltipPropertyXTitle.textContent = toTitleCase(newTitle || '');
+    }
   }
 
   yTitleHandler(newTitle) {
-    this.tooltipPropertyYTitle.textContent = toTitleCase(newTitle || '');
+    if (this.tooltipPropertyYTitle) {
+      this.tooltipPropertyYTitle.textContent = toTitleCase(newTitle || '');
+    }
   }
 
   colorHandler(newValue) {
@@ -2179,7 +2183,9 @@ class JupyterScatterView {
   }
 
   colorTitleHandler(newTitle) {
-    this.tooltipPropertyColorTitle.textContent = toCapitalCase(newTitle || '');
+    if (this.tooltipPropertyColorTitle) {
+      this.tooltipPropertyColorTitle.textContent = toCapitalCase(newTitle || '');
+    }
   }
 
   opacityHandler(newValue) {
@@ -2199,7 +2205,9 @@ class JupyterScatterView {
   }
 
   opacityTitleHandler(newTitle) {
-    this.tooltipPropertyOpacityTitle.textContent = toCapitalCase(newTitle || '');
+    if (this.tooltipPropertyOpacityTitle) {
+      this.tooltipPropertyOpacityTitle.textContent = toCapitalCase(newTitle || '');
+    }
   }
 
   sizeHandler(newValue) {
@@ -2215,7 +2223,9 @@ class JupyterScatterView {
   }
 
   sizeTitleHandler(newTitle) {
-    this.tooltipPropertySizeTitle.textContent = toCapitalCase(newTitle || '');
+    if (this.tooltipPropertySizeTitle) {
+      this.tooltipPropertySizeTitle.textContent = toCapitalCase(newTitle || '');
+    }
   }
 
   connectHandler(newValue) {

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -2181,9 +2181,16 @@ class JupyterScatterView {
   }
 
   colorByHandler(newValue) {
+    const currValue = this.scatterplot.get('colorBy');
     this.createColorScale();
     this.createColorGetter();
     this.withPropertyChangeHandler('colorBy', newValue);
+    if (!currValue && newValue) {
+      // We need to reapply the point color due to some internal
+      // regl-scatterplot logic which uses a different active point color when
+      // the point color is changed and colorBy is undefined
+      this.withPropertyChangeHandler('pointColor', this.model.get('color'));
+    }
   }
 
   colorTitleHandler(newTitle) {

--- a/jscatter/jscatter.py
+++ b/jscatter/jscatter.py
@@ -19,8 +19,8 @@ COMPONENT_CONNECT_ORDER = 5
 VALID_ENCODING_TYPES = [
     pd.api.types.is_float_dtype,
     pd.api.types.is_integer_dtype,
+    pd.api.types.is_string_dtype,
     pd.CategoricalDtype.is_dtype,
-    pd.StringDtype.is_dtype,
 ]
 DEFAULT_HISTOGRAM_BINS = 20
 
@@ -45,14 +45,14 @@ def check_encoding_dtype(series):
         raise ValueError(f'{series.name} is of an unsupported data type: {series.dtype}. Must be one of float*, int*, category, or string.')
 
 def is_categorical_data(data):
-    return pd.CategoricalDtype.is_dtype(data) or pd.StringDtype.is_dtype(data)
+    return pd.CategoricalDtype.is_dtype(data) or pd.api.types.is_string_dtype(data)
 
 def get_categorical_data(data):
     categorical_data = None
 
     if pd.CategoricalDtype.is_dtype(data):
         categorical_data = data
-    elif pd.StringDtype.is_dtype(data):
+    elif pd.api.types.is_string_dtype(data):
         categorical_data = data.copy().astype('category')
 
     return categorical_data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,3 +88,10 @@ test = "pytest ."
 
 [tool.ruff.format]
 quote-style = "single"
+
+[tool.pytest.ini_options]
+filterwarnings = [
+  # Ignore unrelated DeprecationWarning from traitlets:
+  # Sentinel is not a public part of the traitlets API.
+  "ignore::DeprecationWarning:traitlets:28",
+]

--- a/tests/test_jscatter.py
+++ b/tests/test_jscatter.py
@@ -327,10 +327,11 @@ def test_scatter_check_encoding_dtype(df: pd.DataFrame):
     check_encoding_dtype(pd.Series([1], dtype='int'))
     check_encoding_dtype(pd.Series([0.5], dtype='float'))
     check_encoding_dtype(pd.Series(['a'], dtype='string'))
+    check_encoding_dtype(pd.Series(['a']))
     check_encoding_dtype(pd.Series(['a'], dtype='category'))
 
     scatter = Scatter(data=df, x='a', y='b', color_by='group')
     check_encoding_dtype(scatter.color_data)
 
-    with pytest.raises(ValueError) as e_info:
+    with pytest.raises(ValueError):
         check_encoding_dtype(pd.Series(np.array([1+0j])))

--- a/tests/test_jscatter.py
+++ b/tests/test_jscatter.py
@@ -5,7 +5,7 @@ import pytest
 from functools import partial
 from matplotlib.colors import AsinhNorm, LogNorm, Normalize, PowerNorm, SymLogNorm
 
-from jscatter.jscatter import Scatter, component_idx_to_name
+from jscatter.jscatter import Scatter, component_idx_to_name, check_encoding_dtype
 from jscatter.utils import create_default_norm, to_ndc, TimeNormalize
 
 
@@ -322,3 +322,15 @@ def test_scatter_axes_labels(df: pd.DataFrame):
 
     scatter.axes(labels=['axis 1', 'axis 2'])
     assert scatter.widget.axes_labels == ['axis 1', 'axis 2']
+
+def test_scatter_check_encoding_dtype(df: pd.DataFrame):
+    check_encoding_dtype(pd.Series([1], dtype='int'))
+    check_encoding_dtype(pd.Series([0.5], dtype='float'))
+    check_encoding_dtype(pd.Series(['a'], dtype='string'))
+    check_encoding_dtype(pd.Series(['a'], dtype='category'))
+
+    scatter = Scatter(data=df, x='a', y='b', color_by='group')
+    check_encoding_dtype(scatter.color_data)
+
+    with pytest.raises(ValueError) as e_info:
+        check_encoding_dtype(pd.Series(np.array([1+0j])))


### PR DESCRIPTION
This PR fixes several smaller glitches

## Description

> What was changed in this pull request?

- Upon resizing, the axes grid lines were not rerendered correctly (they should remain dashed)
- When changing the `color_by` and `color_map` property at the same time, we need to take care of a special edge case. When `color_by` is undefined and a color map is set, regl-scatterplot uses the special `pointColorActive` instead of the color map colors. Hence in this case we have to reapply the point color after setting `color_by`.
- Revert the switch from `pd.api.types.is_string_dtype` to `pd.StringDtype.is_dtype` as `pd.StringDtype.is_dtype` is not equivalent to `pd.api.types.is_string_dtype`. Some Pandas APIs are a mess... 😞  (I added tests to verify the behavior now)
- Do not set tooltip title if element is undefined

## Checklist

- [x] Provided a concise title as a [semantic commit message](https://www.conventionalcommits.org) (e.g. "fix: correctly handle undefined properties")
- [x] `CHANGELOG.md` updated
- [x] Tests added or updated
- [ ] Documentation in `API.md`/`README.md` added or updated
- [ ] Example(s) added or updated
- [ ] Screenshot, gif, or video attached for visual changes
