### PR TITLE
fix: use internal x/y domains for updating axes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.18.2
+
+- Fix: don't use external view domain (only the view) [#158](https://github.com/flekschas/jupyter-scatter/issues/158)
+
 ## v0.18.1
 
 - Fix: re-enable point transition and make it explicit via `scatter.options(transition_points=True, transition_points_duration=3000)`

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -1846,8 +1846,8 @@ class JupyterScatterView {
   externalViewChangeHandler(event) {
     if (event.uuid === this.viewSync && event.src !== this.randomStr) {
       this.scatterplot.view(event.view, { preventEvent: true });
-      if (this.model.get('axes') && event.xScaleDomain && event.yScaleDomain) {
-        this.updateAxes(event.xScaleDomain, event.yScaleDomain);
+      if (this.model.get('axes')) {
+        this.updateAxes(this.xScaleRegl.domain(), this.yScaleRegl.domain());
       }
     }
   }


### PR DESCRIPTION
This PR fixes an issue when synchronizing two scatters with different domains

## Description

> What was changed in this pull request?

Use internal x/y domains for updating axes for external view synchronizing

> Why is it necessary?

Fixes #158 

> Demo

```py
import jscatter
import numpy as np
import pandas as pd

data1 = pd.DataFrame({
    "x": np.random.rand(1000),
    "y": np.random.rand(1000),
})
data2 = pd.DataFrame({
    "x": 200*np.random.rand(1000),
    "y": 200*np.random.rand(1000),
})
s0 = jscatter.Scatter(data=data1, x="x", y="y", height=500)
s1 = jscatter.Scatter(data=data2, x="x", y="y", height=500)
jscatter.compose(
    [s0, s1],
    sync_view = True
)
```


https://github.com/user-attachments/assets/3632aeb5-2524-4721-acc7-d68dbbd120b4



## Checklist

- [x] Provided a concise title as a [semantic commit message](https://www.conventionalcommits.org) (e.g. "fix: correctly handle undefined properties")
- [x] `CHANGELOG.md` updated
- [ ] Tests added or updated
- [ ] Documentation in `API.md`/`README.md` added or updated
- [ ] Example(s) added or updated
- [x] Screenshot, gif, or video attached for visual changes
