### PR TITLE
refactor: rename `reset_view` to `zoom_view`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.18.2
+
+- Refactor: rename the `reset_view` argument of `scatter.data()` to `zoom_view` for clarity
+- Docs: add API docs for `reset_scales`, `zoom_view`, and `animate` of `scatter.data()`
+
 ## v0.18.1
 
 - Fix: re-enable point transition and make it explicit via `scatter.options(transition_points=True, transition_points_duration=3000)`

--- a/docs/api.md
+++ b/docs/api.md
@@ -104,14 +104,17 @@ scatter.xy('size', 'speed') # Mirror plot along the diagonal
 ```
 
 
-### scatter.data(_data=Undefined_, _use_index=Undefined_, _\*\*kwargs_) {#scatter.data}
+### scatter.data(_data=Undefined_, _use_index=Undefined_, _reset_scales=False_, _zoom_view=False_, _animate=False_, _\*\*kwargs_) {#scatter.data}
 
-Get or set the referenced Pandas DataFrame. This is just a convenience function to animate a change in the x and y coordinate at the same time.
+Get or set the referenced Pandas DataFrame.
 
 **Arguments:**
 
 - `data` is a Pandas DataFrame.
 - `use_index` is a Boolean value indicating if the data frame's index should be used for referencing point by the `selection()` and `filter()` methods instead of the row index.
+- `reset_scales` is a Boolean value indicating whether all scales (and norms) will be reset to the extend of the the new data.
+- `zoom_view` is a Boolean value indicating if the view will zoom to the data extent.
+- `animate` is a Boolean value indicating if the points will transition smoothly. However, animated point transitions are only supported if the number of points remain the same, and if `reset_scales` is `False`. If `zoom_view` is `True`, the view will also transition smoothly.
 - `kwargs`:
   - `skip_widget_update` allows to skip the dynamic widget update when `True`. This can be useful when you want to animate the transition of multiple properties at once instead of animating one after the other.
 

--- a/jscatter/jscatter.py
+++ b/jscatter/jscatter.py
@@ -3,6 +3,7 @@ import math
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+import warnings
 
 from matplotlib.colors import to_rgba, Normalize, LogNorm, PowerNorm, LinearSegmentedColormap, ListedColormap
 from typing import Dict, Optional, Union, List, Tuple
@@ -514,7 +515,7 @@ class Scatter():
         data: Optional[pd.DataFrame] = None,
         use_index: Optional[Union[bool, Undefined]] = UNDEF,
         reset_scales: Optional[bool] = False,
-        reset_view: Optional[bool] = False,
+        zoom_view: Optional[bool] = False,
         animate: Optional[bool] = False,
         **kwargs
     ) -> Union[Scatter, dict]:
@@ -534,17 +535,17 @@ class Scatter():
         reset_scales : bool, optional
             If `True`, all scales (and norms) will be reset to the extend of the
             the new data.
-        reset_view : bool, optional
-            If `True`, the view will be reset to the origin.
+        zoom_view : bool, optional
+            If `True`, the view will zoom to the data extent.
         animate : bool, optional
             If `True`, if the number of points remain the same, and if
             `reset_scales` is `False`, the points will transition smoothly. If
-            `reset_view` is `True`, the view will also transition smoothly.
+            `zoom_view` is `True`, the view will also transition smoothly.
 
         Returns
         -------
         self or dict
-            If no parameter was provided a dictionary with the current `data`
+            If no arguments were provided a dictionary with the current `data`
             and `use_label_index` setting is returned. Otherwise, `self` is
             returned.
 
@@ -625,10 +626,22 @@ class Scatter():
                 self.update_widget('y_domain', self._y_domain)
                 self.update_widget('y_scale_domain', self._y_scale_domain)
 
-            if reset_view:
+            if 'reset_view' in kwargs:
+                warnings.warn(
+                    "The 'reset_view' argument was renamed to 'zoom_view'",
+                    DeprecationWarning,
+                )
+                zoom_view = bool(kwargs.get('reset_view', False))
+
+            if zoom_view:
                 if reset_scales:
+                    # If the scales are reset to the extent of the (new) data,
+                    # then we can zoom to the data extent by simply resetting
+                    # the view
                     self.widget.reset_view()
                 else:
+                    # If the scales unchanged, we can zoom to the data extent by
+                    # setting `data_extent=True` of `self.widget.reset_view`
                     animation = 3000 if animate and same_n else 0
                     self.widget.reset_view(
                         animation=animation,


### PR DESCRIPTION
This PR renames the `reset_view` argument of the `scatter.data()` method to `zoom_view` for clarity. The name `reset_view` and method's docstring suggested that the argument updated the origin, which is not the case. By setting `zoom_view` to `True`, all that's happening is that the view is zoomed to the data extent. Whether or not the origin is updated depends on the `reset_scales` argument.

## Description

> What was changed in this pull request?

- Refactor: rename the `reset_view` argument of `scatter.data()` to `zoom_view` for clarity
- Docs: add API docs for `reset_scales`, `zoom_view`, and `animate` of `scatter.data()`

> Why is it necessary?

Fixes #160 

## Checklist

- [x] Provided a concise title as a [semantic commit message](https://www.conventionalcommits.org) (e.g. "fix: correctly handle undefined properties")
- [x] `CHANGELOG.md` updated
- [ ] Tests added or updated
- [x] Documentation in `API.md`/`README.md` added or updated
- [ ] Example(s) added or updated
- [ ] Screenshot, gif, or video attached for visual changes
