### PR TITLE
fix: revert to `pd.api.types.is_string_dtype`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.19.1
+
+- Fix: revert back to `pd.api.types.is_string_dtype` from `pd.StringDType` because the two function, albeit looking semantically identical, do not do the same thing. The former detects object and string types while the latter only strictly detects string types. This is confusing as `pd.Series(['a', 'b'])` is of type `object`. So `pd.StringDtype.is_dtype(pd.Series(['a', 'b'])) == False` but `pd.api.types.is_string_dtype(pd.Series(['a', 'b'])) == True`. [Wat](https://www.destroyallsoftware.com/talks/wat)?!
+
 ## v0.19.0
 
 - Feat: add contour line annotations [#163](https://github.com/flekschas/jupyter-scatter/issues/163)

--- a/jscatter/utils.py
+++ b/jscatter/utils.py
@@ -1,9 +1,9 @@
 import ipywidgets as widgets
+import pandas as pd
 import warnings
 
 from matplotlib.colors import LogNorm, PowerNorm, Normalize
 from numpy import histogram, isnan, sum
-from pandas import CategoricalDtype, StringDtype
 from urllib.parse import urlparse
 from typing import List, Union
 
@@ -78,13 +78,13 @@ def to_scale_type(norm = None):
     return 'categorical'
 
 def get_scale_type_from_df(data):
-    if isinstance(data.dtype, CategoricalDtype) or isinstance(data.dtype, StringDtype):
+    if pd.CategoricalDtype.is_dtype(data) or pd.api.types.is_string_dtype(data):
         return 'categorical'
 
     return 'linear'
 
 def get_domain_from_df(data):
-    if isinstance(data.dtype, CategoricalDtype) or isinstance(data.dtype, StringDtype):
+    if pd.CategoricalDtype.is_dtype(data) or pd.api.types.is_string_dtype(data):
         # We need to recreate the categorization in case the data is just a
         # filtered view, in which case it might contain "missing" indices
         _data = data.copy().astype(str).astype('category')
@@ -120,7 +120,7 @@ def create_labeling(partial_labeling, column: Union[str, None] = None) -> Labeli
     return labeling
 
 def get_histogram_from_df(data, bins=20, range=None):
-    if isinstance(data.dtype, CategoricalDtype) or isinstance(data.dtype, StringDtype):
+    if pd.CategoricalDtype.is_dtype(data) or pd.api.types.is_string_dtype(data):
         # We need to recreate the categorization in case the data is just a
         # filtered view, in which case it might contain "missing" indices
         value_counts = data.copy().astype(str).astype('category').cat.codes.value_counts()

--- a/notebooks/Untitled4.ipynb
+++ b/notebooks/Untitled4.ipynb
@@ -1,0 +1,152 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "c8d67f28-de9c-4cd4-b60b-c5bf92db023b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "env: ANYWIDGET_HMR=1\n"
+     ]
+    }
+   ],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2\n",
+    "%env ANYWIDGET_HMR=1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "63452dc6-5726-4242-81a0-fc79b68e64a7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "473f9edbd47840f5ab4720fc1abf3479",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(VBox(children=(Button(button_style='primary', icon='arrows', layout=Layout(width='36px'), style…"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import jscatter\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "\n",
+    "data1 = pd.DataFrame({\n",
+    "    \"x\": np.random.rand(1000),\n",
+    "    \"y\": np.random.rand(1000),\n",
+    "    \"z\": ['a','b']*500,\n",
+    "})\n",
+    "scatter = jscatter.Scatter(data=data1, x=\"x\", y=\"y\", width=500, height=500)\n",
+    "scatter.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "3d052d61-79e7-4f7a-9839-92f8e34a5bbf",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<jscatter.jscatter.Scatter at 0x12cc5d640>"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "scatter.tooltip(True, properties = ['x','y', 'z']) "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "3b01ac2a-c9bf-48cc-bb8e-34a646528db3",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "False"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pd.StringDtype.is_dtype(pd.Series(['a', 'b']))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "c8d03133-e4e2-43ad-9292-6ea39dcb3bfb",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pd.api.types.is_string_dtype(pd.Series(['a', 'b']))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "069b99ef-74f9-401e-b26e-851589f0328a",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This PR reverts back the method for detecting whether a column is of type string.

## Description

> What was changed in this pull request?

I reverted back to `pd.api.types.is_string_dtype` from `pd.StringDType` because the two function, albeit looking semantically identical, do not do the same thing. The former detects object and string types while the latter only strictly detects string types. This is confusing as `pd.Series(['a', 'b'])` is of type `object`. So:

```py
pd.StringDtype.is_dtype(pd.Series(['a', 'b'])) == False
pd.api.types.is_string_dtype(pd.Series(['a', 'b'])) == True
```

[Wat?!](https://www.destroyallsoftware.com/talks/wat)

> Why is it necessary?

Fixes #166 

> Test Case

```py
import jscatter
import numpy as np
import pandas as pd

data = pd.DataFrame({
    "x": np.random.rand(1000),
    "y": np.random.rand(1000),
    "z": ["a","b"] * 500,
})
scatter = jscatter.Scatter(
    data=data,
    x="x",
    y="y",
    tooltip=True,
    tooltip_properties=["x", "y", "z"]
)
scatter.show()
```

![Screen Recording 2024-09-25 at 9 21 21 PM](https://github.com/user-attachments/assets/67b843be-9b24-4ddc-84e7-2b3203f7bd3e)


## Checklist

- [x] Provided a concise title as a [semantic commit message](https://www.conventionalcommits.org) (e.g. "fix: correctly handle undefined properties")
- [x] `CHANGELOG.md` updated
- [x] Tests added or updated
- [ ] Documentation in `API.md`/`README.md` added or updated
- [ ] Example(s) added or updated
- [x] Screenshot, gif, or video attached for visual changes
