### PR TITLE
feat: allow customizing the point size's zoom scale function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## v0.20.0
 
+- Feat: add ability to change the point size zoom scale function via `scatter.size(scale_function='asinh')`
 - Feat: add CLI for quick-starting a demo via `uvx jupyter-scatter demo`
 - Chore: switch from ESLint+Prettier to Biome [#170](https://github.com/flekschas/jupyter-scatter/pull/170)
 - Chore: migrate from hatch to uv [#169](https://github.com/flekschas/jupyter-scatter/pull/169)

--- a/docs/api.md
+++ b/docs/api.md
@@ -242,7 +242,7 @@ scatter.opacity(by='density')
 ```
 
 
-### scatter.size(_default=Undefined_, _by=Undefined_, _map=Undefined_, _norm=Undefined_, _order=Undefined_, _labeling=Undefined_, _\*\*kwargs_) {#scatter.size}
+### scatter.size(_default=Undefined_, _by=Undefined_, _map=Undefined_, _norm=Undefined_, _order=Undefined_, _labeling=Undefined_, _scale_function=Undefined_, _\*\*kwargs_) {#scatter.size}
 
 Get or set the point size.
 
@@ -254,6 +254,7 @@ Get or set the point size.
 - `norm` is either a tuple defining a value range that's map to `[0, 1]` with `matplotlib.colors.Normalize` or a [matplotlib normalizer](https://matplotlib.org/3.5.0/api/_as_gen/matplotlib.colors.Normalize.html).
 - `order` is either a list of values (for categorical size encoding) or `reverse` to reverse the size map.
 - `labeling` is either a tuple of three strings specyfing a label for the minimum value, maximum value, and variable that the size encodes or a dictionary of the form `{'minValue': 'label', 'maxValue': 'label', 'variable': 'label'}`. The specified labels are only used for continuous size encoding and are displayed together with the legend.
+- `scale_function` is the function used for adjusting the size of points when zooming in. It can either be `asinh`, `linear`, or `constant`. The default is `asinh`. `constant` is a special case that does not scale the size of points when zooming in.
 - `kwargs`:
   - `skip_widget_update` allows to skip the dynamic widget update when `True`. This can be useful when you want to animate the transition of multiple properties at once instead of animating one after the other.
 

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -22,7 +22,7 @@
         "gl-matrix": "~3.3.0",
         "pub-sub-es": "~3.0.0",
         "regl": "~2.1.0",
-        "regl-scatterplot": "~1.11.0"
+        "regl-scatterplot": "~1.11.1"
       },
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
@@ -1144,9 +1144,10 @@
       }
     },
     "node_modules/regl-scatterplot": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/regl-scatterplot/-/regl-scatterplot-1.11.0.tgz",
-      "integrity": "sha512-ve3Af9X7aoV0haNvdHCtR5Jvhy6VYH7hZRVfHfCg21Zs8phih7s0tHuZJOGd1oQTvKPnWHuYcxTwSDAwhrEbiQ==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/regl-scatterplot/-/regl-scatterplot-1.11.1.tgz",
+      "integrity": "sha512-8s1yu2VNwiJxXIg4WPMge9HxzpgzetTEJq8IgNyMopNaIPNwgdPW3rLRKT0k0wNdcC5BAyjxAzUDflx6lxGcuA==",
+      "license": "MIT",
       "dependencies": {
         "@flekschas/utils": "^0.32.2",
         "dom-2d-camera": "~2.2.5",

--- a/js/package.json
+++ b/js/package.json
@@ -30,7 +30,7 @@
     "gl-matrix": "~3.3.0",
     "pub-sub-es": "~3.0.0",
     "regl": "~2.1.0",
-    "regl-scatterplot": "~1.11.0"
+    "regl-scatterplot": "~1.11.1"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -96,6 +96,7 @@ const properties = {
   filter: 'filteredPoints',
   size: 'pointSize',
   sizeBy: 'sizeBy',
+  sizeScaleFunction: 'pointScaleMode',
   connect: 'showPointConnections',
   connectionColor: 'pointConnectionColor',
   connectionColorSelected: 'pointConnectionColorActive',
@@ -197,6 +198,7 @@ const reglScatterplotProperty = new Set([
   'filteredPoints',
   'pointSize',
   'sizeBy',
+  'pointScaleMode',
   'showPointConnections',
   'pointConnectionColor',
   'pointConnectionColorActive',
@@ -2432,6 +2434,10 @@ class JupyterScatterView {
     this.createSizeScale();
     this.createSizeGetter();
     this.withPropertyChangeHandler('sizeBy', newValue);
+  }
+
+  sizeScaleFunctionHandler(newValue) {
+    this.withPropertyChangeHandler('pointScaleMode', newValue);
   }
 
   sizeTitleHandler(newTitle) {

--- a/jscatter/types.py
+++ b/jscatter/types.py
@@ -9,6 +9,7 @@ Color = Union[str, Rgb, Rgba]
 TooltipPreviewType = Literal['text', 'image', 'audio']
 TooltipPreviewImagePosition = Literal['top', 'bottom', 'left', 'right', 'center']
 TooltipPreviewImageSize = Literal['contain', 'cover']
+SizeScaleFunction = Literal['asinh', 'linear', 'constant']
 
 # To distinguish between None and an undefined (optional) argument, where None
 # is used for unsetting and Undefined is used for skipping.

--- a/jscatter/widget.py
+++ b/jscatter/widget.py
@@ -259,6 +259,9 @@ class JupyterScatter(anywidget.AnyWidget):
     size_by = Enum([None, 'valueA', 'valueB'], allow_none=True, default_value=None).tag(
         sync=True
     )
+    size_scale_function = Enum(
+        ['asinh', 'constant', 'linear'], default_value='asinh'
+    ).tag(sync=True)
     connect = Bool().tag(sync=True)
     connection_color = Union(
         [

--- a/jscatter/widget.py
+++ b/jscatter/widget.py
@@ -347,7 +347,7 @@ class JupyterScatter(anywidget.AnyWidget):
         data = self.data.iloc[point_idx]
         self.send(
             {
-                'type': TOOLTIP_EVENT_TYPE,
+                'type': EVENT_TYPES['TOOLTIP'],
                 'show': True,
                 'index': point_idx,
                 'preview': data[self.tooltip_preview]

--- a/tests/test_jscatter.py
+++ b/tests/test_jscatter.py
@@ -533,3 +533,35 @@ def test_tooltip(df: pd.DataFrame):
     # Test with invalid property
     scatter.tooltip(properties=['color', 'invalid_column'])
     assert scatter.widget.tooltip_properties == ['color']
+
+
+def test_point_size_scale(df: pd.DataFrame):
+    # Test initializing a scatter plot with tooltip properties
+    scatter = Scatter(data=df, x='a', y='b')
+
+    # Default size scale function is 'asinh'
+    assert scatter.widget.size_scale_function == 'asinh'
+
+    # Test changing the size scale function to 'linear'
+    scatter.size(scale_function='linear')
+    assert scatter.widget.size_scale_function == 'linear'
+
+    # Test changing the size scale function to 'constant'
+    scatter.size(scale_function='constant')
+    assert scatter.widget.size_scale_function == 'constant'
+
+    # Test initializing with the size scale function to 'constant'
+    assert (
+        Scatter(
+            data=df, x='a', y='b', size_scale_function='linear'
+        ).widget.size_scale_function
+        == 'linear'
+    )
+
+    # Test initializing with the size scale function to 'constant'
+    assert (
+        Scatter(
+            data=df, x='a', y='b', size_scale_function='constant'
+        ).widget.size_scale_function
+        == 'constant'
+    )


### PR DESCRIPTION
This PR introduces a new property called `size_scale_function` to allow customizing the point size's zoom scale function.

## Description

> What was changed in this pull request?

This PR exposes regl-scatterplot's `pointScaleMode` (added by @abast! Thanks again 🎉 ) via `scatter.size(scale_function)`. You can choose between
- `asinh` (default)
- `linear`
- `constant` (a.k.a., no zoom-based scaling)

> Why is it necessary?

Because it's a neat feature to have and it's already implemented in regl-scatterplot

> Demo

Zoom-based scale functions in the following order:
1. `asinh`
2. `linear`
3. `constant`

https://github.com/user-attachments/assets/7e373c87-7f3a-4a7c-ace4-1244fdc3c13b

## Checklist

- [x] Provided a concise title as a [semantic commit message](https://www.conventionalcommits.org) (e.g. "fix: correctly handle undefined properties")
- [x] `CHANGELOG.md` updated
- [x] Tests added or updated
- [x] Documentation in `API.md`/`README.md` added or updated
- [ ] Example(s) added or updated
- [x] Screenshot, gif, or video attached for visual changes
