### PR TITLE
fix: allow disabling pan/zoom by fixing the camera

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v0.20.0
 
 - Feat: add ability to change the point size zoom scale function via `scatter.size(scale_function='asinh')`
+- Feat: add `scatter.camera(is_fixed=True)` to allow fixing the camera (i.e., disable pan/zoom) [#176](https://github.com/flekschas/jupyter-scatter/issues/176)
 - Feat: add CLI for quick-starting a demo via `uvx jupyter-scatter demo`
 - Chore: switch from ESLint+Prettier to Biome [#170](https://github.com/flekschas/jupyter-scatter/pull/170)
 - Chore: migrate from hatch to uv [#169](https://github.com/flekschas/jupyter-scatter/pull/169)

--- a/docs/api.md
+++ b/docs/api.md
@@ -491,7 +491,7 @@ scatter.zoom(to=scatter.selection(), animation=2000, padding=0.1)
 ```
 
 
-### scatter.camera(_target=Undefined_, _distance=Undefined_, _rotation=Undefined_, _view=Undefined_) {#scatter.camera}
+### scatter.camera(_target=Undefined_, _distance=Undefined_, _rotation=Undefined_, _view=Undefined_, _is_fixed=Undefined_) {#scatter.camera}
 
 Get or set the camera view.
 
@@ -500,6 +500,7 @@ Get or set the camera view.
 - `distance` is a float value defining the distance of the camera from the scatter plot (imagine as a 2D plane in a 3D world).
 - `rotation` is a float value defining the rotation in radians.
 - `view` is an array-like list of 16 floats defining a view matrix.
+- `is_fixed` is a Boolean value specifying whether the camera position is fixed to it's current location. If `True`, manual pan and zoom interactions are disabled. Note, you can still programmatically zoom via `scatter.zoom()`.
 
 **Returns:** either the camera properties when all arguments are `Undefined` or `self`.
 

--- a/docs/link-multiple-plots.md
+++ b/docs/link-multiple-plots.md
@@ -24,7 +24,7 @@ import jscatter
 import numpy as np
 
 x, y = np.random.rand(500), np.random.rand(500)
-a, b = jscatter.Scatter(x=x, y=y), Scatter(x=x, y=y)
+a, b = jscatter.Scatter(x=x, y=y), jscatter.Scatter(x=x, y=y)
 
 jscatter.compose([a, b])
 ```

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -18,11 +18,10 @@
         "d3-selection": "~3.0.0",
         "d3-time": "~3.1.0",
         "d3-time-format": "~4.1.0",
-        "dom-2d-camera": "~2.2.5",
         "gl-matrix": "~3.3.0",
         "pub-sub-es": "~3.0.0",
         "regl": "~2.1.0",
-        "regl-scatterplot": "~1.11.1"
+        "regl-scatterplot": "~1.11.3"
       },
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
@@ -854,6 +853,18 @@
         "underscore": ">=1.8.3"
       }
     },
+    "node_modules/camera-2d-simple": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/camera-2d-simple/-/camera-2d-simple-3.0.0.tgz",
+      "integrity": "sha512-hBeuUeerQ2Repi/61PGyFkuJ9jt6IKAny7pjQo2w8/8uZh+RKvNLZQy4xbQeDH8FrlnFxAJDjyM4/yuLdOV5vQ==",
+      "license": "MIT",
+      "dependencies": {
+        "gl-matrix": "~3.3.0"
+      },
+      "peerDependencies": {
+        "gl-matrix": "~3.3.0"
+      }
+    },
     "node_modules/crypto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
@@ -961,26 +972,16 @@
       }
     },
     "node_modules/dom-2d-camera": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/dom-2d-camera/-/dom-2d-camera-2.2.5.tgz",
-      "integrity": "sha512-BmjIiinZsvllot3E7HGsQRS4rfDfmsJK8urFL7po3Sx5r8ZrWvEcHxYxeUqxjEIGqp1Re5qRGTUx3pAACI3mjg==",
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/dom-2d-camera/-/dom-2d-camera-2.2.6.tgz",
+      "integrity": "sha512-HWfV26qjCfpOHa6X0PI1ZyZDhowk6skEs5f7aOwgewuJSP6IgPcK694ImYIOMGnDYK4vC4/Etsi26WpbJtS2vQ==",
+      "license": "MIT",
       "dependencies": {
         "camera-2d-simple": "^3.0.0",
         "gl-matrix": "^3.3.0"
       },
       "peerDependencies": {
         "gl-matrix": "^3.3.0"
-      }
-    },
-    "node_modules/dom-2d-camera/node_modules/camera-2d-simple": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/camera-2d-simple/-/camera-2d-simple-3.0.0.tgz",
-      "integrity": "sha512-hBeuUeerQ2Repi/61PGyFkuJ9jt6IKAny7pjQo2w8/8uZh+RKvNLZQy4xbQeDH8FrlnFxAJDjyM4/yuLdOV5vQ==",
-      "dependencies": {
-        "gl-matrix": "~3.3.0"
-      },
-      "peerDependencies": {
-        "gl-matrix": "~3.3.0"
       }
     },
     "node_modules/esbuild": {
@@ -1127,9 +1128,10 @@
       "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA=="
     },
     "node_modules/regl": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/regl/-/regl-2.1.0.tgz",
-      "integrity": "sha512-oWUce/aVoEvW5l2V0LK7O5KJMzUSKeiOwFuJehzpSFd43dO5spP9r+sSUfhKtsky4u6MCqWJaRL+abzExynfTg=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/regl/-/regl-2.1.1.tgz",
+      "integrity": "sha512-+IOGrxl3FZ8ZM9ixCWQZzFRiRn7Rzn9bu3iFHwg/yz4tlOUQgbO4PHLgG+1ZT60zcIV8tief6Qrmyl8qcoJP0g==",
+      "license": "MIT"
     },
     "node_modules/regl-line": {
       "version": "1.1.1",
@@ -1144,16 +1146,16 @@
       }
     },
     "node_modules/regl-scatterplot": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/regl-scatterplot/-/regl-scatterplot-1.11.1.tgz",
-      "integrity": "sha512-8s1yu2VNwiJxXIg4WPMge9HxzpgzetTEJq8IgNyMopNaIPNwgdPW3rLRKT0k0wNdcC5BAyjxAzUDflx6lxGcuA==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/regl-scatterplot/-/regl-scatterplot-1.11.3.tgz",
+      "integrity": "sha512-mmNUOOmyN5XKLnDVH4UxgcuU8tHhsRhiWo2nQt8wbnStkstSoiRUP3pp+xf01mcElDzmAebEOo5O6nQI7zW9Uw==",
       "license": "MIT",
       "dependencies": {
         "@flekschas/utils": "^0.32.2",
-        "dom-2d-camera": "~2.2.5",
+        "dom-2d-camera": "^2.2.6",
         "gl-matrix": "~3.4.3",
         "pub-sub-es": "~3.0.0",
-        "regl": "~2.1.0",
+        "regl": "~2.1.1",
         "regl-line": "~1.1.1"
       },
       "engines": {
@@ -1162,7 +1164,7 @@
       },
       "peerDependencies": {
         "pub-sub-es": "~3.0.0",
-        "regl": "~2.1.0"
+        "regl": "~2.1.1"
       }
     },
     "node_modules/regl-scatterplot/node_modules/gl-matrix": {

--- a/js/package.json
+++ b/js/package.json
@@ -26,11 +26,10 @@
     "d3-selection": "~3.0.0",
     "d3-time": "~3.1.0",
     "d3-time-format": "~4.1.0",
-    "dom-2d-camera": "~2.2.5",
     "gl-matrix": "~3.3.0",
     "pub-sub-es": "~3.0.0",
     "regl": "~2.1.0",
-    "regl-scatterplot": "~1.11.1"
+    "regl-scatterplot": "~1.11.3"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -73,6 +73,7 @@ const properties = {
   cameraRotation: 'cameraRotation',
   cameraTarget: 'cameraTarget',
   cameraView: 'cameraView',
+  cameraIsFixed: 'cameraIsFixed',
   color: 'pointColor',
   colorSelected: 'pointColorActive',
   colorBy: 'colorBy',
@@ -176,6 +177,7 @@ const reglScatterplotProperty = new Set([
   'cameraRotation',
   'cameraTarget',
   'cameraView',
+  'cameraIsFixed',
   'pointColor',
   'pointColorActive',
   'colorBy',
@@ -2514,6 +2516,10 @@ class JupyterScatterView {
 
   cameraViewHandler(newValue) {
     this.withPropertyChangeHandler('cameraView', newValue);
+  }
+
+  cameraIsFixedHandler(newValue) {
+    this.withPropertyChangeHandler('cameraIsFixed', newValue);
   }
 
   lassoInitiatorHandler(newValue) {

--- a/jscatter/jscatter.py
+++ b/jscatter/jscatter.py
@@ -426,6 +426,7 @@ class Scatter:
         self._camera_view = None
         self._camera_is_fixed = False
         self._mouse_mode = 'panZoom'
+        self._mouse_mode_prev = self._mouse_mode
         self._axes = True
         self._axes_grid = False
         self._axes_labels = False
@@ -3194,6 +3195,12 @@ class Scatter:
 
         if is_fixed is not UNDEF:
             self._camera_is_fixed = is_fixed
+            if is_fixed:
+                self._mouse_mode_prev = self._mouse_mode
+                self._mouse_mode = 'lasso'
+            else:
+                self._mouse_mode = self._mouse_mode_prev
+            self.update_widget('mouse_mode', self._mouse_mode)
             self.update_widget('camera_is_fixed', self._camera_is_fixed)
 
         if any_not([target, distance, rotation, view, is_fixed], UNDEF):
@@ -3529,6 +3536,7 @@ class Scatter:
         if mode is not UNDEF:
             try:
                 self._mouse_mode = mode
+                self._mouse_mode_prev = mode
                 self.update_widget('mouse_mode', mode)
             except:
                 pass

--- a/jscatter/jscatter.py
+++ b/jscatter/jscatter.py
@@ -424,6 +424,7 @@ class Scatter:
         self._camera_distance = 1.0
         self._camera_rotation = 0.0
         self._camera_view = None
+        self._camera_is_fixed = False
         self._mouse_mode = 'panZoom'
         self._axes = True
         self._axes_grid = False
@@ -533,6 +534,7 @@ class Scatter:
             kwargs.get('camera_distance', UNDEF),
             kwargs.get('camera_rotation', UNDEF),
             kwargs.get('camera_view', UNDEF),
+            kwargs.get('camera_is_fixed', UNDEF),
         )
         self.axes(
             kwargs.get('axes', UNDEF),
@@ -3105,6 +3107,7 @@ class Scatter:
         distance: Optional[Union[float, Undefined]] = UNDEF,
         rotation: Optional[Union[float, Undefined]] = UNDEF,
         view: Optional[Union[List[float], np.ndarray, Undefined]] = UNDEF,
+        is_fixed: Optional[Union[bool, Undefined]] = UNDEF,
     ):
         """
         Set or get the camera settings.
@@ -3121,6 +3124,11 @@ class Scatter:
         view : float, optional
             Columnar 4x4 camera's view matrix. The matrix is an array-like list
             of 16 floats where the first numbers represent the first column etc.
+            The camera rotation in radians.
+        is_fixed : bool, optional
+            If `True`, the camera position is fixed to it's current location. As
+            a consequence, manual pan and zoom interactions are disabled. Note,
+            you can still programmatically zoom via `scatter.zoom()`.
 
         Returns
         -------
@@ -3153,7 +3161,13 @@ class Scatter:
         <jscatter.jscatter.Scatter>
 
         >>> scatter.camera()
-        {'target': [0, 0], 'distance': 1.0, 'rotation': 0.0, 'view': None}
+        {
+          'target': [0, 0],
+          'distance': 1.0,
+          'rotation': 0.0,
+          'view': None,
+          'is_fixed': True,
+        }
         """
         if target is not UNDEF:
             self._camera_target = target
@@ -3178,7 +3192,11 @@ class Scatter:
             self._camera_view = view
             self.update_widget('camera_view', self._camera_view)
 
-        if any_not([target, distance, rotation, view], UNDEF):
+        if is_fixed is not UNDEF:
+            self._camera_is_fixed = is_fixed
+            self.update_widget('camera_is_fixed', self._camera_is_fixed)
+
+        if any_not([target, distance, rotation, view, is_fixed], UNDEF):
             return self
 
         return dict(
@@ -3186,6 +3204,7 @@ class Scatter:
             distance=self._camera_distance,
             rotation=self._camera_rotation,
             view=self._camera_view,
+            is_fixed=self._camera_is_fixed,
         )
 
     def lasso(
@@ -4441,6 +4460,7 @@ class Scatter:
             camera_rotation=self._camera_rotation,
             camera_target=self._camera_target,
             camera_view=self._camera_view,
+            camera_is_fixed=self._camera_is_fixed,
             color=order_map(self._color_map, self._color_order)
             if self._color_map
             else self._color,

--- a/jscatter/widget.py
+++ b/jscatter/widget.py
@@ -145,6 +145,7 @@ class JupyterScatter(anywidget.AnyWidget):
     camera_distance = Float(1).tag(sync=True)
     camera_rotation = Float(1).tag(sync=True)
     camera_view = List(None, allow_none=True).tag(sync=True)
+    camera_is_fixed = Bool(False).tag(sync=True)
 
     # Zoom properties
     zoom_to = Array(default_value=None, allow_none=True).tag(

--- a/jscatter/widget.py
+++ b/jscatter/widget.py
@@ -464,6 +464,7 @@ class JupyterScatter(anywidget.AnyWidget):
             icon='arrows',
             tooltip='Activate pan & zoom',
         )
+        button_pan_zoom.disabled = self.camera_is_fixed
         button_lasso = self.create_mouse_mode_toggle_button(
             mouse_mode='lasso',
             icon='crosshairs',
@@ -506,6 +507,11 @@ class JupyterScatter(anywidget.AnyWidget):
         plots = widgets.VBox(
             children=[self], layout=widgets.Layout(flex='1', width='auto')
         )
+
+        def camera_is_fixed_change_handler(change):
+            button_pan_zoom.disabled = change['new']
+
+        self.observe(camera_is_fixed_change_handler, names=['camera_is_fixed'])
 
         return widgets.HBox([buttons, plots])
 

--- a/tests/test_jscatter.py
+++ b/tests/test_jscatter.py
@@ -565,3 +565,20 @@ def test_point_size_scale(df: pd.DataFrame):
         ).widget.size_scale_function
         == 'constant'
     )
+
+
+def test_camera_is_fixed(df: pd.DataFrame):
+    scatter = Scatter(data=df, x='a', y='b')
+
+    # Check that by default, the camera is not fixed
+    assert scatter.widget.camera_is_fixed == False
+
+    # Test fixing the camera
+    scatter.camera(is_fixed=True)
+    assert scatter.widget.camera_is_fixed == True
+
+    # Test initializing a Scatter with a fixed camera
+    assert (
+        Scatter(data=df, x='a', y='b', camera_is_fixed=True).widget.camera_is_fixed
+        == True
+    )

--- a/tests/test_jscatter.py
+++ b/tests/test_jscatter.py
@@ -569,16 +569,32 @@ def test_point_size_scale(df: pd.DataFrame):
 
 def test_camera_is_fixed(df: pd.DataFrame):
     scatter = Scatter(data=df, x='a', y='b')
+    pan_zoom_button = scatter.show().children[0].children[0]
 
     # Check that by default, the camera is not fixed
     assert scatter.widget.camera_is_fixed == False
+    assert scatter.widget.mouse_mode == 'panZoom'
+    assert pan_zoom_button.disabled == False
 
     # Test fixing the camera
     scatter.camera(is_fixed=True)
     assert scatter.widget.camera_is_fixed == True
+    assert scatter.widget.mouse_mode == 'lasso'
+    assert pan_zoom_button.disabled == True
+
+    # Test unfixing the camera
+    scatter.camera(is_fixed=False)
+    assert scatter.widget.camera_is_fixed == False
+    assert scatter.widget.mouse_mode == 'panZoom'
+    assert pan_zoom_button.disabled == False
+
+    scatter.mouse(mode='lasso')
+    scatter.camera(is_fixed=True)
+    scatter.camera(is_fixed=False)
+    assert scatter.widget.mouse_mode == 'lasso'
+
+    scatter_b = Scatter(data=df, x='a', y='b', camera_is_fixed=True)
 
     # Test initializing a Scatter with a fixed camera
-    assert (
-        Scatter(data=df, x='a', y='b', camera_is_fixed=True).widget.camera_is_fixed
-        == True
-    )
+    assert scatter_b.widget.camera_is_fixed == True
+    assert scatter_b.widget.mouse_mode == 'lasso'


### PR DESCRIPTION
This PR adds support for disabling pan/zoom via `scatter.camera(is_fixed=True)`

## Description

> What was changed in this pull request?

You can control the camera's fixed state via
- `Scatter(camera_is_fixed=True)`
- `scatter.camera(is_fixed=True)`

Note that when the camera is fixed, manual pan and zoom is disabled. However, you can still pan and zoom programmatically via `scatter.zoom()`

> Why is it necessary?

Fixes #176

> Demo

https://github.com/user-attachments/assets/ac850945-82ec-487d-a4ba-97a922565627

## Checklist

- [x] Provided a concise title as a [semantic commit message](https://www.conventionalcommits.org) (e.g. "fix: correctly handle undefined properties")
- [x] `CHANGELOG.md` updated
- [x] Tests added or updated
- [x] Documentation in `API.md`/`README.md` added or updated
- [ ] Example(s) added or updated
- [x] Screenshot, gif, or video attached for visual changes
