### PR TITLE
feat: brush rectangle lasso

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.21.0
+
+- Feat: add support for brush and rectangle lasso types.
+- Feat: expose lasso selection polygon via `scatter.widget.lasso_polygon_selection`
+- Feat: enable merging of lasso selection upon holding down the [meta key](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/metaKey) and deselected points upon holding down the [alt key](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/altKey).
+
 ## v0.20.0
 
 - Feat: add support for showing a scatter plot in full-screen mode. In full-screen mode you can easily customize and up-scale the resolution for better exporting in PNG.

--- a/docs/api.md
+++ b/docs/api.md
@@ -553,16 +553,18 @@ scatter.mouse(mode='lasso')
 ```
 
 
-### scatter.lasso(_color=Undefined_, _initiator=Undefined_, _min_delay=Undefined_, _min_dist=Undefined_, _on_long_press=Undefined_) {#scatter.lasso}
+### scatter.lasso(_type=Undefined_, _color=Undefined_, _initiator=Undefined_, _min_delay=Undefined_, _min_dist=Undefined_, _on_long_press=Undefined_, _brush_size=Undefined_) {#scatter.lasso}
 
 Get or set the lasso for selecting multiple points.
 
 **Arguments:**
+- `type` is a string specifying the lasso type. Must be one of `'freeform'`, `'brush'`, or `'rectangle'`.
 - `color` is a string referring to a Matplotlib-compatible color.
 - `initiator` is a Boolean value to specify if the click-based lasso initiator should be enabled or not.
 - `min_delay` is an integer specifying the minimal delay in milliseconds before a new lasso point is stored. Higher values will result in more coarse grain lasso polygons but might be more performant. 
 - `min_dist` is an integer specifying the minimal distance in pixels that the mouse has to move before a new lasso point is stored. Higher values will result in more coarse grain lasso polygons but might be more performant.
 - `on_long_press` is a Boolean value specifying if the lasso should be activated upon a long press.
+- `brush_size` is an integer specifying the size of the brush in pixels. This has only an effect if `type` is set to `'brush'`'. Defaults to `24`.
 
 **Returns:** either the lasso properties when all arguments are `Undefined` or `self`.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -403,7 +403,7 @@ from jscatter import HLine, VLine
 scatter.annotations([HLine(42), VLine(42)])
 ```
 
-### scatter.tooltip(_enable=Undefined_, _properties=Undefined_, _histograms=Undefined_, _histograms_bins=Undefined_, _histograms_ranges=Undefined_, _histograms_size=Undefined_, _preview=Undefined_, _preview_type=Undefined_, _preview_text_lines=Undefined_, _preview_image_background_color=Undefined_, _preview_image_position=Undefined_, _preview_image_size=Undefined_, _preview_audio_length=Undefined_, _preview_audio_loop=Undefined_, _preview_audio_controls=Undefined_, _size=Undefined_) {#scatter.tooltip}
+### scatter.tooltip(_enable=Undefined_, _properties=Undefined_, _histograms=Undefined_, _histograms_bins=Undefined_, _histograms_ranges=Undefined_, _histograms_size=Undefined_, _preview=Undefined_, _preview_type=Undefined_, _preview_text_lines=Undefined_, _preview_image_background_color=Undefined_, _preview_image_position=Undefined_, _preview_image_size=Undefined_, _preview_image_height=Undefined_, _preview_audio_length=Undefined_, _preview_audio_loop=Undefined_, _preview_audio_controls=Undefined_, _size=Undefined_) {#scatter.tooltip}
 
 Set or get the tooltip settings.
 
@@ -412,7 +412,7 @@ Set or get the tooltip settings.
 
 - `properties` is a list of string specifying for which visual or data properties to show in the tooltip. The visual properties can be some of `x`, `y`, `color`, `opacity`, and `size`. Note that visual properties are only shown if they are actually used to data properties. To reference other data properties, specify a column of the bound DataFrame by its name.
 
-- `histograms` is a Boolean specifying if the tooltip should show histograms of the properties
+- `histograms` is a Boolean or list of property names specifying if histograms should be shown. When set to `True`, the tooltip will show histograms for all properties. Alternatively, you can provide a list of properties for which you want to show a histogram.
 
 - `histograms_bins` is either an Integer specifying the number of bins of all numerical histograms or a dictionary of property-specific number of bins. The default is `20`.
 
@@ -435,6 +435,8 @@ Set or get the tooltip settings.
 - `preview_image_size` is a string specifying the size of the image in the context of the preview area. This can be one of `"cover"` or `"contain"` and is set to `"contain"` by default.
 
   See https://developer.mozilla.org/en-US/docs/Web/CSS/background-size for details on the behavior.
+
+- `preview_image_height` The height of the image container pixels. By default, it is `None`, which makes the height deffault to 6em.
 
 - `preview_audio_length` is an integer specifying the number of seconds of an audio preview that should be played. By default (`None`), the audio file is played from the start to the end.
 
@@ -720,8 +722,8 @@ The widget (`scatter.widget`) has the following properties, which you can think 
 While you can adjust these properties directly, the [`Scatter` methods](#methods) are the idiomatic and recommended way to set widget properties.
 :::
 
-| Name                                     | Type <div style="min-width:250px"/>                                                                                                                                  | Default <div style="min-width:180px"/>   | Allow None | Read Only | Note <div style="min-width:320px"/> |
-| ---------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------- | ---------- | --------- | ------------- |
+| Name                                     | Type <div style="min-width:250px"/>                                                                                                                                  | Default <div style="min-width:180px"/>     | Allow None | Read Only | Note <div style="min-width:320px"/> |
+| ---------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ | ---------- | --------- | ------------- |
 | `dom_element_id`                         | str                                                                                                                                                                  |                                            |            | `True`    | For debugging |
 | `data`                                   | 2D numerical array                                                                                                                                                   |                                            |            |           |               |
 | `prevent_filter_reset`                   | bool                                                                                                                                                                 | `False`                                    |            |           |               |
@@ -790,6 +792,7 @@ While you can adjust these properties directly, the [`Scatter` methods](#methods
 | `tooltip_preview_image_background_color` | `"auto"` \| str                                                                                                                                                      | `"auto"`                                   |            |           |               |
 | `tooltip_preview_image_position`         | `"top"`<br/>\| `"left"`<br/>\| `"right"`<br/>\| `"bottom"`<br/>\| `"center"`                                                                                         | `"center"`                                 | `True`     |           |               |
 | `tooltip_preview_image_size`             | `"contain"` \| `"cover"`                                                                                                                                             | `"contain"`                                | `True`     |           |               |
+| `tooltip_preview_image_height`           | int                                                                                                                                                                  | `None`                                     | `True`     |           |               |
 | `tooltip_preview_audio_length`           | int                                                                                                                                                                  | `None`                                     | `True`     |           |               |
 | `tooltip_preview_audio_loop`             | bool                                                                                                                                                                 | `False`                                    |            |           |               |
 | `tooltip_preview_audio_controls`         | bool                                                                                                                                                                 | `True`                                     |            |           |               |

--- a/docs/interactions.md
+++ b/docs/interactions.md
@@ -94,12 +94,66 @@ closed it'll turn blue. At this point the lasso is active.
   <div class="overlay">Hover to play video</div>
 </div>
 
-Alternatively, you can click on the crosshair icon in the top-left of the
-scatter plot to permanently activate the lasso.
+Once the lasso is active, keep holding down your primary mouse button and move
+your mouse cursor around the points you want to select. Finally, release your
+primary mouse key.
 
-To select points once the lasso is active, keep holding down your primary mouse
-button and move your mouse cursor around the points you want to select. Finally,
-release your primary mouse key.
+::: info
+To permanently activate the lasso, you can click on the crosshair icon in the
+top-left of the scatter plot.
+:::
+
+### Add and Remove Selected Points
+
+To add more points to an existing selection, hold down the [_meta_ key](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/metaKey) as you
+lasso select the points you want to add. To remove points from a selection, hold
+down the [_alt_ key](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/altKey) as you lasso select the points you want to remove.
+
+<div class="video">
+  <video loop muted playsinline width="1256" data-name="interactions-lasso-add-remove">
+    <source
+      src="/videos/interactions-lasso-add-remove-light.mp4"
+      type="video/mp4"
+    />
+  </video>
+  <div class="overlay">Hover to play video</div>
+</div>
+
+::: info
+On macOS, the meta key is `Command` or `⌘` and the alt key is `Option` or `⌥`.
+:::
+
+### Brush and Rectangle Lasso Selections
+
+Beyond this _freeform_ lasso selection, Jupyter Scatter also offers
+_rectangular_ and _brush_ style lasso selections. You can change the lasso type
+either via the _lasso_ button in the top-left corner of the plot or via
+`scatter.lasso(type=lasso_type)`, where `lasso_type` must be one of
+`'freeform'`, `'brush'`, or `'rectangle'`.
+
+Below is an example of the brush lasso selection.
+
+<div class="video">
+  <video loop muted playsinline width="1256" data-name="interactions-lasso-brush">
+    <source
+      src="/videos/interactions-lasso-brush-light.mp4"
+      type="video/mp4"
+    />
+  </video>
+  <div class="overlay">Hover to play video</div>
+</div>
+
+And finally an example of the classic rectangular lasso selection.
+
+<div class="video">
+  <video loop muted playsinline width="1256" data-name="interactions-lasso-rectangle">
+    <source
+      src="/videos/interactions-lasso-rectangle-light.mp4"
+      type="video/mp4"
+    />
+  </video>
+  <div class="overlay">Hover to play video</div>
+</div>
 
 ## Filter Points
 

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "devDependencies": {
-        "vitepress": "^1.5.0"
+        "vitepress": "^1.6.1"
       }
     },
     "node_modules/@algolia/autocomplete-core": {
@@ -743,9 +743,9 @@
       }
     },
     "node_modules/@iconify-json/simple-icons": {
-      "version": "1.2.17",
-      "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.17.tgz",
-      "integrity": "sha512-1vXbM6a6HV2rwXxu8ptD2OYhqrqX0ZZRepOg7nIjkvKlKq90Iici4X++A8h36bEVlV2wGjqx8uVYB0pwnPZVSw==",
+      "version": "1.2.21",
+      "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.21.tgz",
+      "integrity": "sha512-aqbIuVshMZ2fNEhm25//9DoKudboXF3CpoEQJJlHl9gVSVNOTr4cgaCIZvgSEYmys2HHEfmhcpoZIhoEFZS8SQ==",
       "dev": true,
       "license": "CC0-1.0",
       "dependencies": {
@@ -1033,68 +1033,89 @@
       ]
     },
     "node_modules/@shikijs/core": {
-      "version": "1.24.4",
-      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.24.4.tgz",
-      "integrity": "sha512-jjLsld+xEEGYlxAXDyGwWsKJ1sw5Pc1pnp4ai2ORpjx2UX08YYTC0NNqQYO1PaghYaR+PvgMOGuvzw2he9sk0Q==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-2.0.3.tgz",
+      "integrity": "sha512-dhbLagx1As0BmaNGUTxJ/qshb4MPyKYIvjCcd7y1utDToebUS4BZI3FH+WVCJF3/VwWWKOhuzX4lgjOb7qtSjQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/engine-javascript": "1.24.4",
-        "@shikijs/engine-oniguruma": "1.24.4",
-        "@shikijs/types": "1.24.4",
-        "@shikijs/vscode-textmate": "^9.3.1",
+        "@shikijs/engine-javascript": "2.0.3",
+        "@shikijs/engine-oniguruma": "2.0.3",
+        "@shikijs/types": "2.0.3",
+        "@shikijs/vscode-textmate": "^10.0.1",
         "@types/hast": "^3.0.4",
         "hast-util-to-html": "^9.0.4"
       }
     },
     "node_modules/@shikijs/engine-javascript": {
-      "version": "1.24.4",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-1.24.4.tgz",
-      "integrity": "sha512-TClaQOLvo9WEMJv6GoUsykQ6QdynuKszuORFWCke8qvi6PeLm7FcD9+7y45UenysxEWYpDL5KJaVXTngTE+2BA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-2.0.3.tgz",
+      "integrity": "sha512-GMmfP8xEmUl0H7RXo4VTFYqAWzAADtlghA9perlm6mzuo0n/Ih+owh57ZLWBMMe/N1TUMis4SGJRvx31HtK3jg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "1.24.4",
-        "@shikijs/vscode-textmate": "^9.3.1",
-        "oniguruma-to-es": "0.8.1"
+        "@shikijs/types": "2.0.3",
+        "@shikijs/vscode-textmate": "^10.0.1",
+        "oniguruma-to-es": "^2.2.0"
       }
     },
     "node_modules/@shikijs/engine-oniguruma": {
-      "version": "1.24.4",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.24.4.tgz",
-      "integrity": "sha512-Do2ry6flp2HWdvpj2XOwwa0ljZBRy15HKZITzPcNIBOGSeprnA8gOooA/bLsSPuy8aJBa+Q/r34dMmC3KNL/zw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-2.0.3.tgz",
+      "integrity": "sha512-MicRzo0aNaS18yXBnXjYFLnzi5Sh3NUHtm/WXzavtpGiWd75gRdZsZDMceeFyTL9MMy9iGifK2JePXY5dlZHIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "1.24.4",
-        "@shikijs/vscode-textmate": "^9.3.1"
+        "@shikijs/types": "2.0.3",
+        "@shikijs/vscode-textmate": "^10.0.1"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-2.0.3.tgz",
+      "integrity": "sha512-L+QcwH6tjVY21xDxe3etR+C+33mAbkyQVvUIsszwnQrRVI54r7VPNTMVWR4EbZfPFwWmwLCoO83V5YiBWusvVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.0.3"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-2.0.3.tgz",
+      "integrity": "sha512-NFnArltjzmYAssn1SLIFlKX9HJEL9K12z0uBB0tg579hW6UHIXwfd+AhsaB/+cXYLix2YuN5uEPJpqtRN2zi0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.0.3"
       }
     },
     "node_modules/@shikijs/transformers": {
-      "version": "1.24.4",
-      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-1.24.4.tgz",
-      "integrity": "sha512-0jq5p9WLB7ToM/O7RWfxuIwirTJbIQsUR06jxdG3h3CEuO5m7ik8GnDsxwHhyIEfgJSZczSnVUZWFrNKy5It6g==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-2.0.3.tgz",
+      "integrity": "sha512-Y5qmHA2LyoXccq6IPP5AeGqialn54ZORPBxbyNH+NEbCaw1nTCCy+Tfm3idRkqYLZOw0yq+0MUSDWbGezHksow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "shiki": "1.24.4"
+        "@shikijs/core": "2.0.3",
+        "@shikijs/types": "2.0.3"
       }
     },
     "node_modules/@shikijs/types": {
-      "version": "1.24.4",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.24.4.tgz",
-      "integrity": "sha512-0r0XU7Eaow0PuDxuWC1bVqmWCgm3XqizIaT7SM42K03vc69LGooT0U8ccSR44xP/hGlNx4FKhtYpV+BU6aaKAA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-2.0.3.tgz",
+      "integrity": "sha512-jyP6NMdWkbBpEn3WqqH8TCfkzE52/hS7msKGJAvxcwyQQah7+hU8x7ejFhCVoxrBaW001v+ID4zl3wspcDSaaw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/vscode-textmate": "^9.3.1",
+        "@shikijs/vscode-textmate": "^10.0.1",
         "@types/hast": "^3.0.4"
       }
     },
     "node_modules/@shikijs/vscode-textmate": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-9.3.1.tgz",
-      "integrity": "sha512-79QfK1393x9Ho60QFyLti+QfdJzRQCVLFb97kOIV7Eo9vQU/roINgk7m24uv0a7AUvN//RDH36FLjjK48v0s9g==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.1.tgz",
+      "integrity": "sha512-fTIQwLF+Qhuws31iw7Ncl1R3HUDtGwIipiJ9iU+UsDUwMhegFcQKQHd51nZjb7CArq0MvON8rbgCGQYWHUKAdg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1240,23 +1261,23 @@
       }
     },
     "node_modules/@vue/devtools-api": {
-      "version": "7.6.8",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.6.8.tgz",
-      "integrity": "sha512-ma6dY/sZR36zALVsV1W7eC57c6IJPXsy8SNgZn1PLVWU4z4dPn5TIBmnF4stmdJ4sQcixqKaQ8pwjbMPzEZwiA==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.0.tgz",
+      "integrity": "sha512-bHEv6kT85BHtyGgDhE07bAUMAy7zpv6nnR004nSTd0wWMrAOtcrYoXO5iyr20Hkf5jR8obQOfS3byW+I3l2CCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/devtools-kit": "^7.6.8"
+        "@vue/devtools-kit": "^7.7.0"
       }
     },
     "node_modules/@vue/devtools-kit": {
-      "version": "7.6.8",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.6.8.tgz",
-      "integrity": "sha512-JhJ8M3sPU+v0P2iZBF2DkdmR9L0dnT5RXJabJqX6o8KtFs3tebdvfoXV2Dm3BFuqeECuMJIfF1aCzSt+WQ4wrw==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.0.tgz",
+      "integrity": "sha512-5cvZ+6SA88zKC8XiuxUfqpdTwVjJbvYnQZY5NReh7qlSGPvVDjjzyEtW+gdzLXNSd8tStgOjAdMCpvDQamUXtA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/devtools-shared": "^7.6.8",
+        "@vue/devtools-shared": "^7.7.0",
         "birpc": "^0.2.19",
         "hookable": "^5.5.3",
         "mitt": "^3.0.1",
@@ -1266,9 +1287,9 @@
       }
     },
     "node_modules/@vue/devtools-shared": {
-      "version": "7.6.8",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.6.8.tgz",
-      "integrity": "sha512-9MBPO5Z3X1nYGFqTJyohl6Gmf/J7UNN1oicHdyzBVZP4jnhZ4c20MgtaHDIzWmHDHCMYVS5bwKxT3jxh7gOOKA==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.0.tgz",
+      "integrity": "sha512-jtlQY26R5thQxW9YQTpXbI0HoK0Wf9Rd4ekidOkRvSy7ChfK0kIU6vvcBtjj87/EcpeOSK49fZAicaFNJcoTcQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1331,58 +1352,31 @@
       "license": "MIT"
     },
     "node_modules/@vueuse/core": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-11.3.0.tgz",
-      "integrity": "sha512-7OC4Rl1f9G8IT6rUfi9JrKiXy4bfmHhZ5x2Ceojy0jnd3mHNEvV4JaRygH362ror6/NZ+Nl+n13LPzGiPN8cKA==",
+      "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-12.4.0.tgz",
+      "integrity": "sha512-XnjQYcJwCsyXyIafyA6SvyN/OBtfPnjvJmbxNxQjCcyWD198urwm5TYvIUUyAxEAN0K7HJggOgT15cOlWFyLeA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/web-bluetooth": "^0.0.20",
-        "@vueuse/metadata": "11.3.0",
-        "@vueuse/shared": "11.3.0",
-        "vue-demi": ">=0.14.10"
+        "@vueuse/metadata": "12.4.0",
+        "@vueuse/shared": "12.4.0",
+        "vue": "^3.5.13"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
-      }
-    },
-    "node_modules/@vueuse/core/node_modules/vue-demi": {
-      "version": "0.14.10",
-      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
-      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "vue-demi-fix": "bin/vue-demi-fix.js",
-        "vue-demi-switch": "bin/vue-demi-switch.js"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      },
-      "peerDependencies": {
-        "@vue/composition-api": "^1.0.0-rc.1",
-        "vue": "^3.0.0-0 || ^2.6.0"
-      },
-      "peerDependenciesMeta": {
-        "@vue/composition-api": {
-          "optional": true
-        }
       }
     },
     "node_modules/@vueuse/integrations": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-11.3.0.tgz",
-      "integrity": "sha512-5fzRl0apQWrDezmobchoiGTkGw238VWESxZHazfhP3RM7pDSiyXy18QbfYkILoYNTd23HPAfQTJpkUc5QbkwTw==",
+      "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-12.4.0.tgz",
+      "integrity": "sha512-EZm+TLoZMeEwDnccnEqB54CvvcVKbVnJubOF380HqdyZAxWfQ8egnFCESdlXWEIbxFgjfhcGfZUvQx5Nqw9Ofw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vueuse/core": "11.3.0",
-        "@vueuse/shared": "11.3.0",
-        "vue-demi": ">=0.14.10"
+        "@vueuse/core": "12.4.0",
+        "@vueuse/shared": "12.4.0",
+        "vue": "^3.5.13"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
@@ -1440,37 +1434,10 @@
         }
       }
     },
-    "node_modules/@vueuse/integrations/node_modules/vue-demi": {
-      "version": "0.14.10",
-      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
-      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "vue-demi-fix": "bin/vue-demi-fix.js",
-        "vue-demi-switch": "bin/vue-demi-switch.js"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      },
-      "peerDependencies": {
-        "@vue/composition-api": "^1.0.0-rc.1",
-        "vue": "^3.0.0-0 || ^2.6.0"
-      },
-      "peerDependenciesMeta": {
-        "@vue/composition-api": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@vueuse/metadata": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-11.3.0.tgz",
-      "integrity": "sha512-pwDnDspTqtTo2HwfLw4Rp6yywuuBdYnPYDq+mO38ZYKGebCUQC/nVj/PXSiK9HX5otxLz8Fn7ECPbjiRz2CC3g==",
+      "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-12.4.0.tgz",
+      "integrity": "sha512-AhPuHs/qtYrKHUlEoNO6zCXufu8OgbR8S/n2oMw1OQuBQJ3+HOLQ+EpvXs+feOlZMa0p8QVvDWNlmcJJY8rW2g==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1478,43 +1445,16 @@
       }
     },
     "node_modules/@vueuse/shared": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-11.3.0.tgz",
-      "integrity": "sha512-P8gSSWQeucH5821ek2mn/ciCk+MS/zoRKqdQIM3bHq6p7GXDAJLmnRRKmF5F65sAVJIfzQlwR3aDzwCn10s8hA==",
+      "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-12.4.0.tgz",
+      "integrity": "sha512-9yLgbHVIF12OSCojnjTIoZL1+UA10+O4E1aD6Hpfo/DKVm5o3SZIwz6CupqGy3+IcKI8d6Jnl26EQj/YucnW0Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "vue-demi": ">=0.14.10"
+        "vue": "^3.5.13"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
-      }
-    },
-    "node_modules/@vueuse/shared/node_modules/vue-demi": {
-      "version": "0.14.10",
-      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
-      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "vue-demi-fix": "bin/vue-demi-fix.js",
-        "vue-demi-switch": "bin/vue-demi-switch.js"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      },
-      "peerDependencies": {
-        "@vue/composition-api": "^1.0.0-rc.1",
-        "vue": "^3.0.0-0 || ^2.6.0"
-      },
-      "peerDependenciesMeta": {
-        "@vue/composition-api": {
-          "optional": true
-        }
       }
     },
     "node_modules/algoliasearch": {
@@ -1710,9 +1650,9 @@
       "license": "MIT"
     },
     "node_modules/focus-trap": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.2.tgz",
-      "integrity": "sha512-9FhUxK1hVju2+AiQIDJ5Dd//9R2n2RAfJ0qfhF4IHGHgcoEUTMpbTeG/zbEuwaiYXfuAH6XE0/aCyxDdRM+W5w==",
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.4.tgz",
+      "integrity": "sha512-xx560wGBk7seZ6y933idtjJQc1l+ck+pI3sKvhKozdBV1dRZoKhkW5xoCaFv9tQiX5RH1xfSxjuNu6g+lmN/gw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1969,15 +1909,15 @@
       }
     },
     "node_modules/oniguruma-to-es": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-0.8.1.tgz",
-      "integrity": "sha512-dekySTEvCxCj0IgKcA2uUCO/e4ArsqpucDPcX26w9ajx+DvMWLc5eZeJaRQkd7oC/+rwif5gnT900tA34uN9Zw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-2.3.0.tgz",
+      "integrity": "sha512-bwALDxriqfKGfUufKGGepCzu9x7nJQuoRoAFp4AnwehhC2crqrDIAP/uN2qdlsAvSMpeRC3+Yzhqc7hLmle5+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex-xs": "^1.0.0",
-        "regex": "^5.0.2",
-        "regex-recursion": "^5.0.0"
+        "regex": "^5.1.1",
+        "regex-recursion": "^5.1.1"
       }
     },
     "node_modules/perfect-debounce": {
@@ -2128,17 +2068,19 @@
       "peer": true
     },
     "node_modules/shiki": {
-      "version": "1.24.4",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.24.4.tgz",
-      "integrity": "sha512-aVGSFAOAr1v26Hh/+GBIsRVDWJ583XYV7CuNURKRWh9gpGv4OdbisZGq96B9arMYTZhTQkmRF5BrShOSTvNqhw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-2.0.3.tgz",
+      "integrity": "sha512-njF3iF97mxWcEFxxB591EeVFgf5VPpXJKFIB3RCFSkcgINetMIb+9CfNInmzkz8BlPWlEEY1nSGd0F1807YhCg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/core": "1.24.4",
-        "@shikijs/engine-javascript": "1.24.4",
-        "@shikijs/engine-oniguruma": "1.24.4",
-        "@shikijs/types": "1.24.4",
-        "@shikijs/vscode-textmate": "^9.3.1",
+        "@shikijs/core": "2.0.3",
+        "@shikijs/engine-javascript": "2.0.3",
+        "@shikijs/engine-oniguruma": "2.0.3",
+        "@shikijs/langs": "2.0.3",
+        "@shikijs/themes": "2.0.3",
+        "@shikijs/types": "2.0.3",
+        "@shikijs/vscode-textmate": "^10.0.1",
         "@types/hast": "^3.0.4"
       }
     },
@@ -2323,9 +2265,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.4.11",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.11.tgz",
-      "integrity": "sha512-c7jFQRklXua0mTzneGW9QVyxFjUgwcihC4bXEtujIo2ouWCe1Ajt/amn2PCxYnhYfd5k09JX3SB7OYWFKYqj8Q==",
+      "version": "5.4.14",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.14.tgz",
+      "integrity": "sha512-EK5cY7Q1D8JNhSaPKVK4pwBFvaTmZxEnoKXLG/U9gmdDcihQGNzFlgIvaxezFR4glP1LsuiedwMBqCXH3wZccA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2383,30 +2325,30 @@
       }
     },
     "node_modules/vitepress": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.5.0.tgz",
-      "integrity": "sha512-q4Q/G2zjvynvizdB3/bupdYkCJe2umSAMv9Ju4d92E6/NXJ59z70xB0q5p/4lpRyAwflDsbwy1mLV9Q5+nlB+g==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.6.1.tgz",
+      "integrity": "sha512-n41KBL08aonxaWMnk5V+TkpZ29rZF4sgYjvIqU2k0foteNhgms5BmbVWw9xTqD5hps12H1W+EZUwc7NlHh1s3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@docsearch/css": "^3.6.2",
-        "@docsearch/js": "^3.6.2",
-        "@iconify-json/simple-icons": "^1.2.10",
-        "@shikijs/core": "^1.22.2",
-        "@shikijs/transformers": "^1.22.2",
-        "@shikijs/types": "^1.22.2",
+        "@docsearch/css": "^3.8.2",
+        "@docsearch/js": "^3.8.2",
+        "@iconify-json/simple-icons": "^1.2.20",
+        "@shikijs/core": "^2.0.0",
+        "@shikijs/transformers": "^2.0.0",
+        "@shikijs/types": "^2.0.0",
         "@types/markdown-it": "^14.1.2",
-        "@vitejs/plugin-vue": "^5.1.4",
-        "@vue/devtools-api": "^7.5.4",
-        "@vue/shared": "^3.5.12",
-        "@vueuse/core": "^11.1.0",
-        "@vueuse/integrations": "^11.1.0",
-        "focus-trap": "^7.6.0",
+        "@vitejs/plugin-vue": "^5.2.1",
+        "@vue/devtools-api": "^7.7.0",
+        "@vue/shared": "^3.5.13",
+        "@vueuse/core": "^12.4.0",
+        "@vueuse/integrations": "^12.4.0",
+        "focus-trap": "^7.6.4",
         "mark.js": "8.11.1",
-        "minisearch": "^7.1.0",
-        "shiki": "^1.22.2",
-        "vite": "^5.4.10",
-        "vue": "^3.5.12"
+        "minisearch": "^7.1.1",
+        "shiki": "^2.0.0",
+        "vite": "^5.4.12",
+        "vue": "^3.5.13"
       },
       "bin": {
         "vitepress": "bin/vitepress.js"

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "devDependencies": {
-    "vitepress": "^1.5.0"
+    "vitepress": "^1.6.1"
   },
   "scripts": {
     "start": "vitepress dev",

--- a/docs/public/videos/interactions-lasso-add-remove-dark.mp4
+++ b/docs/public/videos/interactions-lasso-add-remove-dark.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:588d51d200a87380e439793206f8a1fae882c75f1c66f9b58cdee8222557e83c
+size 949397

--- a/docs/public/videos/interactions-lasso-add-remove-light.mp4
+++ b/docs/public/videos/interactions-lasso-add-remove-light.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f44b4f897f0b5b442eabfefa03ca1bb3fd01f8c3c691c611753d608809d7a799
+size 980287

--- a/docs/public/videos/interactions-lasso-brush-dark.mp4
+++ b/docs/public/videos/interactions-lasso-brush-dark.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:89156053a5a67e9e4f2fdf75f9a3826bcbd99024b6bc96672c385c8f89bef250
+size 583275

--- a/docs/public/videos/interactions-lasso-brush-light.mp4
+++ b/docs/public/videos/interactions-lasso-brush-light.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:51936d7b3a8b1553ce81d1fb4cb9cd2f703e9ba834f3d100d838e1ee04a81ded
+size 562861

--- a/docs/public/videos/interactions-lasso-rectangle-dark.mp4
+++ b/docs/public/videos/interactions-lasso-rectangle-dark.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:91d338c106ffdcb135c8c81e0e111442edaab9f9e1672ea2df300bb4eac02d90
+size 650048

--- a/docs/public/videos/interactions-lasso-rectangle-light.mp4
+++ b/docs/public/videos/interactions-lasso-rectangle-light.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:47b8ff37f0ebffbef2c87b86f9ebdbd997b18535e684cb00f6328263d283d448
+size 602398

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -21,7 +21,7 @@
         "gl-matrix": "~3.3.0",
         "pub-sub-es": "~3.0.0",
         "regl": "~2.1.0",
-        "regl-scatterplot": "~1.13.0"
+        "regl-scatterplot": "~1.13.2"
       },
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
@@ -1152,9 +1152,9 @@
       }
     },
     "node_modules/regl-scatterplot": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/regl-scatterplot/-/regl-scatterplot-1.13.0.tgz",
-      "integrity": "sha512-KdhyWq0yTryzGECkDY1I3yANiPlQ/O4MdaTf8OF0MMvFDeCTzueT/Cpq6kGLPGskscNUczVqhhaeBzuZ2GtIrA==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/regl-scatterplot/-/regl-scatterplot-1.13.2.tgz",
+      "integrity": "sha512-UOQUdNW2mncL4f0sURz8yAg/ueqnX/KJ1O02xx0TC4RZQ3Df2aZnaLUf6lddKFo2zPd+H9uVSWfVRfugf+gb0w==",
       "license": "MIT",
       "dependencies": {
         "@flekschas/utils": "^0.32.2",

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -21,7 +21,7 @@
         "gl-matrix": "~3.3.0",
         "pub-sub-es": "~3.0.0",
         "regl": "~2.1.0",
-        "regl-scatterplot": "~1.12.0"
+        "regl-scatterplot": "~1.13.0"
       },
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
@@ -984,6 +984,12 @@
         "gl-matrix": "^3.3.0"
       }
     },
+    "node_modules/earcut": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.1.tgz",
+      "integrity": "sha512-0l1/0gOjESMeQyYaK5IDiPNvFeu93Z/cO0TjZh9eZ1vyCtZnA7KMZ8rQggpsJHIbGSdrqYq9OhuveadOVHCshw==",
+      "license": "ISC"
+    },
     "node_modules/esbuild": {
       "version": "0.24.0",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.0.tgz",
@@ -1146,13 +1152,14 @@
       }
     },
     "node_modules/regl-scatterplot": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/regl-scatterplot/-/regl-scatterplot-1.12.0.tgz",
-      "integrity": "sha512-fvPYfdgtm8Y7UFbpCc6TJQw2mhdHKBCl/OVNEiyuHm/QG6rb2Agukj5CPtTQo2I78uWPxtj1UaDlQm+jK1qjUA==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/regl-scatterplot/-/regl-scatterplot-1.13.0.tgz",
+      "integrity": "sha512-KdhyWq0yTryzGECkDY1I3yANiPlQ/O4MdaTf8OF0MMvFDeCTzueT/Cpq6kGLPGskscNUczVqhhaeBzuZ2GtIrA==",
       "license": "MIT",
       "dependencies": {
         "@flekschas/utils": "^0.32.2",
         "dom-2d-camera": "^2.2.6",
+        "earcut": "^3.0.1",
         "gl-matrix": "~3.4.3",
         "pub-sub-es": "~3.0.0",
         "regl": "~2.1.1",

--- a/js/package.json
+++ b/js/package.json
@@ -29,7 +29,7 @@
     "gl-matrix": "~3.3.0",
     "pub-sub-es": "~3.0.0",
     "regl": "~2.1.0",
-    "regl-scatterplot": "~1.12.0"
+    "regl-scatterplot": "~1.13.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",

--- a/js/package.json
+++ b/js/package.json
@@ -29,7 +29,7 @@
     "gl-matrix": "~3.3.0",
     "pub-sub-es": "~3.0.0",
     "regl": "~2.1.0",
-    "regl-scatterplot": "~1.13.0"
+    "regl-scatterplot": "~1.13.2"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",

--- a/js/src/codecs.js
+++ b/js/src/codecs.js
@@ -84,10 +84,13 @@ export function Numpy2D(dtype) {
      */
     serialize(data) {
       const height = data.length;
-      const width = data[0].length;
+      const width = height > 0 ? data[0].length : 0;
+      if (height === 0 || width === 0) {
+        return null;
+      }
       const arr = new DTYPES[dtype](height * width);
       for (let i = 0; i < data.length; i++) {
-        arr.set(data[i], i * height);
+        arr.set(data[i], i * width);
       }
       return {
         view: new DataView(arr.buffer),

--- a/js/src/histogram.js
+++ b/js/src/histogram.js
@@ -146,7 +146,7 @@ const createNumericalHistogramBackground = (canvas, data) => {
     ctx.clearRect(0, 0, canvas.width, canvas.height);
     ctx.fillStyle = state.color;
     for (const rect of state.rects) {
-      ctx.fillRect(rect.x, rect.y, rect.width, rect.height);
+      ctx.fillRect(rect.x, rect.y, state.binWidth, rect.height);
     }
   };
 

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -1202,11 +1202,9 @@ class JupyterScatterView {
   }
 
   enableTooltipHistograms() {
-    const display = Object.values(this.model.get('tooltip_histograms')).some(
-      (show) => show,
-    )
-      ? 'block'
-      : 'none';
+    const showHistograms = this.model.get('tooltip_histograms');
+    const display =
+      showHistograms === true || showHistograms.length > 0 ? 'block' : 'none';
     const histograms =
       this.tooltipContentProperties.querySelectorAll('.histogram');
 
@@ -3232,8 +3230,14 @@ class JupyterScatterView {
   }
 
   showHistogram(property) {
-    const histogram = this.model.get('tooltip_histograms');
-    return histogram.includes(property);
+    const histograms = this.model.get('tooltip_histograms');
+    if (histograms === true) {
+      return true;
+    }
+    if (histograms === false) {
+      return false;
+    }
+    return histograms.includes(property);
   }
 }
 

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -475,6 +475,9 @@ class JupyterScatterView {
             this.zoomToHandler(this.selection);
           }
         });
+
+        this.lassoStartHandlerBound = this.lassoStartHandler.bind(this);
+        this.scatterplot.subscribe('lassoStart', this.lassoStartHandlerBound);
       }
     });
 
@@ -529,6 +532,10 @@ class JupyterScatterView {
       this.toggleFullscreen();
       return;
     }
+  }
+
+  lassoStartHandler() {
+    this.hideTooltip();
   }
 
   getWidth() {

--- a/jscatter/jscatter.py
+++ b/jscatter/jscatter.py
@@ -39,7 +39,6 @@ from .types import (
     Color,
     Scales,
     MouseModes,
-    Auto,
     Reverse,
     Segment,
     Size,
@@ -438,7 +437,7 @@ class Scatter:
         self._tooltip_properties = visual_properties.copy()
         self._tooltip_properties_non_visual = None
         self._tooltip_size = 'small'
-        self._tooltip_histograms = True
+        self._tooltip_histograms = self._tooltip_properties.copy()
         self._tooltip_histograms_bins = DEFAULT_HISTOGRAM_BINS
         self._tooltip_histograms_ranges = {}
         self._tooltip_histograms_size = 'small'
@@ -448,6 +447,7 @@ class Scatter:
         self._tooltip_preview_image_background_color = 'auto'
         self._tooltip_preview_image_position = 'center'
         self._tooltip_preview_image_size = 'contain'
+        self._tooltip_preview_image_height = None
         self._tooltip_preview_audio_length = None
         self._tooltip_preview_audio_loop = False
         self._tooltip_preview_audio_controls = True
@@ -563,6 +563,7 @@ class Scatter:
             kwargs.get('tooltip_preview_image_background_color', UNDEF),
             kwargs.get('tooltip_preview_image_position', UNDEF),
             kwargs.get('tooltip_preview_image_size', UNDEF),
+            kwargs.get('tooltip_preview_image_height', UNDEF),
             kwargs.get('tooltip_preview_audio_length', UNDEF),
             kwargs.get('tooltip_preview_audio_loop', UNDEF),
             kwargs.get('tooltip_preview_audio_controls', UNDEF),
@@ -3734,7 +3735,7 @@ class Scatter:
         self,
         enable: Optional[Union[bool, Undefined]] = UNDEF,
         properties: Optional[Union[List[VisualProperty], Undefined]] = UNDEF,
-        histograms: Optional[Union[bool, Undefined]] = UNDEF,
+        histograms: Optional[Union[bool, List[str], Undefined]] = UNDEF,
         histograms_bins: Optional[Union[int, Dict[str, int], Undefined]] = UNDEF,
         histograms_ranges: Optional[
             Union[Tuple[float], Dict[str, Tuple[float]], Undefined]
@@ -3748,6 +3749,7 @@ class Scatter:
             Union[TooltipPreviewImagePosition, str, Undefined]
         ] = UNDEF,
         preview_image_size: Optional[Union[TooltipPreviewImageSize, Undefined]] = UNDEF,
+        preview_image_height: Optional[Union[int, Undefined]] = UNDEF,
         preview_audio_length: Optional[Union[int, Undefined]] = UNDEF,
         preview_audio_loop: Optional[Union[bool, int, Undefined]] = UNDEF,
         preview_audio_controls: Optional[Union[bool, Undefined]] = UNDEF,
@@ -3767,10 +3769,11 @@ class Scatter:
             actually used to encode data properties. To reference other data
             properties that are not visually encoded, specify a column of the
             bound DataFrame by its name.
-        histograms : bool, optional
-            When set to `True`, the tooltip will show histograms of the
-            properties
-        histograms_bins : int, optional
+        histograms : bool or list, optional
+            When set to `True`, the tooltip will show histograms for all
+            properties. Alternatively, you can provide a list of
+            properties for which you want to show a histogram.
+        histograms_bins : int or dict, optional
             The number of bins for all numerical histograms. Or a dictionary of
             property-specific number of bins. Defaults to 20.
         histograms_ranges : (float, float) or dict of (float, float), optional
@@ -3805,6 +3808,8 @@ class Scatter:
             The size of the image in the context of the preview area. This can
             be one of `"cover"` or `"contain"` and is set to `"contain"` by
             default.
+        preview_image_height : int, optional
+            The height of the image container pixels. This defaults to 6em.
         preview_audio_length : int or None, optional
             The number of seconds that should be played as the audio preview. By
             default (`None`), the audio file is played from the start to the
@@ -3935,6 +3940,10 @@ class Scatter:
             self._tooltip_preview_image_size = preview_image_size
             self.update_widget('tooltip_preview_image_size', preview_image_size)
 
+        if preview_image_height is not UNDEF:
+            self._tooltip_preview_image_height = preview_image_height
+            self.update_widget('tooltip_preview_image_height', preview_image_height)
+
         if preview_audio_length is not UNDEF:
             try:
                 self._tooltip_preview_audio_length = max(0, preview_audio_length)
@@ -3961,9 +3970,16 @@ class Scatter:
             self.update_widget('tooltip_preview', preview)
 
         if properties is not UNDEF:
+            current_tooltip_properties = self._tooltip_properties.copy()
+
             self._tooltip_properties = sanitize_tooltip_properties(
                 self._data, visual_properties, properties
             )
+
+            # Let's automatically enable histograms for newly added properties
+            for prop in self._tooltip_properties:
+                if prop not in current_tooltip_properties:
+                    self._tooltip_histograms.append(prop)
 
             self._tooltip_histograms_bins = {
                 property: get_histogram_bins(self._tooltip_histograms_bins, property)
@@ -3980,8 +3996,15 @@ class Scatter:
             self.update_widget('tooltip_size', size)
 
         if histograms is not UNDEF:
-            self._tooltip_histograms = histograms
-            self.update_widget('tooltip_histograms', histograms)
+            if type(histograms) is bool:
+                if histograms:
+                    self._tooltip_histograms = self._tooltip_properties.copy()
+                else:
+                    self._tooltip_histograms = []
+            else:
+                self._tooltip_histograms = histograms
+
+        self.update_widget('tooltip_histograms', self._tooltip_histograms)
 
         if histograms_size is not UNDEF:
             self._tooltip_histograms_size = histograms_size
@@ -4018,7 +4041,7 @@ class Scatter:
             self.update_widget('y_histogram', self._y_histogram)
 
             if self._color_by is not None and self._color_categories is None:
-                component = self._encodings.data[self._color_by].component
+                component = self._encodings.data[self._color_data_dimension].component
                 self._color_histogram = get_histogram_from_df(
                     self._points[:, component],
                     self.get_histogram_bins('color'),
@@ -4034,7 +4057,7 @@ class Scatter:
                 and self._opacity_by != 'density'
                 and self._opacity_categories is None
             ):
-                component = self._encodings.data[self._opacity_by].component
+                component = self._encodings.data[self._opacity_data_dimension].component
                 self._opacity_histogram = get_histogram_from_df(
                     self._points[:, component],
                     self.get_histogram_bins('opacity'),
@@ -4046,7 +4069,7 @@ class Scatter:
                 self.update_widget('opacity_histogram', self._opacity_histogram)
 
             if self._size_by is not None and self._size_categories is None:
-                component = self._encodings.data[self._size_by].component
+                component = self._encodings.data[self._size_data_dimension].component
                 self._size_histogram = get_histogram_from_df(
                     self._points[:, component],
                     self.get_histogram_bins('size'),
@@ -4068,15 +4091,28 @@ class Scatter:
 
             self._tooltip_properties_non_visual_info = {}
             for property in self._tooltip_properties_non_visual:
-                self._tooltip_properties_non_visual_info[property] = dict(
-                    scale=get_scale_type_from_df(self._data[property]),
-                    domain=get_domain_from_df(self._data[property]),
-                    range=self.get_histogram_range(property),
-                    histogram=get_histogram_from_df(
+                scale = None
+                domain = None
+                range = None
+                histogram = None
+
+                if property in self._tooltip_histograms:
+                    scale = get_scale_type_from_df(self._data[property])
+
+                if scale is not None:
+                    domain = get_domain_from_df(self._data[property])
+                    range = self.get_histogram_range(property)
+                    histogram = get_histogram_from_df(
                         self._data[property],
                         self.get_histogram_bins(property),
                         self.get_histogram_range(property),
-                    ),
+                    )
+
+                self._tooltip_properties_non_visual_info[property] = dict(
+                    scale=scale,
+                    domain=domain,
+                    range=range,
+                    histogram=histogram,
                 )
 
             self.update_widget(
@@ -4094,6 +4130,16 @@ class Scatter:
                 histograms_bins,
                 histograms_ranges,
                 histograms_size,
+                preview,
+                preview_type,
+                preview_text_lines,
+                preview_image_background_color,
+                preview_image_position,
+                preview_image_size,
+                preview_image_height,
+                preview_audio_length,
+                preview_audio_loop,
+                preview_audio_controls,
             ],
             UNDEF,
         ):
@@ -4112,6 +4158,7 @@ class Scatter:
             preview_image_background_color=self._tooltip_preview_image_background_color,
             preview_image_position=self._tooltip_preview_image_position,
             preview_image_size=self._tooltip_preview_image_size,
+            preview_image_height=self._tooltip_preview_image_height,
             preview_audio_length=self._tooltip_preview_audio_length,
             preview_audio_loop=self._tooltip_preview_audio_loop,
             preview_audio_controls=self._tooltip_preview_audio_controls,
@@ -4204,10 +4251,10 @@ class Scatter:
         >>> scatter.zoom(target=[0, 1, 2])
         <jscatter.jscatter.Scatter>
 
-        >>> scatter.zoom(target=scatter.selection(), animation=True)
+        >>> scatter.zoom(to=scatter.selection(), animation=True)
         <jscatter.jscatter.Scatter>
 
-        >>> scatter.zoom(target=None, animation=500, padding=0)
+        >>> scatter.zoom(to=None, animation=500, padding=0)
         <jscatter.jscatter.Scatter>
 
         >>> scatter.zoom()
@@ -4591,6 +4638,7 @@ class Scatter:
             tooltip_preview_image_background_color=self._tooltip_preview_image_background_color,
             tooltip_preview_image_position=self._tooltip_preview_image_position,
             tooltip_preview_image_size=self._tooltip_preview_image_size,
+            tooltip_preview_image_height=self._tooltip_preview_image_height,
             tooltip_preview_audio_length=self._tooltip_preview_audio_length,
             tooltip_preview_audio_loop=self._tooltip_preview_audio_loop,
             tooltip_preview_audio_controls=self._tooltip_preview_audio_controls,

--- a/jscatter/jscatter.py
+++ b/jscatter/jscatter.py
@@ -437,7 +437,7 @@ class Scatter:
         self._tooltip_properties = visual_properties.copy()
         self._tooltip_properties_non_visual = None
         self._tooltip_size = 'small'
-        self._tooltip_histograms = self._tooltip_properties.copy()
+        self._tooltip_histograms = True
         self._tooltip_histograms_bins = DEFAULT_HISTOGRAM_BINS
         self._tooltip_histograms_ranges = {}
         self._tooltip_histograms_size = 'small'
@@ -3970,16 +3970,9 @@ class Scatter:
             self.update_widget('tooltip_preview', preview)
 
         if properties is not UNDEF:
-            current_tooltip_properties = self._tooltip_properties.copy()
-
             self._tooltip_properties = sanitize_tooltip_properties(
                 self._data, visual_properties, properties
             )
-
-            # Let's automatically enable histograms for newly added properties
-            for prop in self._tooltip_properties:
-                if prop not in current_tooltip_properties:
-                    self._tooltip_histograms.append(prop)
 
             self._tooltip_histograms_bins = {
                 property: get_histogram_bins(self._tooltip_histograms_bins, property)
@@ -3996,15 +3989,8 @@ class Scatter:
             self.update_widget('tooltip_size', size)
 
         if histograms is not UNDEF:
-            if type(histograms) is bool:
-                if histograms:
-                    self._tooltip_histograms = self._tooltip_properties.copy()
-                else:
-                    self._tooltip_histograms = []
-            else:
-                self._tooltip_histograms = histograms
-
-        self.update_widget('tooltip_histograms', self._tooltip_histograms)
+            self._tooltip_histograms = histograms
+            self.update_widget('tooltip_histograms', self._tooltip_histograms)
 
         if histograms_size is not UNDEF:
             self._tooltip_histograms_size = histograms_size
@@ -4096,7 +4082,10 @@ class Scatter:
                 range = None
                 histogram = None
 
-                if property in self._tooltip_histograms:
+                if (
+                    self._tooltip_histograms == True
+                    or property in self._tooltip_histograms
+                ):
                     scale = get_scale_type_from_df(self._data[property])
 
                 if scale is not None:

--- a/jscatter/jscatter.py
+++ b/jscatter/jscatter.py
@@ -326,11 +326,13 @@ class Scatter:
         )
 
         self._annotations = None
+        self._lasso_type = 'freeform'
         self._lasso_color = (0, 0.666666667, 1, 1)
         self._lasso_on_long_press = True
         self._lasso_initiator = False
         self._lasso_min_delay = 10
         self._lasso_min_dist = 3
+        self._lasso_brush_size = 24
         self._x_data = None
         self._x_by = None
         self._x_histogram = None
@@ -521,11 +523,13 @@ class Scatter:
             kwargs.get('connection_size_labeling', UNDEF),
         )
         self.lasso(
+            kwargs.get('lasso_type', UNDEF),
             kwargs.get('lasso_color', UNDEF),
             kwargs.get('lasso_initiator', UNDEF),
             kwargs.get('lasso_min_delay', UNDEF),
             kwargs.get('lasso_min_dist', UNDEF),
             kwargs.get('lasso_on_long_press', UNDEF),
+            kwargs.get('lasso_brush_size', UNDEF),
         )
         self.reticle(kwargs.get('reticle', UNDEF), kwargs.get('reticle_color', UNDEF))
         self.mouse(kwargs.get('mouse_mode', UNDEF))
@@ -3215,17 +3219,22 @@ class Scatter:
 
     def lasso(
         self,
+        type: Optional[Union[bool, Undefined]] = UNDEF,
         color: Optional[Union[Color, Undefined]] = UNDEF,
         initiator: Optional[Union[bool, Undefined]] = UNDEF,
         min_delay: Optional[Union[int, Undefined]] = UNDEF,
         min_dist: Optional[Union[float, Undefined]] = UNDEF,
         on_long_press: Optional[Union[bool, Undefined]] = UNDEF,
+        brush_size: Optional[Union[bool, Undefined]] = UNDEF,
     ):
         """
         Set or get the lasso settings.
 
         Parameters
         ----------
+        type : str, optional
+            The lasso type. Must be one of `'freeform'`, `'brush'`, or
+            `'rectangle'`. Defaults to `'freeform'`.
         color : matplotlib compatible color, optional
             The lasso color
         initiator : bool, optional
@@ -3245,6 +3254,9 @@ class Scatter:
             a high-resolution lasso.
         on_long_press : bool, optional
             When set to `True`, the lasso is activated upon a long press.
+        brush_size : int, optional
+            The size of the brush in pixel. This has only an effect if `type` is
+            set to `'brush'`'. Defaults to `24`.
 
         Returns
         -------
@@ -3263,6 +3275,9 @@ class Scatter:
 
         Examples
         --------
+        >>> scatter.lasso(type='brush')
+        <jscatter.jscatter.Scatter>
+
         >>> scatter.lasso(color='red')
         <jscatter.jscatter.Scatter>
 
@@ -3278,13 +3293,25 @@ class Scatter:
         >>> scatter.lasso(on_long_press=False)
         <jscatter.jscatter.Scatter>
 
+        >>> scatter.lasso(brush_size=64)
+        <jscatter.jscatter.Scatter>
+
         >>> scatter.lasso()
-        {'color': (0, 0.666666667, 1, 1),
+        {'type': 'brush',
+         'color': (0, 0.666666667, 1, 1),
          'initiator': False,
          'min_delay': 10,
          'min_dist': 3,
-         'on_long_press': True}
+         'on_long_press': True,
+         'brush_size': 64}
         """
+        if type is not UNDEF:
+            try:
+                self._lasso_type = type
+                self.update_widget('lasso_type', self._lasso_type)
+            except:
+                pass
+
         if color is not UNDEF:
             try:
                 self._lasso_color = to_rgba(color)
@@ -3320,15 +3347,27 @@ class Scatter:
             except:
                 pass
 
-        if any_not([color, initiator, min_delay, min_dist], UNDEF):
+        if brush_size is not UNDEF:
+            try:
+                self._lasso_brush_size = brush_size
+                self.update_widget('lasso_brush_size', self._lasso_brush_size)
+            except:
+                pass
+
+        if any_not(
+            [type, color, initiator, min_delay, min_dist, on_long_press, brush_size],
+            UNDEF,
+        ):
             return self
 
         return dict(
+            type=self._lasso_type,
             color=self._lasso_color,
             initiator=self._lasso_initiator,
             min_delay=self._lasso_min_delay,
             min_dist=self._lasso_min_dist,
             on_long_press=self._lasso_on_long_press,
+            brush_size=self._lasso_brush_size,
         )
 
     def width(self, width: Optional[Union[Auto, int, Undefined]] = UNDEF):
@@ -4507,6 +4546,8 @@ class Scatter:
             lasso_min_delay=self._lasso_min_delay,
             lasso_min_dist=self._lasso_min_dist,
             lasso_on_long_press=self._lasso_on_long_press,
+            lasso_type=self._lasso_type,
+            lasso_brush_size=self._lasso_brush_size,
             legend=self._legend,
             legend_color=self.get_legend_color(),
             legend_encoding=self.get_legend_encoding(),

--- a/jscatter/utils.py
+++ b/jscatter/utils.py
@@ -89,6 +89,10 @@ def to_scale_type(norm=None):
 
 def get_scale_type_from_df(data):
     if pd.CategoricalDtype.is_dtype(data) or pd.api.types.is_string_dtype(data):
+        if data.nunique() == len(data):
+            # When the number of unique values is the same as the data, then
+            # the data is not nominal
+            return None
         return 'categorical'
 
     return 'linear'
@@ -101,7 +105,7 @@ def get_domain_from_df(data):
         _data = data.copy().astype(str).astype('category')
         return dict(zip(_data, _data.cat.codes))
 
-    return [data.min(), data.max()]
+    return [data.min(skipna=True), data.max(skipna=True)]
 
 
 def create_labeling(partial_labeling, column: Union[str, None] = None) -> Labeling:

--- a/jscatter/widget.py
+++ b/jscatter/widget.py
@@ -16,7 +16,7 @@ from .annotations_traits import (
     serialization as annotation_serialization,
 )
 from .types import UNDEF, Undefined, WidgetButtons
-from .widgets import Button, ButtonChoice, ButtonIntSlider
+from .widgets import Button, ButtonChoice, ButtonIntSlider, Divider
 
 SELECTION_DTYPE = 'uint32'
 EVENT_TYPES = {
@@ -29,15 +29,7 @@ EVENT_TYPES = {
 BRUSH_SIZE_MIN = 1
 BRUSH_SIZE_MAX = 128
 
-divider = widgets.Box(
-    children=[],
-    layout=widgets.Layout(
-        margin='10px 0',
-        width='100%',
-        height='0',
-        border='1px solid var(--jp-layout-color2)',
-    ),
-)
+divider = Divider()
 
 
 def component_idx_to_name(idx):
@@ -472,27 +464,21 @@ class JupyterScatter(anywidget.AnyWidget):
         button.on_click(click_handler)
         return button
 
-    def create_mouse_mode_toggle_button(
-        self,
-        mouse_mode,
-        icon,
-        tooltip,
-    ):
-        button = widgets.Button(
+    def create_mouse_mode_toggle_button(self, mouse_mode, icon, tooltip, width=36):
+        button = Button(
             description='',
             icon=icon,
             tooltip=tooltip,
-            button_style='primary' if self.mouse_mode == mouse_mode else '',
+            width=width,
+            style='primary' if self.mouse_mode == mouse_mode else '',
         )
 
-        button.layout.width = '36px'
-
         def click_handler(b):
-            button.button_style = 'primary'
+            button.style = 'primary'
             self.mouse_mode = mouse_mode
 
         def change_handler(change):
-            button.button_style = 'primary' if change['new'] == mouse_mode else ''
+            button.style = 'primary' if change['new'] == mouse_mode else ''
 
         self.observe(change_handler, names=['mouse_mode'])
 

--- a/jscatter/widget.py
+++ b/jscatter/widget.py
@@ -221,7 +221,7 @@ class JupyterScatter(anywidget.AnyWidget):
         sync=True
     )
     tooltip_properties_non_visual_info = Dict(dict()).tag(sync=True)
-    tooltip_histograms = Bool().tag(sync=True)
+    tooltip_histograms = List().tag(sync=True)
     tooltip_histograms_ranges = Dict(dict()).tag(sync=True)
     tooltip_histograms_size = Enum(
         ['small', 'medium', 'large'], default_value='small'
@@ -242,6 +242,7 @@ class JupyterScatter(anywidget.AnyWidget):
     tooltip_preview_image_size = Enum(
         ['contain', 'cover'], allow_none=True, default_value=None
     ).tag(sync=True)
+    tooltip_preview_image_height = Int(None, allow_none=True).tag(sync=True)
     tooltip_preview_audio_length = Int(None, allow_none=True).tag(sync=True)
     tooltip_preview_audio_loop = Bool().tag(sync=True)
     tooltip_preview_audio_controls = Bool().tag(sync=True)

--- a/jscatter/widget.py
+++ b/jscatter/widget.py
@@ -16,6 +16,7 @@ from .annotations_traits import (
     serialization as annotation_serialization,
 )
 from .types import UNDEF, Undefined, WidgetButtons
+from .widgets import Button, ButtonChoice, ButtonIntSlider
 
 SELECTION_DTYPE = 'uint32'
 EVENT_TYPES = {
@@ -25,6 +26,8 @@ EVENT_TYPES = {
     'VIEW_RESET': 'view_reset',
     'VIEW_SAVE': 'view_save',
 }
+BRUSH_SIZE_MIN = 1
+BRUSH_SIZE_MAX = 128
 
 divider = widgets.Box(
     children=[],
@@ -70,6 +73,8 @@ def array_to_binary(ar, obj=None, force_contiguous=True):
 
 
 def binary_to_array(value, obj=None):
+    if value is None:
+        return None
     return np.frombuffer(value['view'], dtype=value['dtype']).reshape(value['shape'])
 
 
@@ -174,8 +179,17 @@ class JupyterScatter(anywidget.AnyWidget):
     mouse_mode = Enum(['panZoom', 'lasso', 'rotate'], default_value='panZoom').tag(
         sync=True
     )
+    lasso_type = Enum(['freeform', 'brush', 'rectangle'], default_value='freeform').tag(
+        sync=True
+    )
     lasso_initiator = Bool().tag(sync=True)
     lasso_on_long_press = Bool().tag(sync=True)
+    lasso_selection_polygon = Array(
+        default_value=None,
+        allow_none=True,
+        read_only=True,
+    ).tag(sync=True, **ndarray_serialization)
+    lasso_brush_size = Int(24, min=BRUSH_SIZE_MIN, max=BRUSH_SIZE_MAX).tag(sync=True)
 
     # Axes
     axes = Bool().tag(sync=True)
@@ -485,6 +499,62 @@ class JupyterScatter(anywidget.AnyWidget):
         button.on_click(click_handler)
         return button
 
+    def create_lasso_type_button(self):
+        button = ButtonChoice(
+            icon={
+                'freeform': '<svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><path stroke-width="2px" stroke="currentColor" fill="none" d="m15.99958,27.5687c-1.8418,-0.3359 -3.71385,-1.01143 -5.49959,-2.04243c-6.69178,-3.8635 -9.65985,-11.26864 -6.62435,-16.52628c3.0355,-5.25764 10.93258,-6.38978 17.62435,-2.52628c6.1635,3.5585 9.16819,10.12222 7.23126,15.24508"/><circle stroke-width="2px" stroke="currentColor" fill="none" r="3" cy="25" cx="27"/></svg>',
+                'brush': '<svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><path stroke-width="2px" stroke="currentColor" fill="none" d="m25.985,26.755c-5.345,2.455 -10.786,2.981 -14.455,1.899c-3.449,-1.017 -5.53,-3.338 -5.53,-6.654c0,-3.33 1.705,-4.929 3.835,-6.127c0.894,-0.503 1.88,-0.912 2.738,-1.451c0.786,-0.493 1.427,-1.143 1.427,-2.422c0,-1.692 -1.552,-2.769 -3.177,-3.649c-3.177,-1.722 -7.152,-2.378 -7.152,-2.378l0.658,-3.946c0,0 4.665,0.784 8.4,2.806c2.987,1.618 5.271,4.055 5.271,7.167c0,3.33 -1.705,4.929 -3.835,6.127c-0.894,0.503 -1.88,0.912 -2.738,1.451c-0.786,0.493 -1.427,1.143 -1.427,2.422c0,1.486 1.117,2.362 2.662,2.818c2.897,0.854 7.122,0.332 11.338,-1.551"/><circle stroke-width="2px" stroke="currentColor" fill="none" r="3" cy="24" cx="27"/></svg>',
+                'rectangle': '<svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><circle  stroke-width="2px" stroke="currentColor" fill="none" r="3" cy="24" cx="27"/><path stroke-linecap="square" stroke-width="2px" stroke="currentColor" fill="none" d="m24,24l-22,0l0,-19l25,0l0,16"/></svg>',
+            },
+            tooltip='Lasso Type',
+            width=36,
+            value=self.lasso_type,
+            options={
+                'freeform': 'Freeform',
+                'brush': 'Brush',
+                'rectangle': 'Rectangle',
+            },
+        )
+
+        def internal_change_handler(change):
+            self.lasso_type = change['new']
+
+        button.observe(internal_change_handler, names=['value'])
+
+        def change_handler(change):
+            button.value = change['new']
+
+        self.observe(change_handler, names=['lasso_type'])
+
+        return button
+
+    def create_lasso_brush_size_button(self):
+        button = ButtonIntSlider(
+            icon='<svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><circle fill="currentColor" r="3" cx="5" cy="16" /><circle fill="currentColor" r="9" cx="21" cy="16" /><path stroke-dasharray="0.5,1.5,0,0,0,0" stroke-width="1px" stroke="currentColor" fill="none" d="m5,13.717l12.378,-5.38l0.031,15.353l-12.409,-5.363l0,-4.61z"/></svg>',
+            tooltip='Brush Size',
+            width=36,
+            slider_label='Brush Size',
+            slider_label_value_suffix='px',
+            slider_label_width=32,
+            slider_width=128,
+            value=self.lasso_brush_size,
+            value_min=BRUSH_SIZE_MIN,
+            value_max=BRUSH_SIZE_MAX,
+            value_step=1,
+        )
+
+        def internal_change_handler(change):
+            self.lasso_brush_size = change['new']
+
+        button.observe(internal_change_handler, names=['value'])
+
+        def change_handler(change):
+            button.value = change['new']
+
+        self.observe(change_handler, names=['lasso_brush_size'])
+
+        return button
+
     def show(
         self, buttons: t.Optional[t.Union[t.List[WidgetButtons], Undefined]] = UNDEF
     ):
@@ -510,6 +580,8 @@ class JupyterScatter(anywidget.AnyWidget):
         button_view_download = self.create_download_view_button()
         button_view_reset = self.create_reset_view_button()
         button_full_screen = self.create_full_screen_button()
+        button_lasso_type = self.create_lasso_type_button()
+        button_lasso_brush_size = self.create_lasso_brush_size_button()
 
         button_map = {
             'pan_zoom': button_pan_zoom,
@@ -519,6 +591,8 @@ class JupyterScatter(anywidget.AnyWidget):
             'reset': button_view_reset,
             'full_screen': button_full_screen,
             'divider': divider,
+            'lasso_type': button_lasso_type,
+            'lasso_brush_size': button_lasso_brush_size,
         }
 
         if buttons is not UNDEF:
@@ -529,10 +603,12 @@ class JupyterScatter(anywidget.AnyWidget):
             button_widgets = [
                 button_pan_zoom,
                 button_lasso,
+                button_lasso_type,
+                button_lasso_brush_size,
                 # button_rotate,
                 divider,
                 button_full_screen,
-                button_view_save,
+                # button_view_save,
                 button_view_download,
                 button_view_reset,
             ]
@@ -554,98 +630,3 @@ class JupyterScatter(anywidget.AnyWidget):
         self.observe(camera_is_fixed_change_handler, names=['camera_is_fixed'])
 
         return widgets.VBox([widgets.HBox([buttons, plots])])
-
-
-class Button(anywidget.AnyWidget):
-    _esm = """
-    function render({ model, el }) {
-      const button = document.createElement('button');
-
-      button.classList.add('jupyter-widgets');
-      button.classList.add('jupyter-button');
-      button.classList.add('widget-button');
-
-      const update = () => {
-        const description = model.get('description');
-        const icon = model.get('icon');
-        const tooltip = model.get('tooltip');
-        const width = model.get('width');
-
-        button.textContent = '';
-
-        if (icon) {
-          const i = document.createElement('i');
-          i.classList.add('fa', `fa-${icon}`);
-
-          if (!description) {
-            i.classList.add('center');
-          }
-
-          button.appendChild(i);
-        }
-
-        if (description) {
-          button.appendChild(document.createTextNode(description));
-        }
-
-        if (tooltip) {
-          button.title = tooltip;
-        }
-
-        if (width) {
-          button.style.width = `${width}px`;
-        }
-      }
-
-      const createEventHandler = (eventType) => (event) => {
-        model.send({
-          type: eventType,
-          alt_key: event.altKey,
-          shift_key: event.shiftKey,
-          meta_key: event.metaKey,
-        });
-      }
-
-      const clickHandler = createEventHandler('click');
-      const dblclickHandler = createEventHandler('dblclick');
-
-      button.addEventListener('click', clickHandler);
-      button.addEventListener('dblclick', dblclickHandler);
-
-      model.on('change:description', update);
-      model.on('change:icon', update);
-      model.on('change:width', update);
-      model.on('change:tooltip', update);
-
-      update();
-
-      el.appendChild(button);
-
-      return () => {
-        button.removeEventListener('click', clickHandler);
-        button.removeEventListener('dblclick', dblclickHandler);
-      };
-    }
-    export default { render }
-    """
-
-    description = Unicode().tag(sync=True)
-    icon = Unicode().tag(sync=True)
-    width = Int(allow_none=True).tag(sync=True)
-
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        self._click_handler = None
-        self.on_msg(self._handle_custom_msg)
-
-    def _handle_custom_msg(self, event: dict, buffers):
-        if event['type'] == 'click' and self._click_handler is not None:
-            self._click_handler(event)
-        if event['type'] == 'dblclick' and self._dblclick_handler is not None:
-            self._dblclick_handler(event)
-
-    def on_click(self, callback):
-        self._click_handler = callback
-
-    def on_dblclick(self, callback):
-        self._dblclick_handler = callback

--- a/jscatter/widget.py
+++ b/jscatter/widget.py
@@ -221,7 +221,7 @@ class JupyterScatter(anywidget.AnyWidget):
         sync=True
     )
     tooltip_properties_non_visual_info = Dict(dict()).tag(sync=True)
-    tooltip_histograms = List().tag(sync=True)
+    tooltip_histograms = Union([Bool(), List()]).tag(sync=True)
     tooltip_histograms_ranges = Dict(dict()).tag(sync=True)
     tooltip_histograms_size = Enum(
         ['small', 'medium', 'large'], default_value='small'

--- a/jscatter/widget.py
+++ b/jscatter/widget.py
@@ -582,6 +582,12 @@ class JupyterScatter(anywidget.AnyWidget):
         button_full_screen = self.create_full_screen_button()
         button_lasso_type = self.create_lasso_type_button()
         button_lasso_brush_size = self.create_lasso_brush_size_button()
+        button_lasso_brush_size.visible = self.lasso_type == 'brush'
+
+        def lasso_type_change_handler(change):
+            button_lasso_brush_size.visible = change['new'] == 'brush'
+
+        self.observe(lasso_type_change_handler, names=['lasso_type'])
 
         button_map = {
             'pan_zoom': button_pan_zoom,

--- a/jscatter/widgets/__init__.py
+++ b/jscatter/widgets/__init__.py
@@ -1,3 +1,4 @@
 from .button import Button
 from .button_choice import ButtonChoice
 from .button_slider import ButtonIntSlider
+from .divider import Divider

--- a/jscatter/widgets/__init__.py
+++ b/jscatter/widgets/__init__.py
@@ -1,0 +1,3 @@
+from .button import Button
+from .button_choice import ButtonChoice
+from .button_slider import ButtonIntSlider

--- a/jscatter/widgets/button.py
+++ b/jscatter/widgets/button.py
@@ -1,6 +1,6 @@
 import anywidget
 
-from traitlets import Int, Unicode
+from traitlets import Bool, Int, Unicode
 
 
 class Button(anywidget.AnyWidget):
@@ -73,6 +73,19 @@ class Button(anywidget.AnyWidget):
 
       update();
 
+      const updateVisibility = () => {
+        const visible = model.get('visible');
+        if (visible) {
+          el.style.display = 'block';
+        } else {
+          el.style.display = 'none';
+        }
+      }
+
+      model.on('change:visible', updateVisibility);
+
+      updateVisibility();
+
       el.appendChild(button);
 
       return () => {
@@ -97,6 +110,7 @@ class Button(anywidget.AnyWidget):
     description = Unicode().tag(sync=True)
     icon = Unicode().tag(sync=True)
     width = Int(allow_none=True).tag(sync=True)
+    visible = Bool(True).tag(sync=True)
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/jscatter/widgets/button.py
+++ b/jscatter/widgets/button.py
@@ -1,6 +1,6 @@
 import anywidget
 
-from traitlets import Bool, Int, Unicode
+from traitlets import Bool, Enum, Int, Unicode
 
 
 class Button(anywidget.AnyWidget):
@@ -20,6 +20,7 @@ class Button(anywidget.AnyWidget):
         const icon = model.get('icon');
         const tooltip = model.get('tooltip');
         const width = model.get('width');
+        const style = model.get('style');
 
         button.textContent = '';
 
@@ -49,6 +50,16 @@ class Button(anywidget.AnyWidget):
         if (width) {
           button.style.width = `${width}px`;
         }
+
+        for (const className of button.classList) {
+          if (className.startsWith('mod')) {
+            button.classList.remove(className);
+          }
+        }
+
+        if (style) {
+          button.classList.add(`mod-${style}`);
+        }
       }
 
       const createEventHandler = (eventType) => (event) => {
@@ -70,6 +81,7 @@ class Button(anywidget.AnyWidget):
       model.on('change:icon', update);
       model.on('change:width', update);
       model.on('change:tooltip', update);
+      model.on('change:style', update);
 
       update();
 
@@ -111,6 +123,9 @@ class Button(anywidget.AnyWidget):
     icon = Unicode().tag(sync=True)
     width = Int(allow_none=True).tag(sync=True)
     visible = Bool(True).tag(sync=True)
+    style = Enum(
+        ['', 'success', 'info', 'warning', 'danger', 'primary'], default_value=''
+    ).tag(sync=True)
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/jscatter/widgets/button.py
+++ b/jscatter/widgets/button.py
@@ -1,0 +1,116 @@
+import anywidget
+
+from traitlets import Int, Unicode
+
+
+class Button(anywidget.AnyWidget):
+    _esm = """
+    function render({ model, el }) {
+      const button = document.createElement('button');
+
+      button.classList.add(
+        'jupyter-widgets',
+        'jupyter-button',
+        'widget-button',
+        'jupyter-scatter-button',
+      );
+
+      const update = () => {
+        const description = model.get('description');
+        const icon = model.get('icon');
+        const tooltip = model.get('tooltip');
+        const width = model.get('width');
+
+        button.textContent = '';
+
+        if (icon.startsWith('<svg')) {
+          const parser = new DOMParser();
+          const doc = parser.parseFromString(icon, "image/svg+xml");
+          button.appendChild(doc.firstChild);
+        } else {
+          const i = document.createElement('i');
+          i.classList.add('fa', `fa-${icon}`);
+
+          if (!description) {
+            i.classList.add('center');
+          }
+
+          button.appendChild(i);
+        }
+
+        if (description) {
+          button.appendChild(document.createTextNode(description));
+        }
+
+        if (tooltip) {
+          button.title = tooltip;
+        }
+
+        if (width) {
+          button.style.width = `${width}px`;
+        }
+      }
+
+      const createEventHandler = (eventType) => (event) => {
+        model.send({
+          type: eventType,
+          alt_key: event.altKey,
+          shift_key: event.shiftKey,
+          meta_key: event.metaKey,
+        });
+      }
+
+      const clickHandler = createEventHandler('click');
+      const dblclickHandler = createEventHandler('dblclick');
+
+      button.addEventListener('click', clickHandler);
+      button.addEventListener('dblclick', dblclickHandler);
+
+      model.on('change:description', update);
+      model.on('change:icon', update);
+      model.on('change:width', update);
+      model.on('change:tooltip', update);
+
+      update();
+
+      el.appendChild(button);
+
+      return () => {
+        button.removeEventListener('click', clickHandler);
+        button.removeEventListener('dblclick', dblclickHandler);
+      };
+    }
+    export default { render }
+    """
+
+    _css = """
+    .jupyter-scatter-button {
+      position: relative;
+    }
+    .jupyter-scatter-button > svg {
+      display: block;
+      width: 100%;
+      height: 100%;
+    }
+    """
+
+    description = Unicode().tag(sync=True)
+    icon = Unicode().tag(sync=True)
+    width = Int(allow_none=True).tag(sync=True)
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._click_handler = None
+        self.on_msg(self._handle_custom_msg)
+
+    def _handle_custom_msg(self, content: dict, buffers):
+        if content['type'] == 'click' and self._click_handler is not None:
+            self._click_handler(content)
+        if content['type'] == 'dblclick' and self._dblclick_handler is not None:
+            self._dblclick_handler(content)
+
+    def on_click(self, callback):
+        self._click_handler = callback
+
+    def on_dblclick(self, callback):
+        self._dblclick_handler = callback

--- a/jscatter/widgets/button_choice.py
+++ b/jscatter/widgets/button_choice.py
@@ -1,0 +1,215 @@
+import anywidget
+
+from traitlets import Dict, Int, List, Unicode, Union
+
+
+class ButtonChoice(anywidget.AnyWidget):
+    _esm = """
+    function removeAllChildren(node) {
+      while (node.firstChild) {
+        node.removeChild(node.firstChild);
+      }
+    }
+
+    function render({ model, el }) {
+      const id = Array.from({ length: 8 }, () =>
+        'abcdefghijklmnopqrstuvwxyz'.charAt(Math.floor(Math.random() * 26))
+      ).join('');
+
+      const button = document.createElement('button');
+      const dialog = document.createElement('dialog');
+      const container = document.createElement('div');
+
+      button.classList.add('jupyter-widgets', 'jupyter-button', 'widget-button', 'jupyter-scatter-choice-toggler');
+      dialog.classList.add('jupyter-scatter-choice-dialog');
+      container.classList.add('jupyter-widgets', 'jupyter-scatter-choice-container');
+
+      let open = false;
+
+      const updateIcon = (newValue) => {
+        const icons = model.get('icon');
+        const value = newValue || model.get('value');
+
+        const icon = icons
+          ? typeof icons === 'string'
+            ? icons
+            : icons[value]
+          : undefined;
+
+        if (icon) {
+          if (icon.startsWith('<svg')) {
+            const parser = new DOMParser();
+            const doc = parser.parseFromString(icon, "image/svg+xml");
+            button.appendChild(doc.firstChild);
+          } else {
+            const i = document.createElement('i');
+            i.classList.add('fa', `fa-${icon}`);
+
+            if (!description) {
+              i.classList.add('center');
+            }
+
+            button.appendChild(i);
+          }
+        }
+      }
+
+      const update = () => {
+        const value = model.get('value');
+        const options = model.get('options');
+        const description = model.get('description');
+        const tooltip = model.get('tooltip');
+        const width = model.get('width');
+
+        button.textContent = '';
+
+        updateIcon();
+
+        if (description) {
+          button.appendChild(document.createTextNode(description));
+        }
+
+        button.title = tooltip || '';
+
+        if (width) {
+          button.style.width = `${width}px`;
+        }
+
+        if (container.firstChild) {
+          container.querySelectorAll('input').forEach((input) => {
+            input.removeEventListener('change', changeHandler);
+          });
+        }
+
+        removeAllChildren(container);
+
+        const optionValueLabelPairs = Array.isArray(options)
+          ? options.map((option) => [option, option])
+          : Object.entries(options)
+        const template = optionValueLabelPairs.reduce((t, [value, label]) => {
+          t += `<label class="jupyter-scatter-choice-label"><input id="${id}-${value}" type="radio" name="${id}" value="${value}" />${label}</label>`
+          return t;
+        }, '');
+
+        container.insertAdjacentHTML('beforeend', template);
+        container.querySelectorAll('input').forEach((input) => {
+          input.checked = input.value === value;
+          input.addEventListener('change', changeHandler);
+        });
+      }
+
+      const dialogClickHandler = (event) => {
+        if (event.target === dialog) {
+          dialog.close();
+        }
+      }
+
+      dialog.addEventListener('click', dialogClickHandler);
+
+      const clickHandler = () => {
+        const { top, left } = button.getBoundingClientRect();
+        dialog.style.top = `${top}px`;
+        dialog.style.left = `${left + (model.get('width') || 0)}px`;
+        dialog.showModal();
+      }
+
+      const changeHandler = (event) => {
+        updateIcon(event.target.value);
+        model.set('value', event.target.value);
+        model.save_changes();
+        dialog.close();
+      }
+
+      button.addEventListener('click', clickHandler);
+
+      model.on('change:description', update);
+      model.on('change:icon', update);
+      model.on('change:width', update);
+      model.on('change:tooltip', update);
+      model.on('change:value', update);
+      model.on('change:options', update);
+
+      update();
+
+      el.appendChild(button);
+      dialog.appendChild(container);
+      el.appendChild(dialog);
+
+      return () => {
+        button.removeEventListener('click', clickHandler);
+        dialog.removeEventListener('click', dialogClickHandler);
+        container.querySelectorAll('input').forEach((input) => {
+          input.removeEventListener('change', changeHandler);
+        });
+      };
+    }
+    export default { render }
+    """
+
+    _css = """
+    .jupyter-scatter-choice-toggler {
+      position: relative;
+    }
+    .jupyter-scatter-choice-toggler > svg {
+      display: block;
+      width: 100%;
+      height: 100%;
+    }
+    .jupyter-scatter-choice-dialog {
+      position: absolute;
+      padding: 0;
+      margin: 0;
+      border: none;
+    }
+    .jupyter-scatter-choice-container {
+      width: min-content;
+      display: flex;
+      align-items: center;
+      gap: 0 1rem;
+      padding: 0 0.5rem;
+      white-space: nowrap;
+      overflow: hidden;
+      font-size: var(--jp-widgets-font-size);
+      height: var(--jp-widgets-inline-height);
+      line-height: var(--jp-widgets-inline-height);
+      color: var(--jp-ui-font-color1);
+      background-color: var(--jp-layout-color2);
+      border-radius: 0 0.25rem 0.25rem 0;
+      user-select: none;
+      border: none;
+      margin: 0;
+    }
+    .jupyter-scatter-choice-label {
+      display: flex;
+      align-items: center;
+      gap: 0 0.25rem;
+    }
+    ::backdrop{
+      background: var(--jp-layout-color0);
+      opacity: 0.33;
+    }
+    """
+
+    value = Unicode().tag(sync=True)
+    options = Union([Dict(), List()], allow_none=True).tag(sync=True)
+    description = Unicode(default_value='').tag(sync=True)
+    icon = Union([Unicode(), Dict()]).tag(sync=True)
+    width = Int(allow_none=True).tag(sync=True)
+    label = Unicode(allow_none=True, default_value=None).tag(sync=True)
+
+
+ButtonChoice(
+    icon={
+        'freeform': '<svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><path stroke-width="2px" stroke="currentColor" fill="none" d="m15.99958,27.5687c-1.8418,-0.3359 -3.71385,-1.01143 -5.49959,-2.04243c-6.69178,-3.8635 -9.65985,-11.26864 -6.62435,-16.52628c3.0355,-5.25764 10.93258,-6.38978 17.62435,-2.52628c6.1635,3.5585 9.16819,10.12222 7.23126,15.24508"/><circle stroke-width="2px" stroke="currentColor" fill="none" r="3" cy="25" cx="27"/></svg>',
+        'brush': '<svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><path stroke-width="2px" stroke="currentColor" fill="none" d="m25.985,26.755c-5.345,2.455 -10.786,2.981 -14.455,1.899c-3.449,-1.017 -5.53,-3.338 -5.53,-6.654c0,-3.33 1.705,-4.929 3.835,-6.127c0.894,-0.503 1.88,-0.912 2.738,-1.451c0.786,-0.493 1.427,-1.143 1.427,-2.422c0,-1.692 -1.552,-2.769 -3.177,-3.649c-3.177,-1.722 -7.152,-2.378 -7.152,-2.378l0.658,-3.946c0,0 4.665,0.784 8.4,2.806c2.987,1.618 5.271,4.055 5.271,7.167c0,3.33 -1.705,4.929 -3.835,6.127c-0.894,0.503 -1.88,0.912 -2.738,1.451c-0.786,0.493 -1.427,1.143 -1.427,2.422c0,1.486 1.117,2.362 2.662,2.818c2.897,0.854 7.122,0.332 11.338,-1.551"/><circle stroke-width="2px" stroke="currentColor" fill="none" r="3" cy="24" cx="27"/></svg>',
+        'rectangle': '<svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><circle  stroke-width="2px" stroke="currentColor" fill="none" r="3" cy="24" cx="27"/><path stroke-linecap="square" stroke-width="2px" stroke="currentColor" fill="none" d="m24,24l-22,0l0,-19l25,0l0,16"/></svg>',
+    },
+    tooltip='Lasso Type',
+    width=36,
+    value='freeform',
+    options={
+        'freeform': 'Freeform',
+        'brush': 'Brush',
+        'rectangle': 'Rectangle',
+    },
+)

--- a/jscatter/widgets/button_choice.py
+++ b/jscatter/widgets/button_choice.py
@@ -1,6 +1,6 @@
 import anywidget
 
-from traitlets import Dict, Int, List, Unicode, Union
+from traitlets import Bool, Dict, Int, List, Unicode, Union
 
 
 class ButtonChoice(anywidget.AnyWidget):
@@ -131,6 +131,19 @@ class ButtonChoice(anywidget.AnyWidget):
 
       update();
 
+      const updateVisibility = () => {
+        const visible = model.get('visible');
+        if (visible) {
+          el.style.display = 'block';
+        } else {
+          el.style.display = 'none';
+        }
+      }
+
+      model.on('change:visible', updateVisibility);
+
+      updateVisibility();
+
       el.appendChild(button);
       dialog.appendChild(container);
       el.appendChild(dialog);
@@ -196,6 +209,7 @@ class ButtonChoice(anywidget.AnyWidget):
     icon = Union([Unicode(), Dict()]).tag(sync=True)
     width = Int(allow_none=True).tag(sync=True)
     label = Unicode(allow_none=True, default_value=None).tag(sync=True)
+    visible = Bool(True).tag(sync=True)
 
 
 ButtonChoice(

--- a/jscatter/widgets/button_slider.py
+++ b/jscatter/widgets/button_slider.py
@@ -13,13 +13,16 @@ class ButtonIntSlider(anywidget.AnyWidget):
       const sliderLabel = document.createElement('label');
       const sliderLabelValue = document.createElement('span');
       const sliderLabelText = document.createElement('span');
+      const sliderCircle = document.createElement('div');
 
       button.classList.add('jupyter-widgets', 'jupyter-button', 'widget-button', 'jupyter-scatter-slider-toggler');
       dialog.classList.add('jupyter-scatter-slider-dialog');
       container.classList.add('jupyter-widgets', 'jupyter-scatter-slider-container');
       slider.type = 'range';
+      slider.classList.add('jupyter-scatter-slider-input');
       sliderLabel.classList.add('jupyter-scatter-slider-label');
       sliderLabelText.classList.add('jupyter-scatter-slider-label-text');
+      sliderCircle.classList.add('jupyter-scatter-slider-circle');
 
       let open = false;
 
@@ -133,17 +136,37 @@ class ButtonIntSlider(anywidget.AnyWidget):
           ? `${value}${suffix}`
           : value;
 
+        sliderCircle.style.opacity = '0';
+
         model.set('value', Number(value));
         model.save_changes();
       }
 
       const inputHandler = (event) => {
+        console.log('slider input', event);
         const value = event.target.value;
         const suffix = model.get('slider_label_value_suffix');
 
         sliderLabelValue.textContent = suffix
           ? `${value}${suffix}`
           : value;
+
+        const computedStyle = window.getComputedStyle(event.target);
+        const bBox = event.target.getBoundingClientRect();
+        const relValue = (Number(value) - Number(event.target.min)) / Number(event.target.max);
+
+        const baseFontSize = Number(window.getComputedStyle(document.body).getPropertyValue('--jp-ui-font-size1').slice(0,-2));
+
+        const relTop = bBox.top - Number(dialog.style.top.slice(0,-2));
+        const relLeft = Math.ceil(baseFontSize / 2) + bBox.left - Number(dialog.style.left.slice(0,-2));
+
+        const effectiveWidth = bBox.width - baseFontSize;
+
+        sliderCircle.style.opacity = '0.5';
+        sliderCircle.style.top = `${relTop + bBox.height / 2}px`;
+        sliderCircle.style.left = `${relLeft + effectiveWidth * relValue}px`;
+        sliderCircle.style.width = `${value}px`;
+        sliderCircle.style.height = `${value}px`;
       }
 
       button.addEventListener('click', clickHandler);
@@ -183,6 +206,7 @@ class ButtonIntSlider(anywidget.AnyWidget):
       container.appendChild(slider);
       container.appendChild(sliderLabel);
       dialog.appendChild(container);
+      dialog.appendChild(sliderCircle);
 
       el.appendChild(button);
       el.appendChild(dialog);
@@ -211,6 +235,7 @@ class ButtonIntSlider(anywidget.AnyWidget):
       padding: 0;
       margin: 0;
       border: none;
+      overflow: visible;
     }
     .jupyter-scatter-slider-container {
       width: min-content;
@@ -230,12 +255,39 @@ class ButtonIntSlider(anywidget.AnyWidget):
       border: none;
       margin: 0;
     }
+
+    .jupyter-scatter-slider-input {
+      margin-left: 0;
+      margin-right: 0;
+    }
+    .jupyter-scatter-slider-input::-webkit-slider-thumb {
+      height: 0.75rem;
+      width: 0.75rem;
+    }
+    .jupyter-scatter-slider-input::-moz-range-thumb {
+      height: 0.75rem;
+      width: 0.75rem;
+    }
+
     .jupyter-scatter-slider-label {
       display: flex;
       align-items: center;
       gap: 0 0.5rem;
       white-space: nowrap;
     }
+
+    .jupyter-scatter-slider-circle {
+      position: absolute;
+      display: block;
+      transform: translate(-50%, -50%);
+      opacity: 0;
+      border: 1px dashed var(--jp-ui-font-color1);
+      border-radius: 100%;
+      pointer-events: none;
+      user-select: none;
+      transition: opacity 0.2s ease;
+    }
+
     ::backdrop{
       background: var(--jp-layout-color0);
       opacity: 0.33;

--- a/jscatter/widgets/button_slider.py
+++ b/jscatter/widgets/button_slider.py
@@ -1,0 +1,244 @@
+import anywidget
+
+from traitlets import Dict, Int, Unicode
+
+
+class ButtonIntSlider(anywidget.AnyWidget):
+    _esm = """
+    function render({ model, el }) {
+      const button = document.createElement('button');
+      const dialog = document.createElement('dialog');
+      const container = document.createElement('div');
+      const slider = document.createElement('input');
+      const sliderLabel = document.createElement('label');
+      const sliderLabelValue = document.createElement('span');
+      const sliderLabelText = document.createElement('span');
+
+      button.classList.add('jupyter-widgets', 'jupyter-button', 'widget-button', 'jupyter-scatter-slider-toggler');
+      dialog.classList.add('jupyter-scatter-slider-dialog');
+      container.classList.add('jupyter-widgets', 'jupyter-scatter-slider-container');
+      slider.type = 'range';
+      sliderLabel.classList.add('jupyter-scatter-slider-label');
+      sliderLabelText.classList.add('jupyter-scatter-slider-label-text');
+
+      let open = false;
+
+      const update = () => {
+        const value = model.get('value');
+        const valueMin = model.get('value_min');
+        const valueMax = model.get('value_max');
+        const valueStep = model.get('value_step');
+        const description = model.get('description');
+        const icon = model.get('icon');
+        const tooltip = model.get('tooltip');
+        const width = model.get('width');
+        const sliderWidth = model.get('slider_width');
+        const _sliderLabelText = model.get('slider_label');
+        const sliderLabelWidth = model.get('slider_label_width');
+        const sliderLabelValueSuffix = model.get('slider_label_value_suffix');
+
+        button.textContent = '';
+
+        if (icon.startsWith('<svg')) {
+          const parser = new DOMParser();
+          const doc = parser.parseFromString(icon, "image/svg+xml");
+          button.appendChild(doc.firstChild);
+        } else {
+          const i = document.createElement('i');
+          i.classList.add('fa', `fa-${icon}`);
+
+          if (!description) {
+            i.classList.add('center');
+          }
+
+          button.appendChild(i);
+        }
+
+        if (description) {
+          button.appendChild(document.createTextNode(description));
+        }
+
+        if (tooltip) {
+          button.title = tooltip;
+        }
+
+        if (width) {
+          button.style.width = `${width}px`;
+        }
+
+        if (value !== undefined) {
+          slider.value = value;
+          sliderLabelValue.textContent = sliderLabelValueSuffix
+            ? `${value}${sliderLabelValueSuffix}`
+            : value;
+        }
+
+        if (valueMin !== undefined) {
+          slider.min = valueMin;
+        } else {
+          slider.removeAttribute('min');
+        }
+
+        if (valueMax !== undefined) {
+          slider.max = valueMax;
+        } else {
+          slider.removeAttribute('max');
+        }
+
+        if (valueStep !== undefined) {
+          slider.step = valueStep;
+        } else {
+          slider.removeAttribute('step');
+        }
+
+        if (sliderWidth) {
+          slider.style.width = `${sliderWidth}px`;
+        } else {
+          slider.style.removeProperty('width');
+        }
+
+        if (sliderLabelWidth) {
+          sliderLabelValue.style.width = `${sliderLabelWidth}px`;
+        } else {
+          sliderLabelValue.style.removeProperty('width');
+        }
+
+        if (_sliderLabelText) {
+          sliderLabelText.textContent = _sliderLabelText;
+        } else {
+          sliderLabelText.textContent = '';
+        }
+      }
+
+      const dialogClickHandler = (event) => {
+        if (event.target === dialog) {
+          dialog.close();
+        }
+      }
+
+      dialog.addEventListener('click', dialogClickHandler);
+
+      const clickHandler = () => {
+        const { top, left } = button.getBoundingClientRect();
+        dialog.style.top = `${top}px`;
+        dialog.style.left = `${left + (model.get('width') || 0)}px`;
+        dialog.showModal();
+      }
+
+      const changeHandler = (event) => {
+        const value = event.target.value;
+        const suffix = model.get('slider_label_value_suffix');
+
+        sliderLabelValue.textContent = suffix
+          ? `${value}${suffix}`
+          : value;
+
+        model.set('value', Number(value));
+        model.save_changes();
+      }
+
+      const inputHandler = (event) => {
+        const value = event.target.value;
+        const suffix = model.get('slider_label_value_suffix');
+
+        sliderLabelValue.textContent = suffix
+          ? `${value}${suffix}`
+          : value;
+      }
+
+      button.addEventListener('click', clickHandler);
+      slider.addEventListener('change', changeHandler);
+      slider.addEventListener('input', inputHandler);
+
+      model.on('change:description', update);
+      model.on('change:icon', update);
+      model.on('change:width', update);
+      model.on('change:tooltip', update);
+      model.on('change:value', update);
+      model.on('change:value_min', update);
+      model.on('change:value_max', update);
+      model.on('change:value_step', update);
+      model.on('change:slider_width', update);
+      model.on('change:slider_label', update);
+      model.on('change:slider_label_width', update);
+      model.on('change:slider_label_value_suffix', update);
+
+      update();
+
+      sliderLabel.appendChild(sliderLabelValue);
+      sliderLabel.appendChild(sliderLabelText);
+      container.appendChild(slider);
+      container.appendChild(sliderLabel);
+      dialog.appendChild(container);
+
+      el.appendChild(button);
+      el.appendChild(dialog);
+
+      return () => {
+        button.removeEventListener('click', clickHandler);
+        slider.removeEventListener('change', changeHandler);
+        slider.removeEventListener('input', inputHandler);
+        dialog.removeEventListener('click', dialogClickHandler);
+      };
+    }
+    export default { render }
+    """
+
+    _css = """
+    .jupyter-scatter-slider-toggler {
+      position: relative;
+    }
+    .jupyter-scatter-slider-toggler > svg {
+      display: block;
+      width: 100%;
+      height: 100%;
+    }
+    .jupyter-scatter-slider-dialog {
+      position: absolute;
+      padding: 0;
+      margin: 0;
+      border: none;
+    }
+    .jupyter-scatter-slider-container {
+      width: min-content;
+      display: flex;
+      align-items: center;
+      gap: 0 1rem;
+      padding: 0 0.5rem;
+      white-space: nowrap;
+      overflow: hidden;
+      font-size: var(--jp-widgets-font-size);
+      height: var(--jp-widgets-inline-height);
+      line-height: var(--jp-widgets-inline-height);
+      color: var(--jp-ui-font-color1);
+      background-color: var(--jp-layout-color2);
+      border-radius: 0 0.25rem 0.25rem 0;
+      user-select: none;
+      border: none;
+      margin: 0;
+    }
+    .jupyter-scatter-slider-label {
+      display: flex;
+      align-items: center;
+      gap: 0 0.5rem;
+      white-space: nowrap;
+    }
+    ::backdrop{
+      background: var(--jp-layout-color0);
+      opacity: 0.33;
+    }
+    """
+
+    value = Int().tag(sync=True)
+    value_min = Int().tag(sync=True)
+    value_max = Int().tag(sync=True)
+    value_step = Int().tag(sync=True)
+    description = Unicode(default_value='').tag(sync=True)
+    icon = Unicode().tag(sync=True)
+    width = Int(allow_none=True).tag(sync=True)
+    slider_width = Int(allow_none=True).tag(sync=True)
+    slider_label = Unicode(allow_none=True, default_value=None).tag(sync=True)
+    slider_label_width = Int(allow_none=True, default_value=None).tag(sync=True)
+    slider_label_value_suffix = Unicode(allow_none=True, default_value=None).tag(
+        sync=True
+    )

--- a/jscatter/widgets/button_slider.py
+++ b/jscatter/widgets/button_slider.py
@@ -1,6 +1,6 @@
 import anywidget
 
-from traitlets import Dict, Int, Unicode
+from traitlets import Bool, Dict, Int, Unicode
 
 
 class ButtonIntSlider(anywidget.AnyWidget):
@@ -165,6 +165,19 @@ class ButtonIntSlider(anywidget.AnyWidget):
 
       update();
 
+      const updateVisibility = () => {
+        const visible = model.get('visible');
+        if (visible) {
+          el.style.display = 'block';
+        } else {
+          el.style.display = 'none';
+        }
+      }
+
+      model.on('change:visible', updateVisibility);
+
+      updateVisibility();
+
       sliderLabel.appendChild(sliderLabelValue);
       sliderLabel.appendChild(sliderLabelText);
       container.appendChild(slider);
@@ -242,3 +255,4 @@ class ButtonIntSlider(anywidget.AnyWidget):
     slider_label_value_suffix = Unicode(allow_none=True, default_value=None).tag(
         sync=True
     )
+    visible = Bool(True).tag(sync=True)

--- a/jscatter/widgets/divider.py
+++ b/jscatter/widgets/divider.py
@@ -1,0 +1,21 @@
+import anywidget
+
+
+class Divider(anywidget.AnyWidget):
+    _esm = """
+    function render({ model, el }) {
+      const div = document.createElement('div');
+      div.classList.add('jupyter-widgets', 'jupyter-scatter-divider');
+      el.appendChild(div);
+    }
+    export default { render }
+    """
+
+    _css = """
+    .jupyter-scatter-divider {
+      margin: 10px 0;
+      width: 100%;
+      height: 0;
+      border: 1px solid var(--jp-layout-color2);
+    }
+    """

--- a/notebooks/Untitled5.ipynb
+++ b/notebooks/Untitled5.ipynb
@@ -174,15 +174,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 10,
    "id": "29a87d94-a5c2-4eaf-bcfa-380a8646ddb9",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from jscatter import glasbey_light\n",
+    "from jscatter import glasbey_dark\n",
     "\n",
     "category_cmap = {\n",
-    "    cat: glasbey_light[i]\n",
+    "    cat: glasbey_dark[i]\n",
     "    for i, cat in enumerate(sorted(huffpost_embeddings.category.unique()))\n",
     "}\n",
     "month_cmap = {\n",
@@ -219,19 +219,19 @@
     "    '2022': '#ff0000',\n",
     "}\n",
     "\n",
-    "huffpost_scatter_config = dict(x='x', y='y', axes=False, background_color='#111111')"
+    "huffpost_scatter_config = dict(x='x', y='y', axes=False, background_color='#ffffff')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 11,
    "id": "06abfdbe-d032-4222-b336-e4b5bf2a7ea9",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "253190077cab41459df43cc26569eecc",
+       "model_id": "376d0f291ad4429fb640f5bec1d56dfa",
        "version_major": 2,
        "version_minor": 0
       },
@@ -239,7 +239,7 @@
        "VBox(children=(HBox(children=(VBox(children=(Button(button_style='primary', icon='arrows', layout=Layout(width…"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/notebooks/Untitled5.ipynb
+++ b/notebooks/Untitled5.ipynb
@@ -1,0 +1,291 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "9ef7a845-ac9c-4bdc-918e-7fca6b854cce",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "env: ANYWIDGET_HMR=1\n"
+     ]
+    }
+   ],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2\n",
+    "%env ANYWIDGET_HMR=1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "bfde7663-2bf1-4735-a9c6-8e6b0bfecce0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n",
+      "                                 Dload  Upload   Total   Spent    Left  Speed\n",
+      "100 23.1M  100 23.1M    0     0  12.9M      0  0:00:01  0:00:01 --:--:-- 12.9M  0:00:15 1577k\n"
+     ]
+    }
+   ],
+   "source": [
+    "!mkdir -p data\n",
+    "!curl -L -C - -o data/huffpost-embeddings.pq https://storage.googleapis.com/flekschas/jupyter-scatter-tutorial/huffpost-embeddings.pq"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "db0e62f7-59a9-4497-9d57-999273082fee",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>link</th>\n",
+       "      <th>headline</th>\n",
+       "      <th>category</th>\n",
+       "      <th>short_description</th>\n",
+       "      <th>date</th>\n",
+       "      <th>year</th>\n",
+       "      <th>month</th>\n",
+       "      <th>season</th>\n",
+       "      <th>x</th>\n",
+       "      <th>y</th>\n",
+       "      <th>length</th>\n",
+       "      <th>length_clr</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>https://www.huffpost.com/entry/covid-boosters-...</td>\n",
+       "      <td>Over 4 Million Americans Roll Up Sleeves For O...</td>\n",
+       "      <td>U.S. NEWS</td>\n",
+       "      <td>Health experts said it is too early to predict...</td>\n",
+       "      <td>2022-09-23</td>\n",
+       "      <td>2022</td>\n",
+       "      <td>September</td>\n",
+       "      <td>Fall</td>\n",
+       "      <td>3.873639</td>\n",
+       "      <td>0.846710</td>\n",
+       "      <td>76</td>\n",
+       "      <td>0.318783</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>https://www.huffpost.com/entry/american-airlin...</td>\n",
+       "      <td>American Airlines Flyer Charged, Banned For Li...</td>\n",
+       "      <td>U.S. NEWS</td>\n",
+       "      <td>He was subdued by passengers and crew when he ...</td>\n",
+       "      <td>2022-09-23</td>\n",
+       "      <td>2022</td>\n",
+       "      <td>September</td>\n",
+       "      <td>Fall</td>\n",
+       "      <td>3.672992</td>\n",
+       "      <td>4.065663</td>\n",
+       "      <td>89</td>\n",
+       "      <td>0.476686</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>https://www.huffpost.com/entry/funniest-tweets...</td>\n",
+       "      <td>23 Of The Funniest Tweets About Cats And Dogs ...</td>\n",
+       "      <td>COMEDY</td>\n",
+       "      <td>\"Until you have a dog you don't understand wha...</td>\n",
+       "      <td>2022-09-23</td>\n",
+       "      <td>2022</td>\n",
+       "      <td>September</td>\n",
+       "      <td>Fall</td>\n",
+       "      <td>7.427926</td>\n",
+       "      <td>5.442265</td>\n",
+       "      <td>69</td>\n",
+       "      <td>0.222156</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                                link  \\\n",
+       "0  https://www.huffpost.com/entry/covid-boosters-...   \n",
+       "1  https://www.huffpost.com/entry/american-airlin...   \n",
+       "2  https://www.huffpost.com/entry/funniest-tweets...   \n",
+       "\n",
+       "                                            headline   category  \\\n",
+       "0  Over 4 Million Americans Roll Up Sleeves For O...  U.S. NEWS   \n",
+       "1  American Airlines Flyer Charged, Banned For Li...  U.S. NEWS   \n",
+       "2  23 Of The Funniest Tweets About Cats And Dogs ...     COMEDY   \n",
+       "\n",
+       "                                   short_description        date  year  \\\n",
+       "0  Health experts said it is too early to predict...  2022-09-23  2022   \n",
+       "1  He was subdued by passengers and crew when he ...  2022-09-23  2022   \n",
+       "2  \"Until you have a dog you don't understand wha...  2022-09-23  2022   \n",
+       "\n",
+       "       month season         x         y  length  length_clr  \n",
+       "0  September   Fall  3.873639  0.846710      76    0.318783  \n",
+       "1  September   Fall  3.672992  4.065663      89    0.476686  \n",
+       "2  September   Fall  7.427926  5.442265      69    0.222156  "
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "\n",
+    "huffpost_embeddings = pd.read_parquet('data/huffpost-embeddings.pq')\n",
+    "huffpost_embeddings.year = huffpost_embeddings.year.astype('category')\n",
+    "huffpost_embeddings['length_clr'] = np.log(\n",
+    "    huffpost_embeddings.length.values\n",
+    "    / np.exp(np.mean(np.log(huffpost_embeddings.length.values)))\n",
+    ")\n",
+    "huffpost_embeddings.head(3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "29a87d94-a5c2-4eaf-bcfa-380a8646ddb9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from jscatter import glasbey_light\n",
+    "\n",
+    "category_cmap = {\n",
+    "    cat: glasbey_light[i]\n",
+    "    for i, cat in enumerate(sorted(huffpost_embeddings.category.unique()))\n",
+    "}\n",
+    "month_cmap = {\n",
+    "    'January': '#3C33FF',\n",
+    "    'February': '#4587E8',\n",
+    "    'March': '#6FCFF1',\n",
+    "    'April': '#40E52C',\n",
+    "    'May': '#9CFA0B',\n",
+    "    'June': '#B7F113',\n",
+    "    'July': '#FFFF34',\n",
+    "    'August': '#FCD66F',\n",
+    "    'September': '#FFAEBC',\n",
+    "    'October': '#FF5DFF',\n",
+    "    'November': '#C75DFF',\n",
+    "    'December': '#AD7EFF',\n",
+    "}\n",
+    "season_cmap = {\n",
+    "    'Spring': '#9CFA0B',\n",
+    "    'Summer': '#FFFF34',\n",
+    "    'Fall': '#FF5DFF',\n",
+    "    'Winter': '#3C33FF',\n",
+    "}\n",
+    "year_cmap = {\n",
+    "    '2012': '#ffffe0',\n",
+    "    '2013': '#ffefc1',\n",
+    "    '2014': '#ffdfa8',\n",
+    "    '2015': '#ffcc92',\n",
+    "    '2016': '#ffba81',\n",
+    "    '2017': '#ffa875',\n",
+    "    '2018': '#ff926c',\n",
+    "    '2019': '#ff7d65',\n",
+    "    '2020': '#ff635e',\n",
+    "    '2021': '#ff4251',\n",
+    "    '2022': '#ff0000',\n",
+    "}\n",
+    "\n",
+    "huffpost_scatter_config = dict(x='x', y='y', axes=False, background_color='#111111')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "06abfdbe-d032-4222-b336-e4b5bf2a7ea9",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "253190077cab41459df43cc26569eecc",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(VBox(children=(Button(button_style='primary', icon='arrows', layout=Layout(width…"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from jscatter import Scatter\n",
+    "\n",
+    "scatter = Scatter(\n",
+    "    data=huffpost_embeddings,\n",
+    "    color_by='category',\n",
+    "    color_map=category_cmap,\n",
+    "    height=720,\n",
+    "    legend=True,\n",
+    "    **huffpost_scatter_config,\n",
+    ")\n",
+    "scatter.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "846ce9ba-e8a0-45bc-be44-f4e58d1d1016",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This PR adds support for rectangle and brush selections and fixes a couple of other issues.

## Description

### What was changed in this pull request?

1. Add support for brush and rectangle lasso types. You can activate a different lasso type via the new lasso type button or via `scatter.widget.lasso_type`
2. Expose lasso selection polygon via `scatter.widget.lasso_polygon_selection`.
3. Enable merging of lasso selection upon holding down the [meta key](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/metaKey) and deselected points upon holding down the [alt key](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/altKey).
4. Allow specifying which properties should feature a histogram via `scatter.tooltip(histograms=['color', 'property_a'])`
5. Fix a background histogram render bug
6. Ensure NAs are skipped for the histogram
7. Ensure that the tooltip is hidden on lasso start

### Example

https://github.com/user-attachments/assets/04b562b8-9b14-4705-be31-4735a6165737

### Why is it necessary?

Because brush and rectangle selections are cool!

## Checklist

- [x] Provided a concise title as a [semantic commit message](https://www.conventionalcommits.org) (e.g. "fix: correctly handle undefined properties")
- [x] `CHANGELOG.md` updated
- [ ] Tests added or updated
- [x] Documentation in `API.md`/`README.md` added or updated
- [ ] Example(s) added or updated
- [x] Screenshot, gif, or video attached for visual changes
