### PR TITLE
feat: use categorical color encoding in histogram bars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.23.0
+
+- Feat: use categorical color encoding in histogram bars ([#97](https://github.com/flekschas/jupyter-scatter/issues/97))
+
 ## v0.22.3
 
 - Fix: geoindex-rs import compatibility ([#222](https://github.com/flekschas/jupyter-scatter/pull/222))

--- a/js/src/histogram.js
+++ b/js/src/histogram.js
@@ -37,16 +37,18 @@ const createCategoricalHistogramBackground = (canvas, data) => {
     height: 10,
     lastI,
     color: DEFAULT_BACKGROUND_COLOR,
+    categoryColors: null,
   };
 
-  const style = (newColor) => {
+  const style = (newColor, categoryColors) => {
     state.color = newColor;
+    state.categoryColors = categoryColors || null;
   };
 
   const draw = () => {
     ctx.clearRect(0, 0, canvas.width, canvas.height);
-    ctx.fillStyle = state.color;
     for (const rect of state.rects) {
+      ctx.fillStyle = state.categoryColors?.[rect.key] ?? state.color;
       ctx.fillRect(rect.x, rect.y, rect.width, rect.height);
     }
   };
@@ -63,6 +65,7 @@ const createCategoricalHistogramBackground = (canvas, data) => {
     const tree = createTreemap(data, state.width, state.height);
 
     state.rects = tree.leaves().map((leaf) => ({
+      key: leaf.data.key,
       x: leaf.x0 + padding,
       y: leaf.y0,
       width: leaf.x1 - leaf.x0,
@@ -84,10 +87,12 @@ const createCategoricalHistogramHighlight = (canvas, data) => {
     height: 10,
     lastI,
     color: DEFAULT_HIGHLIGHT_COLOR,
+    useBorder: false,
   };
 
-  const style = (newColor) => {
+  const style = (newColor, useBorder) => {
     state.color = newColor;
+    state.useBorder = useBorder;
   };
 
   const draw = (key) => {
@@ -97,9 +102,23 @@ const createCategoricalHistogramHighlight = (canvas, data) => {
       return;
     }
 
+    const dpr = window.devicePixelRatio;
+
     ctx.clearRect(0, 0, canvas.width, canvas.height);
-    ctx.fillStyle = state.color;
-    ctx.fillRect(rect.x, rect.y, rect.width, rect.height);
+
+    if (state.useBorder) {
+      ctx.lineWidth = 2 * dpr;
+      ctx.strokeStyle = state.color;
+      ctx.strokeRect(
+        rect.x + dpr,
+        rect.y + dpr,
+        rect.width - 2 * dpr,
+        rect.height - 2 * dpr,
+      );
+    } else {
+      ctx.fillStyle = state.color;
+      ctx.fillRect(rect.x, rect.y, rect.width, rect.height);
+    }
   };
 
   const resize = (width, height) => {
@@ -287,12 +306,12 @@ export const createHistogram = (width, height) => {
     histogramHighlight.draw(key);
   };
 
-  const style = (color, background) => {
+  const style = (color, background, categoryColors) => {
     if (!isInit) {
       return;
     }
-    histogramBackground.style(background);
-    histogramHighlight.style(color);
+    histogramBackground.style(background, categoryColors);
+    histogramHighlight.style(color, Boolean(categoryColors));
   };
 
   const resize = () => {

--- a/js/src/histogram.js
+++ b/js/src/histogram.js
@@ -47,10 +47,12 @@ const createCategoricalHistogramBackground = (canvas, data) => {
 
   const draw = () => {
     ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.globalAlpha = state.categoryColors ? 0.33 : 1;
     for (const rect of state.rects) {
       ctx.fillStyle = state.categoryColors?.[rect.key] ?? state.color;
       ctx.fillRect(rect.x, rect.y, rect.width, rect.height);
     }
+    ctx.globalAlpha = 1;
   };
 
   const resize = (width, height) => {
@@ -90,9 +92,9 @@ const createCategoricalHistogramHighlight = (canvas, data) => {
     useBorder: false,
   };
 
-  const style = (newColor, useBorder) => {
+  const style = (newColor, categoryColors) => {
     state.color = newColor;
-    state.useBorder = useBorder;
+    state.categoryColors = categoryColors || null;
   };
 
   const draw = (key) => {
@@ -102,23 +104,10 @@ const createCategoricalHistogramHighlight = (canvas, data) => {
       return;
     }
 
-    const dpr = window.devicePixelRatio;
-
     ctx.clearRect(0, 0, canvas.width, canvas.height);
 
-    if (state.useBorder) {
-      ctx.lineWidth = 2 * dpr;
-      ctx.strokeStyle = state.color;
-      ctx.strokeRect(
-        rect.x + dpr,
-        rect.y + dpr,
-        rect.width - 2 * dpr,
-        rect.height - 2 * dpr,
-      );
-    } else {
-      ctx.fillStyle = state.color;
-      ctx.fillRect(rect.x, rect.y, rect.width, rect.height);
-    }
+    ctx.fillStyle = state.categoryColors?.[key] ?? state.color;
+    ctx.fillRect(rect.x, rect.y, rect.width, rect.height);
   };
 
   const resize = (width, height) => {
@@ -311,7 +300,7 @@ export const createHistogram = (width, height) => {
       return;
     }
     histogramBackground.style(background, categoryColors);
-    histogramHighlight.style(color, Boolean(categoryColors));
+    histogramHighlight.style(color, categoryColors);
   };
 
   const resize = () => {

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -1290,6 +1290,9 @@ class JupyterScatterView {
       this[`tooltipProperty${toCapitalCase(property)}ValueHistogram`]?.style(
         fg,
         `rgb(${contrast}, ${contrast}, ${contrast}, 0.2)`,
+        property === 'color'
+          ? this.getCategoricalColorHistogramColors()
+          : undefined,
       );
     }
 
@@ -2465,6 +2468,7 @@ class JupyterScatterView {
       this.model.get('color_histogram'),
       this.model.get('color_scale') === 'categorical',
     );
+    this.styleTooltipColorHistogram();
     this.createColorGetter();
   }
 
@@ -2628,6 +2632,7 @@ class JupyterScatterView {
   colorHandler(newValue) {
     this.createColorScale();
     this.createColorGetter();
+    this.styleTooltipColorHistogram();
     this.withPropertyChangeHandler('pointColor', newValue);
   }
 
@@ -3421,6 +3426,44 @@ class JupyterScatterView {
   getYPadding() {
     const xLabel = this.model.get('axes_labels')?.[0];
     return xLabel ? AXES_PADDING_Y_WITH_LABEL : AXES_PADDING_Y;
+  }
+
+  styleTooltipColorHistogram() {
+    const histogram = this.tooltipPropertyColorValueHistogram;
+    if (!histogram) {
+      return;
+    }
+
+    const color = this.model
+      .get('tooltip_color')
+      .map((c) => Math.round(c * 255));
+    const contrast = color[0] <= 127 ? 255 : 0;
+    const fg = `rgb(${contrast}, ${contrast}, ${contrast})`;
+
+    histogram.style(
+      fg,
+      `rgb(${contrast}, ${contrast}, ${contrast}, 0.2)`,
+      this.getCategoricalColorHistogramColors(),
+    );
+  }
+
+  getCategoricalColorHistogramColors() {
+    if (this.model.get('color_scale') !== 'categorical') {
+      return undefined;
+    }
+    const colors = this.model.get('color');
+    if (!colors) {
+      return undefined;
+    }
+    return Object.fromEntries(
+      colors.map((color, i) => [
+        i,
+        `rgb(${color
+          .slice(0, 3)
+          .map((v) => Math.round(v * 255))
+          .join(', ')})`,
+      ]),
+    );
   }
 
   showHistogram(property) {


### PR DESCRIPTION
This PR updates the histogram to reuse categorical colors when available

## Description

### What was changed in this PR?

Allow reusing categorical colormaps in the tooltip's histogram

### Example

<img width="982" height="526" alt="Screenshot 2026-05-08 at 12 01 04 PM" src="https://github.com/user-attachments/assets/79c8f2c5-c047-4a3f-b524-0103f308a6eb" />

### Why is this PR necessary?

Fixes #97

## Checklist

- [x] Provided a concise title as a [semantic commit message](https://www.conventionalcommits.org) (e.g. "fix: correctly handle undefined properties")
- [x] `CHANGELOG.md` updated
- [ ] Tests added or updated
- [ ] Documentation in `README.md` added or updated
- [ ] Example(s) added or updated
- [x] Screenshot, gif, or video attached for visual changes
