### PR TITLE
feat: add support for Arrow PyCapsule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           uv venv --clear
           source .venv/bin/activate
           uv pip install -e ".[all]"
-          uv pip install pytest pytest-cov
+          uv pip install pytest pytest-cov polars
           pytest . --color=yes
         env:
           UV_PYTHON: ${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 - 🚀 **Scalable**: Plot up to several millions data points smoothly thanks to WebGL rendering.
 - 🔗 **Interlinked**: Synchronize the view, hover, and selection across multiple scatter plot instances.
 - ✨ **Effective Defaults**: Rely on Jupyter Scatter to choose perceptually effective point colors and opacity by default.
-- 📚 **Friendly API:** Enjoy a readable API that integrates deeply with Pandas DataFrames.
+- 📚 **Friendly API:** Enjoy a readable API that integrates with Pandas, Polars, and any Arrow-compatible DataFrame.
 - 🛠️ **Integratable**: Use Jupyter Scatter in your own widgets by observing its traitlets.
 
 **Why?**
@@ -63,7 +63,7 @@ Visit [https://jupyter-scatter.dev](https://jupyter-scatter.dev) for detailed do
 1. [Install](#install)
 2. [Get Started](#get-started)
    1. [Simplest Example](#simplest-example)
-   2. [Pandas DataFrame Example](#pandas-dataframe-example)
+   2. [DataFrame Example](#dataframe-example)
    3. [Advanced Example](#advanced-example)
    4. [Functional API Example](#functional-api-example)
    5. [Linking Scatter Plots](#linking-scatter-plots)
@@ -122,9 +122,11 @@ jscatter.plot(x, y)
 
 <img width="448" alt="Simplest scatter plotexample" src="https://user-images.githubusercontent.com/932103/116143120-bc5f2280-a6a8-11eb-8614-51def74d692e.png">
 
-### Pandas DataFrame Example
+### DataFrame Example
 
-Say your data is stored in a Pandas dataframe like the following:
+You can pass a DataFrame and reference columns by name. Jupyter Scatter supports
+Pandas, Polars, and any DataFrame implementing the [Arrow PyCapsule Interface](https://arrow.apache.org/docs/format/CDataInterface/PyCapsuleInterface.html)
+(e.g., DuckDB, cuDF).
 
 ```python
 import pandas as pd
@@ -149,6 +151,15 @@ You can then visualize this data by referencing column names:
 
 ```python
 jscatter.plot(data=df, x='mass', y='speed')
+```
+
+The same works with Polars:
+
+```python
+import polars as pl
+
+df_polars = pl.DataFrame(data, schema=['mass', 'speed', 'pval', 'group'])
+jscatter.plot(data=df_polars, x='mass', y='speed')
 ```
 
 <details><summary>Show the resulting scatter plot</summary>

--- a/docs/api.md
+++ b/docs/api.md
@@ -28,7 +28,7 @@
 
 - `x` is either an array-like list of coordinates or a string referencing a column in `data`.
 - `y` is either an array-like list of coordinates or a string referencing a column in `data`.
-- `data` is a Pandas DataFrame. [optional]
+- `data` is a Pandas or Polars DataFrame, or any object implementing the [Arrow PyCapsule Interface](https://arrow.apache.org/docs/format/CDataInterface/PyCapsuleInterface.html). [optional]
 - `kwargs` is a dictionary of additional [properties](#properties). [optional]
 
 **Returns:** a new scatter instance.
@@ -134,11 +134,11 @@ scatter.xy('size', 'speed') # Mirror plot along the diagonal
 
 ### scatter.data(_data=Undefined_, _use_index=Undefined_, _reset_scales=False_, _zoom_view=False_, _animate=False_, _\*\*kwargs_) {#scatter.data}
 
-Get or set the referenced Pandas DataFrame.
+Get or set the referenced DataFrame.
 
 **Arguments:**
 
-- `data` is a Pandas DataFrame.
+- `data` is a Pandas or Polars DataFrame, or any object implementing the [Arrow PyCapsule Interface](https://arrow.apache.org/docs/format/CDataInterface/PyCapsuleInterface.html).
 - `use_index` is a Boolean value indicating if the data frame's index should be used for referencing point by the `selection()` and `filter()` methods instead of the row index.
 - `reset_scales` is a Boolean value indicating whether all scales (and norms) will be reset to the extend of the the new data.
 - `zoom_view` is a Boolean value indicating if the view will zoom to the data extent.
@@ -736,7 +736,7 @@ You can define those property when creating a `Scatter` instance. For example,
 
 | Name                       | Type                                                                                     | Default                                        |
 | -------------------------- | ---------------------------------------------------------------------------------------- | ---------------------------------------------- |
-| `data`                     | pandas.DataFrame                                                                         | `None`                                         |
+| `data`                     | pandas.DataFrame \| polars.DataFrame \| ArrowPyCapsule                                   | `None`                                         |
 | `x`                        | str \| list[float] \| ndarray                                                            | `None`                                         |
 | `x_scale`                  | 'linear' \| 'log' \| 'pow' \| tuple[float] \| [LogNorm][lognorm] \| [PowerNorm][pownorm] | `linear`                                       |
 | `y`                        | str \| list[float] \| ndarray                                                            | `None`                                         |

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -15,7 +15,7 @@ selections.
 - 🚀 **Scalable**: Plot up to several millions data points smoothly.
 - 🔗 **Interlinked**: Synchronize the view, hover, and selection across multiple plots.
 - ✨ **Effective Defaults**: Perceptually effective point colors and opacity by default.
-- 📚 **Friendly API:** A readable API that integrates deeply with Pandas DataFrames.
+- 📚 **Friendly API:** A readable API that integrates with Pandas, Polars, and any Arrow-compatible DataFrame.
 - 🛠️ **Integratable**: Use Jupyter Scatter in your own widgets by observing its traitlets.
 
 ## Simplest Example
@@ -35,10 +35,12 @@ jscatter.plot(x, y)
 <div class="img get-started-simple"><div /></div>
 
 
-## Bind a Pandas DataFrame
+## Bind a DataFrame
 
-In most cases, however, it's more convenient to work with a `DataFrame` and
-reference the x/y columns via their names.
+In most cases, however, it's more convenient to work with a DataFrame and
+reference the x/y columns via their names. Jupyter Scatter supports Pandas,
+Polars, and any DataFrame implementing the [Arrow PyCapsule Interface](https://arrow.apache.org/docs/format/CDataInterface/PyCapsuleInterface.html)
+(e.g., DuckDB, cuDF).
 
 ```python
 import jscatter
@@ -46,6 +48,16 @@ import numpy as np
 import pandas as pd
 
 df = pd.DataFrame(np.random.rand(500, 2), columns=['mass', 'speed'])
+
+jscatter.plot(data=df, x='mass', y='speed')
+```
+
+The same works with Polars:
+
+```python
+import polars as pl
+
+df = pl.DataFrame(np.random.rand(500, 2), schema=['mass', 'speed'])
 
 jscatter.plot(data=df, x='mass', y='speed')
 ```

--- a/docs/selections.md
+++ b/docs/selections.md
@@ -59,11 +59,12 @@ category `A`.
 ::: info
 By default, Jupyter Scatter references points by their range index. Meaning,
 `scatter.selection([0, 1, 2])` will select the first, second, and third point.
+This works consistently across Pandas, Polars, and other supported DataFrames.
 
-Alternatively, if you're binding a DataFrame to a `Scatter` instance via
-`Scatter(data=df)` and your DataFrame has a custom index, you can make the
-`Scatter` instance reference data points by the DataFrame's index via
-`Scatter(data=df, data_use_index=True)`.
+Alternatively, if you're binding a Pandas DataFrame with a custom index, you can
+make the `Scatter` instance reference data points by the DataFrame's label index
+via `Scatter(data=df, data_use_index=True)`. Note that `data_use_index` is only
+supported for Pandas DataFrames.
 :::
 
 ## Lasso Select Points {#set-interactive}

--- a/jscatter/dataframe_utils.py
+++ b/jscatter/dataframe_utils.py
@@ -35,20 +35,10 @@ def ensure_pandas(data):
         return data
 
     if hasattr(data, '__arrow_c_stream__'):
+        from .serializers.dataframe import _cast_unsigned_dict_indices
+
         table = pa.RecordBatchReader.from_stream(data).read_all()
-
-        # Polars exports categoricals as Arrow dictionary arrays with uint32
-        # indices. Older PyArrow versions (<14) can't convert unsigned
-        # dictionary indices to Pandas, so we cast them to signed int32.
-        for i, field in enumerate(table.schema):
-            if pa.types.is_dictionary(field.type) and not pa.types.is_signed_integer(
-                field.type.index_type
-            ):
-                signed_type = pa.dictionary(pa.int32(), field.type.value_type)
-                table = table.set_column(
-                    i, field.name, table.column(i).cast(signed_type)
-                )
-
+        table = _cast_unsigned_dict_indices(table)
         df = table.to_pandas()
 
         # Arrow dictionary columns (from Polars Categorical, etc.) become

--- a/jscatter/dataframe_utils.py
+++ b/jscatter/dataframe_utils.py
@@ -36,6 +36,19 @@ def ensure_pandas(data):
 
     if hasattr(data, '__arrow_c_stream__'):
         table = pa.RecordBatchReader.from_stream(data).read_all()
+
+        # Polars exports categoricals as Arrow dictionary arrays with uint32
+        # indices. Older PyArrow versions (<14) can't convert unsigned
+        # dictionary indices to Pandas, so we cast them to signed int32.
+        for i, field in enumerate(table.schema):
+            if pa.types.is_dictionary(field.type) and not pa.types.is_signed_integer(
+                field.type.index_type
+            ):
+                signed_type = pa.dictionary(pa.int32(), field.type.value_type)
+                table = table.set_column(
+                    i, field.name, table.column(i).cast(signed_type)
+                )
+
         df = table.to_pandas()
 
         # Arrow dictionary columns (from Polars Categorical, etc.) become

--- a/jscatter/dataframe_utils.py
+++ b/jscatter/dataframe_utils.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import re
+
+import pandas as pd
+import pyarrow as pa
+
+_NATURAL_SORT_RE = re.compile(r'(\d+)')
+
+
+def _natural_sort_key(value):
+    """Sort key that orders strings naturally: A1 < A2 < A10."""
+    parts = _NATURAL_SORT_RE.split(str(value))
+    return [int(p) if p.isdigit() else p.lower() for p in parts]
+
+
+def ensure_pandas(data):
+    """Convert a DataFrame-like object to a Pandas DataFrame.
+
+    Accepts:
+    - Pandas DataFrames (returned as-is)
+    - Any object implementing the Arrow PyCapsule Interface
+      (``__arrow_c_stream__``), e.g. Polars, DuckDB, cuDF
+    - ``None`` (returned as-is)
+
+    Raises
+    ------
+    TypeError
+        If the input is not a supported DataFrame type.
+    """
+    if data is None:
+        return data
+
+    if isinstance(data, pd.DataFrame):
+        return data
+
+    if hasattr(data, '__arrow_c_stream__'):
+        table = pa.RecordBatchReader.from_stream(data).read_all()
+        df = table.to_pandas()
+
+        # Arrow dictionary columns (from Polars Categorical, etc.) become
+        # Pandas Categoricals whose category order matches the source library.
+        # Polars orders by first appearance; Pandas conventions expect sorted
+        # categories.  Re-sorting ensures consistent color/code assignments
+        # regardless of the input library.
+        for col in df.columns:
+            if isinstance(df[col].dtype, pd.CategoricalDtype):
+                df[col] = df[col].cat.reorder_categories(
+                    sorted(df[col].cat.categories, key=_natural_sort_key)
+                )
+
+        return df
+
+    raise TypeError(
+        f'Expected a Pandas or Polars DataFrame (or any object implementing '
+        f'the Arrow PyCapsule Interface), got {type(data).__name__}'
+    )
+
+
+def is_pandas(data) -> bool:
+    """Check if data is a Pandas DataFrame."""
+    return isinstance(data, pd.DataFrame)

--- a/jscatter/jscatter.py
+++ b/jscatter/jscatter.py
@@ -16,6 +16,8 @@ from matplotlib.colors import (
     to_rgba,
 )
 
+from .dataframe_utils import ensure_pandas
+
 from .annotations import HLine, Line, Rect, VLine
 from .color_maps import glasbey_dark, glasbey_light, gray_dark, gray_light, okabe_ito
 from .composite_annotations import CompositeAnnotation, Contour
@@ -264,7 +266,7 @@ class Scatter:
         self,
         x: Union[str, List[float], np.ndarray],
         y: Union[str, List[float], np.ndarray],
-        data: Optional[pd.DataFrame] = None,
+        data=None,
         **kwargs,
     ):
         """
@@ -278,10 +280,12 @@ class Scatter:
         y : str, array_like
             The y coordinates given as either an array-like list of coordinates
             or a string referencing a column in `data`.
-        data : pd.DataFrame, optional
+        data : DataFrame, optional
             The data frame that holds the x and y coordinates as well as other
             possible dimensions that can be used for color, size, or opacity
-            encoding.
+            encoding. Supports Pandas and Polars DataFrames as well as any
+            object implementing the Arrow PyCapsule Interface
+            (``__arrow_c_stream__``).
         kwargs : optional
             Options to customize the scatter instance and the visual encoding.
             See https://jupyter-scatter.dev/api#properties
@@ -307,7 +311,7 @@ class Scatter:
         >>> scatter.x(data=df, x='weight', y='speed', color_by='length')
         <jscatter.jscatter.Scatter>
         """
-        self._data = data
+        self._data = ensure_pandas(data)
         self._data_use_index = kwargs.get('data_use_index', False)
 
         try:
@@ -664,7 +668,7 @@ class Scatter:
 
     def data(
         self,
-        data: Optional[pd.DataFrame] = None,
+        data=None,
         use_index: Optional[Union[bool, Undefined]] = UNDEF,
         reset_scales: Optional[bool] = False,
         zoom_view: Optional[bool] = False,
@@ -672,14 +676,16 @@ class Scatter:
         **kwargs,
     ) -> Union[Scatter, dict]:
         """
-        Set or get the referenced Pandas DataFrame
+        Set or get the referenced DataFrame
 
         Parameters
         ----------
-        data : pd.DataFrame, optional
+        data : DataFrame, optional
             The new data frame that holds the x and y coordinates as well as
             other possible dimensions that can be used for color, size, or
-            opacity encoding.
+            opacity encoding. Supports Pandas and Polars DataFrames as well as
+            any object implementing the Arrow PyCapsule Interface
+            (``__arrow_c_stream__``).
         label_index : bool, optional
             If `True` and if the data frame's index is not an instance of
             `RangeIndex` then the selection and filter methods will reference
@@ -720,6 +726,7 @@ class Scatter:
         """
         if data is not None:
             old_n = self._n
+            data = ensure_pandas(data)
 
             try:
                 self._n = len(data)
@@ -5418,7 +5425,7 @@ class Scatter:
 def plot(
     x: Union[str, List[float], np.ndarray],
     y: Union[str, List[float], np.ndarray],
-    data: Optional[pd.DataFrame] = None,
+    data=None,
     **kwargs,
 ):
     """
@@ -5432,10 +5439,12 @@ def plot(
     y : str, array_like
         The y coordinates given as either an array-like list of coordinates
         or a string referencing a column in `data`.
-    data : pd.DataFrame, optional
+    data : DataFrame, optional
         The data frame that holds the x and y coordinates as well as other
         possible dimensions that can be used for color, size, or opacity
-        encoding.
+        encoding. Supports Pandas and Polars DataFrames as well as any
+        object implementing the Arrow PyCapsule Interface
+        (``__arrow_c_stream__``).
     kwargs : optional
         Options to customize the scatter instance and the visual encoding.
         See https://jupyter-scatter.dev/api#properties

--- a/jscatter/serializers/dataframe.py
+++ b/jscatter/serializers/dataframe.py
@@ -9,8 +9,11 @@ def df_to_arrow_ipc_buffer(df, obj=None, force_contiguous=True):
     if df is None:
         return None
 
-    # Convert pandas DataFrame to Arrow Table
-    table = pa.Table.from_pandas(df)
+    # Convert to Arrow Table, supporting PyCapsule Interface (Polars, etc.)
+    if hasattr(df, '__arrow_c_stream__') and not isinstance(df, pd.DataFrame):
+        table = pa.RecordBatchReader.from_stream(df).read_all()
+    else:
+        table = pa.Table.from_pandas(df)
 
     # Create an in-memory buffer
     buf = io.BytesIO()

--- a/jscatter/serializers/dataframe.py
+++ b/jscatter/serializers/dataframe.py
@@ -28,13 +28,24 @@ def df_to_arrow_ipc_buffer(df, obj=None, force_contiguous=True):
     return buf.getbuffer()
 
 
+def _cast_unsigned_dict_indices(table):
+    """Cast unsigned dictionary indices to signed for older PyArrow compat."""
+    for i, field in enumerate(table.schema):
+        if pa.types.is_dictionary(field.type) and not pa.types.is_signed_integer(
+            field.type.index_type
+        ):
+            signed_type = pa.dictionary(pa.int32(), field.type.value_type)
+            table = table.set_column(i, field.name, table.column(i).cast(signed_type))
+    return table
+
+
 def arrow_ipc_buffer_to_df(ipc_buffer, obj=None):
     if ipc_buffer is None:
         return None
 
     buf_reader = pa.BufferReader(ipc_buffer)
     reader = pa.ipc.open_file(buf_reader)
-    table = reader.read_all()
+    table = _cast_unsigned_dict_indices(reader.read_all())
     return table.to_pandas()
 
 

--- a/jscatter/traittypes/dataframe.py
+++ b/jscatter/traittypes/dataframe.py
@@ -19,7 +19,15 @@ class PandasType(SciType):
         if value is None or value is Undefined:
             return super(PandasType, self).validate(obj, value)
         try:
-            value = self.klass(value)
+            # Convert non-Pandas DataFrames (e.g. Polars) via Arrow PyCapsule
+            if not isinstance(value, self.klass) and hasattr(
+                value, '__arrow_c_stream__'
+            ):
+                from ..dataframe_utils import ensure_pandas
+
+                value = ensure_pandas(value)
+            else:
+                value = self.klass(value)
         except (ValueError, TypeError) as e:
             raise TraitError(e)
         return super(PandasType, self).validate(obj, value)

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -3,10 +3,12 @@ pre-commit:
   commands:
     ruff-format:
       glob: "*.py"
-      run: uv run ruff format --check {staged_files}
+      run: uv run ruff format {staged_files}
+      stage_fixed: true
     ruff-lint:
       glob: "*.py"
-      run: uv run ruff check {staged_files}
+      run: uv run ruff check --fix {staged_files}
+      stage_fixed: true
     biome-lint:
       glob: "js/src/**/*.{js,ts,jsx,tsx}"
       run: cd js && npm run lint

--- a/notebooks/dataframe_test.ipynb
+++ b/notebooks/dataframe_test.ipynb
@@ -1,0 +1,431 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e5cf96ab",
+   "metadata": {},
+   "source": [
+    "# DataFrame Input Test\n",
+    "\n",
+    "This notebook tests that `jscatter` works with five different data sources:\n",
+    "\n",
+    "1. **NumPy** arrays (vanilla)\n",
+    "2. **Pandas** DataFrame\n",
+    "3. **Polars** DataFrame\n",
+    "4. **PyArrow** Table\n",
+    "5. **DuckDB** query result\n",
+    "\n",
+    "All five should produce identical scatter plots."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "12595d82",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import polars as pl\n",
+    "import pyarrow as pa\n",
+    "import duckdb\n",
+    "import jscatter"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "127bc411",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Shared data\n",
+    "np.random.seed(42)\n",
+    "n = 1000\n",
+    "\n",
+    "x = np.random.randn(n)\n",
+    "y = np.random.randn(n)\n",
+    "value = np.sqrt(x**2 + y**2)\n",
+    "group = np.array(['A', 'B', 'C', 'D'])[np.random.randint(0, 4, n)]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6310c343",
+   "metadata": {},
+   "source": [
+    "## 1. NumPy Arrays"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "3bae06eb",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ebefa9a8eb514811b85d71a5b8fa3e4a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(VBox(children=(<jscatter.widgets.button.Button object at 0x161f3e270>, <jscatter…"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "scatter_np = jscatter.Scatter(x=x, y=y, color_by=value, legend=True)\n",
+    "scatter_np.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c3c19377",
+   "metadata": {},
+   "source": [
+    "## 2. Pandas DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "f77621f3",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "089fa1829a0240698bd2f018e825b20e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(VBox(children=(<jscatter.widgets.button.Button object at 0x110e386e0>, <jscatter…"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_pandas = pd.DataFrame(\n",
+    "    {'x': x, 'y': y, 'value': value, 'group': pd.Categorical(group)}\n",
+    ")\n",
+    "\n",
+    "scatter_pd = jscatter.Scatter(\n",
+    "    data=df_pandas, x='x', y='y', color_by='group', size_by='value', legend=True\n",
+    ")\n",
+    "scatter_pd.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ed00c0ad",
+   "metadata": {},
+   "source": [
+    "## 3. Polars DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "1447cd5e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a3fea4b6b5ee4df696fce140e97a99e8",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(VBox(children=(<jscatter.widgets.button.Button object at 0x162db9700>, <jscatter…"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_polars = pl.DataFrame({'x': x, 'y': y, 'value': value, 'group': group}).cast(\n",
+    "    {'group': pl.Categorical}\n",
+    ")\n",
+    "\n",
+    "scatter_pl = jscatter.Scatter(\n",
+    "    data=df_polars, x='x', y='y', color_by='group', size_by='value', legend=True\n",
+    ")\n",
+    "scatter_pl.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "174eff95",
+   "metadata": {},
+   "source": [
+    "## 4. PyArrow Table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "f335fb5c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "661411e306334e3d9618e242bc2829c8",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(VBox(children=(<jscatter.widgets.button.Button object at 0x162dbb8c0>, <jscatter…"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "table_arrow = pa.table(\n",
+    "    {\n",
+    "        'x': x,\n",
+    "        'y': y,\n",
+    "        'value': value,\n",
+    "        'group': pa.DictionaryArray.from_arrays(\n",
+    "            pa.array(np.searchsorted(np.unique(group), group), type=pa.int32()),\n",
+    "            pa.array(np.unique(group)),\n",
+    "        ),\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "scatter_pa = jscatter.Scatter(\n",
+    "    data=table_arrow, x='x', y='y', color_by='group', size_by='value', legend=True\n",
+    ")\n",
+    "scatter_pa.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4a4461a8",
+   "metadata": {},
+   "source": [
+    "## 5. DuckDB Query Result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "65bafeec",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "37c0a489f03941ac9f3ff2038d32105c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(VBox(children=(<jscatter.widgets.button.Button object at 0x162dfdb50>, <jscatter…"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "conn = duckdb.connect()\n",
+    "conn.execute('CREATE TABLE points AS SELECT * FROM df_pandas')\n",
+    "table_duckdb = conn.sql('SELECT * FROM points').arrow()\n",
+    "\n",
+    "scatter_db = jscatter.Scatter(\n",
+    "    data=table_duckdb, x='x', y='y', color_by='group', size_by='value', legend=True\n",
+    ")\n",
+    "scatter_db.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d43f8099",
+   "metadata": {},
+   "source": [
+    "## Selection Roundtrip\n",
+    "\n",
+    "Verify that selections from a Polars-backed scatter return the same rows as from a Pandas-backed scatter, and that the integer indices can index directly back into the original Polars DataFrame (no `.tolist()` needed)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "12b50b46",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Pandas selection:  [  0  10  50 100]\n",
+      "Polars selection:  [  0  10  50 100]\n",
+      "Identical:         True\n",
+      "\n",
+      "Pandas rows:\n",
+      "        x         y group\n",
+      " 0.496714  1.399355     B\n",
+      "-0.463418  1.317394     A\n",
+      " 0.324084 -0.625563     A\n",
+      "-1.415371  0.998010     B\n",
+      "\n",
+      "Polars rows:\n",
+      "shape: (4, 3)\n",
+      "┌───────────┬───────────┬───────┐\n",
+      "│ x         ┆ y         ┆ group │\n",
+      "│ ---       ┆ ---       ┆ ---   │\n",
+      "│ f64       ┆ f64       ┆ cat   │\n",
+      "╞═══════════╪═══════════╪═══════╡\n",
+      "│ 0.496714  ┆ 1.399355  ┆ B     │\n",
+      "│ -0.463418 ┆ 1.317394  ┆ A     │\n",
+      "│ 0.324084  ┆ -0.625563 ┆ A     │\n",
+      "│ -1.415371 ┆ 0.99801   ┆ B     │\n",
+      "└───────────┴───────────┴───────┘\n"
+     ]
+    }
+   ],
+   "source": [
+    "indices = [0, 10, 50, 100]\n",
+    "\n",
+    "# Select the same points in both Pandas and Polars scatters\n",
+    "scatter_pd.selection(indices)\n",
+    "scatter_pl.selection(indices)\n",
+    "\n",
+    "# Get selections back\n",
+    "sel_pd = scatter_pd.selection()\n",
+    "sel_pl = scatter_pl.selection()\n",
+    "\n",
+    "print('Pandas selection: ', sel_pd)\n",
+    "print('Polars selection: ', sel_pl)\n",
+    "print('Identical:        ', np.array_equal(sel_pd, sel_pl))\n",
+    "\n",
+    "# Index back into the original DataFrames\n",
+    "rows_pd = df_pandas.iloc[sel_pd]\n",
+    "rows_pl = df_polars[sel_pl]  # numpy array works directly, no .tolist() needed\n",
+    "\n",
+    "print('\\nPandas rows:')\n",
+    "print(rows_pd[['x', 'y', 'group']].to_string(index=False))\n",
+    "\n",
+    "print('\\nPolars rows:')\n",
+    "print(rows_pl.select('x', 'y', 'group'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b9b501d4",
+   "metadata": {},
+   "source": [
+    "## Data Update Across Types\n",
+    "\n",
+    "Swap data from one format to another on an existing scatter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "ad0ce5a1",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "95d691cffd6c40c1a3ef16426763ab98",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(VBox(children=(<jscatter.widgets.button.Button object at 0x162dfd9a0>, <jscatter…"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Start with a Pandas DF scatter\n",
+    "scatter_swap = jscatter.Scatter(data=df_pandas, x='x', y='y', color_by='group')\n",
+    "scatter_swap.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "5da26bfc",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<jscatter.jscatter.Scatter at 0x162e3d730>"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Now swap in a Polars DataFrame -- the scatter above should update\n",
+    "new_polars = pl.DataFrame(\n",
+    "    {\n",
+    "        'x': np.random.randn(500).tolist(),\n",
+    "        'y': np.random.randn(500).tolist(),\n",
+    "        'group': (['X', 'Y'] * 250),\n",
+    "    }\n",
+    ").cast({'group': pl.Categorical})\n",
+    "\n",
+    "scatter_swap.data(new_polars)\n",
+    "scatter_swap.color(by='group')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4a923456-41df-4070-b4ea-8468b4e33479",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/marimo.py
+++ b/notebooks/marimo.py
@@ -5,6 +5,9 @@
 #     "marimo",
 #     "numpy",
 #     "pandas",
+#     "polars",
+#     "pyarrow",
+#     "duckdb",
 # ]
 #
 # [tool.uv.sources]
@@ -30,6 +33,9 @@ def _():
     import jscatter
     import numpy as np
     import pandas as pd
+    import polars as pl
+    import pyarrow as pa
+    import duckdb
 
     np.random.seed(42)
     n = 500
@@ -41,7 +47,7 @@ def _():
             'value': np.random.uniform(0, 100, n),
         }
     )
-    return df, jscatter
+    return df, duckdb, jscatter, np, pa, pl
 
 
 @app.cell
@@ -67,6 +73,155 @@ def _(df, jscatter):
         rows=1,
         row_height=320,
     )
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    # DataFrame Input Test
+
+    The same scatter from **Pandas**, **Polars**, **PyArrow**, and **DuckDB**.
+    All four should look identical.
+    """)
+    return
+
+
+@app.cell
+def _(df, np, pa, pl):
+    x = df['x'].values
+    y = df['y'].values
+    value = df['value'].values
+    group = np.array(df['category'].values.astype(str).tolist())
+
+    df_polars = pl.DataFrame(
+        {
+            'x': x,
+            'y': y,
+            'value': value,
+            'group': group,
+        }
+    ).cast({'group': pl.Categorical})
+
+    table_arrow = pa.table(
+        {
+            'x': x,
+            'y': y,
+            'value': value,
+            'group': pa.DictionaryArray.from_arrays(
+                pa.array(np.searchsorted(np.unique(group), group), type=pa.int32()),
+                pa.array(np.unique(group)),
+            ),
+        }
+    )
+    return df_polars, table_arrow
+
+
+@app.cell
+def _(df, df_polars, jscatter, table_arrow):
+    scatter_pd = jscatter.Scatter(
+        data=df,
+        x='x',
+        y='y',
+        color_by='category',
+        size_by='value',
+        legend=True,
+        height=280,
+    )
+    scatter_pl = jscatter.Scatter(
+        data=df_polars,
+        x='x',
+        y='y',
+        color_by='group',
+        size_by='value',
+        legend=True,
+        height=280,
+    )
+    scatter_pa = jscatter.Scatter(
+        data=table_arrow,
+        x='x',
+        y='y',
+        color_by='group',
+        size_by='value',
+        legend=True,
+        height=280,
+    )
+
+    jscatter.compose(
+        [
+            (scatter_pd, 'Pandas'),
+            (scatter_pl, 'Polars'),
+            (scatter_pa, 'PyArrow'),
+        ],
+        sync_selection=True,
+        sync_view=True,
+        rows=1,
+        row_height=280,
+    )
+    return scatter_pd, scatter_pl
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## DuckDB Query Result
+    """)
+    return
+
+
+@app.cell
+def _(duckdb, jscatter):
+    conn = duckdb.connect()
+    conn.execute('CREATE TABLE points AS SELECT * FROM df')
+    table_duckdb = conn.sql('SELECT * FROM points').arrow()
+
+    scatter_db = jscatter.Scatter(
+        data=table_duckdb,
+        x='x',
+        y='y',
+        color_by='category',
+        size_by='value',
+        legend=True,
+        height=320,
+    )
+    scatter_db
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## Selection Roundtrip
+
+    Verify that integer indices from a Polars-backed scatter match the
+    Pandas-backed scatter and can index directly into the original Polars DF.
+    """)
+    return
+
+
+@app.cell
+def _(df, df_polars, mo, np, scatter_pd, scatter_pl):
+    _indices = [0, 10, 50, 100]
+    scatter_pd.selection(_indices)
+    scatter_pl.selection(_indices)
+
+    _sel_pd = scatter_pd.selection()
+    _sel_pl = scatter_pl.selection()
+
+    _rows_pd = df.iloc[_sel_pd]
+    _rows_pl = df_polars[_sel_pl]
+
+    mo.md(f"""
+    **Pandas selection:** `{_sel_pd}`
+    **Polars selection:** `{_sel_pl}`
+    **Identical:** `{np.array_equal(_sel_pd, _sel_pl)}`
+
+    **Pandas rows:**
+    {mo.as_html(_rows_pd[['x', 'y', 'category']])}
+
+    **Polars rows:**
+    {mo.as_html(_rows_pl.select('x', 'y', 'group'))}
+    """)
     return
 
 

--- a/tests/test_polars_support.py
+++ b/tests/test_polars_support.py
@@ -1,0 +1,674 @@
+import numpy as np
+import pandas as pd
+import polars as pl
+import pyarrow as pa
+import pytest
+
+from jscatter.jscatter import Scatter, check_encoding_dtype
+from jscatter.dataframe_utils import ensure_pandas, _natural_sort_key
+from jscatter.serializers.dataframe import (
+    df_to_arrow_ipc_buffer,
+    arrow_ipc_buffer_to_df,
+)
+from jscatter.utils import create_default_norm, to_ndc
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def polars_df() -> pl.DataFrame:
+    """Basic Polars DataFrame with numeric and categorical columns."""
+    num_groups = 8
+    np.random.seed(42)
+
+    return pl.DataFrame(
+        {
+            'a': np.linspace(0, 1, 500).tolist(),
+            'b': np.linspace(0, 1, 500).tolist(),
+            'c': (np.random.rand(500) * 100).tolist(),
+            'd': (np.random.rand(500) * 100).astype(int).tolist(),
+            'group': [
+                chr(65 + int(x))
+                for x in np.round(np.random.rand(500) * (num_groups - 1))
+            ],
+            'connect': np.repeat(np.arange(100), 5).tolist(),
+            'connect_order': np.resize(np.arange(5), 500).tolist(),
+        }
+    ).cast(
+        {
+            'group': pl.Categorical,
+        }
+    )
+
+
+@pytest.fixture
+def polars_df2() -> pl.DataFrame:
+    """Second Polars DataFrame for update tests."""
+    num_groups = 10
+    np.random.seed(123)
+
+    return pl.DataFrame(
+        {
+            'a': np.linspace(-2, 2, 500).tolist(),
+            'b': np.linspace(-2, 2, 500).tolist(),
+            'c': (np.random.rand(500) * 200).tolist(),
+            'd': (np.random.rand(500) * 200).astype(int).tolist(),
+            'group': [
+                chr(65 + int(x))
+                for x in np.round(np.random.rand(500) * (num_groups - 1))
+            ],
+            'connect': np.repeat(np.arange(100), 5).tolist(),
+            'connect_order': np.resize(np.arange(5), 500).tolist(),
+        }
+    ).cast(
+        {
+            'group': pl.Categorical,
+        }
+    )
+
+
+@pytest.fixture
+def pandas_df(polars_df) -> pd.DataFrame:
+    """Equivalent Pandas DataFrame from the same Polars data."""
+    return polars_df.to_pandas()
+
+
+@pytest.fixture
+def arrow_table(polars_df) -> pa.Table:
+    """PyArrow Table (also supports __arrow_c_stream__)."""
+    return polars_df.to_arrow()
+
+
+# ---------------------------------------------------------------------------
+# ensure_pandas() unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestEnsurePandas:
+    def test_none_passthrough(self):
+        assert ensure_pandas(None) is None
+
+    def test_pandas_passthrough(self):
+        df = pd.DataFrame({'x': [1, 2, 3]})
+        result = ensure_pandas(df)
+        assert result is df  # Same object, not a copy
+
+    def test_polars_conversion(self, polars_df):
+        result = ensure_pandas(polars_df)
+        assert isinstance(result, pd.DataFrame)
+        assert len(result) == 500
+        assert list(result.columns) == [
+            'a',
+            'b',
+            'c',
+            'd',
+            'group',
+            'connect',
+            'connect_order',
+        ]
+
+    def test_polars_has_range_index(self, polars_df):
+        result = ensure_pandas(polars_df)
+        assert isinstance(result.index, pd.RangeIndex)
+        assert result.index[0] == 0
+        assert result.index[-1] == 499
+
+    def test_polars_numeric_values_preserved(self, polars_df):
+        result = ensure_pandas(polars_df)
+        np.testing.assert_allclose(result['a'].values, np.linspace(0, 1, 500))
+
+    def test_polars_categorical_preserved(self, polars_df):
+        result = ensure_pandas(polars_df)
+        assert isinstance(result['group'].dtype, pd.CategoricalDtype)
+
+    def test_polars_categorical_order_sorted(self, polars_df):
+        """Polars orders categories by first appearance; after conversion the
+        categories must be naturally sorted so that color codes are
+        deterministic."""
+        result = ensure_pandas(polars_df)
+        cats = result['group'].cat.categories.tolist()
+        assert cats == sorted(cats, key=_natural_sort_key)
+
+    def test_polars_categorical_codes_match_native_pandas(self):
+        """Category codes from Polars->ensure_pandas must match a natively
+        constructed Pandas Categorical with the same values (pure alpha case
+        where natural sort == lexicographic sort)."""
+        values = ['C', 'A', 'B', 'A', 'C', 'B', 'D', 'D', 'A', 'B']
+
+        # Native Pandas (sorted categories by default)
+        native = pd.DataFrame({'g': pd.Categorical(values)})
+
+        # Polars -> ensure_pandas
+        converted = ensure_pandas(
+            pl.DataFrame({'g': values}).cast({'g': pl.Categorical})
+        )
+
+        assert (
+            native['g'].cat.categories.tolist()
+            == converted['g'].cat.categories.tolist()
+        )
+        np.testing.assert_array_equal(
+            native['g'].cat.codes.values,
+            converted['g'].cat.codes.values,
+        )
+
+    def test_polars_categorical_natural_sort_order(self):
+        """Categories with numbers must be sorted naturally:
+        A1 < A2 < A10, not A1 < A10 < A2."""
+        values = ['A10', 'A1', 'A2', 'A20', 'A3', 'A1', 'A10', 'A3']
+
+        converted = ensure_pandas(
+            pl.DataFrame({'g': values}).cast({'g': pl.Categorical})
+        )
+
+        assert converted['g'].cat.categories.tolist() == [
+            'A1',
+            'A2',
+            'A3',
+            'A10',
+            'A20',
+        ]
+
+    def test_pyarrow_table_conversion(self, arrow_table):
+        result = ensure_pandas(arrow_table)
+        assert isinstance(result, pd.DataFrame)
+        assert len(result) == 500
+
+    def test_unsupported_type_raises(self):
+        with pytest.raises(TypeError, match='Arrow PyCapsule Interface'):
+            ensure_pandas([1, 2, 3])
+
+    def test_unsupported_type_raises_dict(self):
+        with pytest.raises(TypeError, match='Arrow PyCapsule Interface'):
+            ensure_pandas({'x': [1, 2, 3]})
+
+    def test_polars_integer_columns(self):
+        df = pl.DataFrame({'x': [1, 2, 3], 'y': [4, 5, 6]})
+        result = ensure_pandas(df)
+        assert result['x'].tolist() == [1, 2, 3]
+        assert result['y'].tolist() == [4, 5, 6]
+
+    def test_polars_float_columns(self):
+        df = pl.DataFrame({'x': [1.5, 2.5, 3.5], 'y': [4.5, 5.5, 6.5]})
+        result = ensure_pandas(df)
+        np.testing.assert_allclose(result['x'].values, [1.5, 2.5, 3.5])
+
+    def test_polars_string_columns(self):
+        df = pl.DataFrame({'label': ['a', 'b', 'c']})
+        result = ensure_pandas(df)
+        assert result['label'].tolist() == ['a', 'b', 'c']
+
+    def test_polars_null_values(self):
+        df = pl.DataFrame({'x': [1.0, None, 3.0], 'y': [None, 2.0, 3.0]})
+        result = ensure_pandas(df)
+        assert pd.isna(result['x'].iloc[1])
+        assert pd.isna(result['y'].iloc[0])
+
+    def test_polars_enum_dtype(self):
+        """Polars Enum type should convert to Pandas Categorical."""
+        df = pl.DataFrame(
+            {
+                'status': pl.Series(
+                    ['active', 'inactive', 'active'],
+                    dtype=pl.Enum(['active', 'inactive', 'pending']),
+                )
+            }
+        )
+        result = ensure_pandas(df)
+        assert isinstance(result, pd.DataFrame)
+        assert result['status'].tolist() == ['active', 'inactive', 'active']
+
+
+# ---------------------------------------------------------------------------
+# Scatter with Polars input
+# ---------------------------------------------------------------------------
+
+
+class TestScatterPolarsInit:
+    def test_basic_scatter(self, polars_df):
+        scatter = Scatter(data=polars_df, x='a', y='b')
+        assert scatter._data is not None
+        assert isinstance(scatter._data, pd.DataFrame)
+        assert scatter._n == 500
+
+    def test_widget_points_shape(self, polars_df):
+        scatter = Scatter(data=polars_df, x='a', y='b')
+        widget_data = np.asarray(scatter.widget.points)
+        assert widget_data.shape == (500, 4)
+
+    def test_widget_points_values(self, polars_df, pandas_df):
+        scatter_pl = Scatter(data=polars_df, x='a', y='b')
+        scatter_pd = Scatter(data=pandas_df, x='a', y='b')
+
+        pl_points = np.asarray(scatter_pl.widget.points)
+        pd_points = np.asarray(scatter_pd.widget.points)
+
+        # Points from Polars and Pandas input should be identical
+        np.testing.assert_allclose(pl_points[:, 0], pd_points[:, 0], atol=1e-6)
+        np.testing.assert_allclose(pl_points[:, 1], pd_points[:, 1], atol=1e-6)
+
+    def test_x_y_normalization(self, polars_df, pandas_df):
+        scatter = Scatter(data=polars_df, x='a', y='b')
+        widget_data = np.asarray(scatter.widget.points)
+
+        expected_x = to_ndc(pandas_df['a'].values, create_default_norm())
+        expected_y = to_ndc(pandas_df['b'].values, create_default_norm())
+
+        np.testing.assert_allclose(widget_data[:, 0], expected_x)
+        np.testing.assert_allclose(widget_data[:, 1], expected_y)
+
+
+class TestScatterPolarsColorEncoding:
+    def test_color_by_numeric(self, polars_df):
+        scatter = Scatter(data=polars_df, x='a', y='b', color_by='c')
+        widget_data = np.asarray(scatter.widget.points)
+        assert np.sum(widget_data[:, 2]) > 0
+
+    def test_color_by_categorical(self, polars_df):
+        scatter = Scatter(data=polars_df, x='a', y='b', color_by='group')
+        widget_data = np.asarray(scatter.widget.points)
+        assert 'color' in scatter._encodings.visual
+        assert np.sum(widget_data[:, 2]) > 0
+
+    def test_color_categories_match_pandas(self, polars_df, pandas_df):
+        scatter_pl = Scatter(data=polars_df, x='a', y='b', color_by='group')
+        scatter_pd = Scatter(data=pandas_df, x='a', y='b', color_by='group')
+        assert set(scatter_pl._color_categories.keys()) == set(
+            scatter_pd._color_categories.keys()
+        )
+
+
+class TestScatterPolarsOpacitySizeEncoding:
+    def test_opacity_by(self, polars_df):
+        scatter = Scatter(data=polars_df, x='a', y='b', color_by='group')
+        scatter.opacity(by='c')
+        widget_data = np.asarray(scatter.widget.points)
+        assert 'opacity' in scatter._encodings.visual
+        assert np.sum(widget_data[:, 3]) > 0
+
+    def test_size_by(self, polars_df):
+        scatter = Scatter(data=polars_df, x='a', y='b', color_by='group')
+        scatter.size(by='c')
+        widget_data = np.asarray(scatter.widget.points)
+        assert 'size' in scatter._encodings.visual
+        assert np.sum(widget_data[:, 3]) > 0
+
+
+class TestScatterPolarsConnectionEncoding:
+    def test_connect_by(self, polars_df):
+        scatter = Scatter(data=polars_df, x='a', y='b')
+        scatter.connect(by='connect')
+        widget_data = np.asarray(scatter.widget.points)
+        assert widget_data.shape == (500, 5)
+
+    def test_connect_by_with_order(self, polars_df):
+        scatter = Scatter(data=polars_df, x='a', y='b')
+        scatter.connect(by='connect', order='connect_order')
+        widget_data = np.asarray(scatter.widget.points)
+        assert widget_data.shape == (500, 6)
+
+
+# ---------------------------------------------------------------------------
+# Selection & filtering with Polars input
+# ---------------------------------------------------------------------------
+
+
+class TestScatterPolarsSelection:
+    def test_selection_set_and_get(self, polars_df):
+        scatter = Scatter(data=polars_df, x='a', y='b')
+        _ = scatter.widget  # Instantiate widget
+
+        scatter.selection([0, 5, 10])
+        result = scatter.selection()
+        np.testing.assert_array_equal(result, np.array([0, 5, 10], dtype='uint32'))
+
+    def test_selection_clear(self, polars_df):
+        scatter = Scatter(data=polars_df, x='a', y='b')
+        _ = scatter.widget
+
+        scatter.selection([0, 5, 10])
+        scatter.selection(None)
+        result = scatter.selection()
+        assert len(result) == 0
+
+    def test_filter_set_and_get(self, polars_df):
+        scatter = Scatter(data=polars_df, x='a', y='b')
+        _ = scatter.widget
+
+        scatter.filter([1, 2, 3, 4])
+        result = scatter.filter()
+        np.testing.assert_array_equal(result, np.array([1, 2, 3, 4], dtype='uint32'))
+
+    def test_filter_clear(self, polars_df):
+        scatter = Scatter(data=polars_df, x='a', y='b')
+        _ = scatter.widget
+
+        scatter.filter([1, 2, 3])
+        result = scatter.filter()
+        np.testing.assert_array_equal(result, np.array([1, 2, 3], dtype='uint32'))
+
+        scatter.filter(None)
+        # After clearing, filter returns the stored None value
+        assert scatter._filtered_points_ids is None
+
+    def test_selection_roundtrip_to_polars(self, polars_df):
+        """Selected indices can be used to index back into the original Polars DF."""
+        scatter = Scatter(data=polars_df, x='a', y='b')
+        _ = scatter.widget
+
+        indices = [0, 10, 50]
+        scatter.selection(indices)
+        selected = scatter.selection()
+
+        # Use the integer positions to index back into the original Polars DF
+        result = polars_df[selected.tolist()]
+        assert len(result) == 3
+        assert result['a'][0] == polars_df['a'][0]
+        assert result['a'][1] == polars_df['a'][10]
+        assert result['a'][2] == polars_df['a'][50]
+
+
+# ---------------------------------------------------------------------------
+# Data update with Polars
+# ---------------------------------------------------------------------------
+
+
+class TestScatterPolarsDataUpdate:
+    def test_data_update_polars_to_polars(self, polars_df, polars_df2):
+        scatter = Scatter(data=polars_df, x='a', y='b')
+        _ = scatter.widget
+
+        scatter.data(polars_df2)
+        assert scatter._n == 500
+        assert isinstance(scatter._data, pd.DataFrame)
+
+    def test_data_update_pandas_to_polars(self, polars_df):
+        pandas_df = pd.DataFrame(
+            {
+                'a': np.linspace(0, 1, 500),
+                'b': np.linspace(0, 1, 500),
+            }
+        )
+        scatter = Scatter(data=pandas_df, x='a', y='b')
+        _ = scatter.widget
+
+        scatter.data(polars_df)
+        assert scatter._n == 500
+        assert isinstance(scatter._data, pd.DataFrame)
+
+    def test_data_update_polars_to_pandas(self, polars_df):
+        scatter = Scatter(data=polars_df, x='a', y='b')
+        _ = scatter.widget
+
+        pandas_df = pd.DataFrame(
+            {
+                'a': np.linspace(-1, 1, 300),
+                'b': np.linspace(-1, 1, 300),
+            }
+        )
+        scatter.data(pandas_df)
+        assert scatter._n == 300
+        assert isinstance(scatter._data, pd.DataFrame)
+
+    def test_data_update_preserves_encodings(self, polars_df, polars_df2):
+        scatter = Scatter(data=polars_df, x='a', y='b', color_by='group')
+        _ = scatter.widget
+        assert 'color' in scatter._encodings.visual
+
+        scatter.data(polars_df2)
+        scatter.color(by='group')
+        widget_data = np.asarray(scatter.widget.points)
+        assert np.sum(widget_data[:, 2]) > 0
+
+
+# ---------------------------------------------------------------------------
+# PyArrow Table input (via PyCapsule)
+# ---------------------------------------------------------------------------
+
+
+class TestScatterPyArrowInput:
+    def test_basic_arrow_table(self, arrow_table):
+        scatter = Scatter(data=arrow_table, x='a', y='b')
+        assert isinstance(scatter._data, pd.DataFrame)
+        assert scatter._n == 500
+
+    def test_arrow_points_match_polars(self, polars_df, arrow_table):
+        scatter_pl = Scatter(data=polars_df, x='a', y='b')
+        scatter_pa = Scatter(data=arrow_table, x='a', y='b')
+
+        pl_points = np.asarray(scatter_pl.widget.points)
+        pa_points = np.asarray(scatter_pa.widget.points)
+
+        np.testing.assert_allclose(pl_points, pa_points, atol=1e-6)
+
+    def test_arrow_with_color_encoding(self, arrow_table):
+        scatter = Scatter(data=arrow_table, x='a', y='b', color_by='c')
+        widget_data = np.asarray(scatter.widget.points)
+        assert np.sum(widget_data[:, 2]) > 0
+
+
+# ---------------------------------------------------------------------------
+# Serialization round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestSerializationPolars:
+    def test_polars_to_arrow_ipc(self, polars_df):
+        """Polars DF serialized through ensure_pandas should round-trip via Arrow IPC."""
+        pdf = ensure_pandas(polars_df)
+        buf = df_to_arrow_ipc_buffer(pdf)
+        assert buf is not None
+
+        result = arrow_ipc_buffer_to_df(buf)
+        assert isinstance(result, pd.DataFrame)
+        assert len(result) == 500
+        assert list(result.columns) == list(pdf.columns)
+
+    def test_arrow_ipc_values_preserved(self, polars_df):
+        pdf = ensure_pandas(polars_df)
+        buf = df_to_arrow_ipc_buffer(pdf)
+        result = arrow_ipc_buffer_to_df(buf)
+
+        np.testing.assert_allclose(result['a'].values, pdf['a'].values)
+        np.testing.assert_allclose(result['b'].values, pdf['b'].values)
+
+    def test_serializer_pycapsule_path(self, arrow_table):
+        """Arrow table can be serialized directly via the PyCapsule path."""
+        buf = df_to_arrow_ipc_buffer(arrow_table)
+        assert buf is not None
+
+        result = arrow_ipc_buffer_to_df(buf)
+        assert isinstance(result, pd.DataFrame)
+        assert len(result) == 500
+
+
+# ---------------------------------------------------------------------------
+# Tooltip with Polars input
+# ---------------------------------------------------------------------------
+
+
+class TestScatterPolarsTooltip:
+    def test_tooltip_init(self, polars_df):
+        scatter = Scatter(
+            data=polars_df,
+            x='a',
+            y='b',
+            tooltip=True,
+            tooltip_properties=['a', 'b', 'c', 'group'],
+        )
+        assert scatter.widget.tooltip_enable == True
+        assert scatter.widget.tooltip_properties == ['a', 'b', 'c', 'group']
+
+    def test_tooltip_histograms(self, polars_df, pandas_df):
+        scatter = Scatter(
+            data=polars_df,
+            x='a',
+            y='b',
+            tooltip=True,
+            tooltip_properties=['a', 'b'],
+        )
+
+        # X histogram should match what Pandas produces
+        expected = np.histogram(pandas_df['a'].values, bins=20)[0]
+        expected = expected / expected.max()
+        np.testing.assert_allclose(scatter.widget.x_histogram, expected)
+
+
+# ---------------------------------------------------------------------------
+# Axes labels with Polars input
+# ---------------------------------------------------------------------------
+
+
+class TestScatterPolarsAxes:
+    def test_axes_labels(self, polars_df):
+        scatter = Scatter(data=polars_df, x='a', y='b')
+        scatter.axes(labels=True)
+        assert scatter.widget.axes_labels == ['a', 'b']
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestPolarsEdgeCases:
+    def test_empty_polars_df(self):
+        """Empty DataFrames trigger a numpy min/max error (pre-existing issue)."""
+        df = pl.DataFrame({'x': [], 'y': []}).cast({'x': pl.Float64, 'y': pl.Float64})
+        result = ensure_pandas(df)
+        assert isinstance(result, pd.DataFrame)
+        assert len(result) == 0
+
+    def test_single_row_polars_df(self):
+        df = pl.DataFrame({'x': [1.0], 'y': [2.0]})
+        scatter = Scatter(data=df, x='x', y='y')
+        assert scatter._n == 1
+
+    def test_large_polars_df(self):
+        n = 100_000
+        df = pl.DataFrame(
+            {
+                'x': np.random.rand(n).tolist(),
+                'y': np.random.rand(n).tolist(),
+            }
+        )
+        scatter = Scatter(data=df, x='x', y='y')
+        assert scatter._n == n
+
+    def test_polars_with_many_columns(self):
+        data = {f'col_{i}': np.random.rand(100).tolist() for i in range(50)}
+        data['x'] = np.random.rand(100).tolist()
+        data['y'] = np.random.rand(100).tolist()
+        df = pl.DataFrame(data)
+
+        scatter = Scatter(data=df, x='x', y='y')
+        assert scatter._n == 100
+
+    def test_polars_boolean_column(self):
+        df = pl.DataFrame(
+            {
+                'x': [1.0, 2.0, 3.0],
+                'y': [4.0, 5.0, 6.0],
+                'flag': [True, False, True],
+            }
+        )
+        scatter = Scatter(data=df, x='x', y='y')
+        assert scatter._n == 3
+
+    def test_polars_multiple_categorical_columns(self):
+        df = pl.DataFrame(
+            {
+                'x': [1.0, 2.0, 3.0, 4.0],
+                'y': [4.0, 5.0, 6.0, 7.0],
+                'cat_a': ['a', 'b', 'a', 'b'],
+                'cat_b': ['x', 'y', 'x', 'y'],
+            }
+        ).cast(
+            {
+                'cat_a': pl.Categorical,
+                'cat_b': pl.Categorical,
+            }
+        )
+        scatter = Scatter(data=df, x='x', y='y', color_by='cat_a')
+        widget_data = np.asarray(scatter.widget.points)
+        assert np.sum(widget_data[:, 2]) > 0
+
+    def test_polars_with_nan_in_encoding(self):
+        no_nan = [0.0, 0.25, 0.5, 0.75, 1.0]
+        with_nan = [0.0, 0.25, 0.5, None, 1.0]
+
+        df = pl.DataFrame({'x': no_nan, 'y': no_nan, 'z': with_nan})
+
+        with pytest.warns(UserWarning, match='missing values'):
+            scatter = Scatter(data=df, x='x', y='y', color_by='z')
+            assert np.isfinite(scatter.widget.points).all()
+
+    def test_polars_datetime_column_ignored(self):
+        """Datetime columns shouldn't break anything if not used for encoding."""
+        from datetime import date
+
+        df = pl.DataFrame(
+            {
+                'x': [1.0, 2.0, 3.0],
+                'y': [4.0, 5.0, 6.0],
+                'date': [date(2024, 1, 1), date(2024, 1, 2), date(2024, 1, 3)],
+            }
+        )
+        scatter = Scatter(data=df, x='x', y='y')
+        assert scatter._n == 3
+
+
+# ---------------------------------------------------------------------------
+# Custom PyCapsule-compatible object
+# ---------------------------------------------------------------------------
+
+
+class TestCustomPyCapsuleObject:
+    def test_custom_object_with_arrow_c_stream(self):
+        """Any object with __arrow_c_stream__ should work."""
+        # Create a PyArrow table and use it as a PyCapsule source
+        table = pa.table({'x': [1.0, 2.0, 3.0], 'y': [4.0, 5.0, 6.0]})
+
+        # Simulate a custom object that wraps Arrow data
+        class CustomArrowWrapper:
+            def __init__(self, table):
+                self._table = table
+
+            def __len__(self):
+                return len(self._table)
+
+            def __arrow_c_stream__(self, requested_schema=None):
+                return self._table.__arrow_c_stream__(requested_schema)
+
+        wrapper = CustomArrowWrapper(table)
+        result = ensure_pandas(wrapper)
+        assert isinstance(result, pd.DataFrame)
+        assert len(result) == 3
+        assert result['x'].tolist() == [1.0, 2.0, 3.0]
+
+
+# ---------------------------------------------------------------------------
+# DuckDB integration (if available)
+# ---------------------------------------------------------------------------
+
+
+class TestDuckDBIntegration:
+    @pytest.fixture(autouse=True)
+    def _check_duckdb(self):
+        pytest.importorskip('duckdb')
+
+    def test_duckdb_result_to_scatter(self):
+        import duckdb
+
+        conn = duckdb.connect()
+        result = conn.sql(
+            'SELECT x::DOUBLE as x, y::DOUBLE as y FROM '
+            '(VALUES (1, 4), (2, 5), (3, 6)) AS t(x, y)'
+        ).arrow()
+
+        scatter = Scatter(data=result, x='x', y='y')
+        assert scatter._n == 3
+        assert isinstance(scatter._data, pd.DataFrame)

--- a/tests/test_polars_support.py
+++ b/tests/test_polars_support.py
@@ -1,8 +1,9 @@
 import numpy as np
 import pandas as pd
-import polars as pl
 import pyarrow as pa
 import pytest
+
+pl = pytest.importorskip('polars')
 
 from jscatter.jscatter import Scatter, check_encoding_dtype
 from jscatter.dataframe_utils import ensure_pandas, _natural_sort_key


### PR DESCRIPTION
This PR adds support for the Arrow PyCapsule Interface and as a consequence now supports Arrow, Polars, DuckDB, and more

## Description

### What was changed in this PR?

We're internally wrapping incoming data to a Pandas dataframe

- Any DataFrame implementing the Arrow PyCapsule Interface (`__arrow_c_stream__`) are converted to Pandas at the input boundary via Arrow. This ensures that all existing behavior
is preserved.
- Categorical columns are naturally sorted after conversion (A1 < A2 < A10, not A1 < A10 < A2) to ensure consistent color assignments across libraries

### Example

https://github.com/user-attachments/assets/5ae6bed4-2a13-4ea8-8d0f-6e0469e89a84

### Why is this PR necessary?

Fixes #196

## Checklist

- [x] Provided a concise title as a [semantic commit message](https://www.conventionalcommits.org) (e.g. "fix: correctly handle undefined properties")
- [x] `CHANGELOG.md` updated
- [x] Tests added or updated
- [x] Documentation in `README.md` added or updated
- [x] Example(s) added or updated
- [x] Screenshot, gif, or video attached for visual changes
