### PR TITLE
feat: order points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-## v0.23.0
+## v1.0.0
 
+- Feat: add `order()` for determining the draw order of points ([#190](https://github.com/flekschas/jupyter-scatter/issues/190) via [#237](https://github.com/flekschas/jupyter-scatter/pull/237))
 - Feat: use categorical color encoding in histogram bars ([#97](https://github.com/flekschas/jupyter-scatter/issues/97))
 - Refactor: move toolbar UI from Python ipywidgets to TS React. This enables full Marimo support 🎉
 - Chore: add `straight` option to connect() for straight line connections ([#130](https://github.com/flekschas/jupyter-scatter/pull/130))

--- a/docs/api.md
+++ b/docs/api.md
@@ -3,7 +3,7 @@
 - [Scatter](#scatter)
   - [Methods](#methods)
     - [x()](#scatter.x), [y()](#scatter.x), [xy()](#scatter.xy), and [data()](#scatter.data)
-    - [selection()](#scatter.selection) and [filter()](#scatter.filter)
+    - [selection()](#scatter.selection), [filter()](#scatter.filter), and [order()](#scatter.order)
     - [color()](#scatter.color), [opacity()](#scatter.opacity), and [size()](#scatter.size)
     - [connect()](#scatter.connect), [connection_color()](#scatter.connection_color), [connection_opacity()](#scatter.connection_opacity), and [connection_size()](#scatter.connection_size)
     - [axes()](#scatter.axes), [legend()](#scatter.legend), [label()](#scatter.label), and [annotations()](#scatter.annotations)
@@ -195,6 +195,43 @@ Get or set the filtered points. When filtering down to a set of points, all othe
 ```python
 scatter.filter(cars.query('speed < 50').index)
 scatter.filter(None) # To unset filter
+```
+
+
+### scatter.order(_by=Undefined_, _map=Undefined_, _direction=Undefined_, _na\_values=Undefined_) {#scatter.order}
+
+Get or set the draw order of points. Points drawn later appear on top of earlier points. By default, points are drawn in the order they appear in the data. This method allows you to control the draw order without reordering the underlying data.
+
+**Arguments:**
+
+- `by` is either a string referencing a column in `data` (for sorting by column values), an array-like list of integers (used directly as the draw order), or `None` (to reset to the default input order).
+- `map` is a list of category values defining a custom draw sequence. Values earlier in the list are drawn first (behind), values later are drawn last (on top). When set, `direction` is ignored. Missing values (NaN) are still controlled by `na_values`.
+- `direction` is either `'asc'` or `'desc'`. Controls the sort direction when `by` is a column name. `'asc'` draws points with smaller values first (behind). Defaults to `'asc'`.
+- `na_values` is either `'first'`, `'last'`, or `None`. Controls where NaN/missing values are placed in the sort order. `'first'` draws them behind all other points, `'last'` draws them on top. Defaults to `'last'`.
+
+**Returns:** either the current order settings when all arguments are `Undefined` or `self`.
+
+**Examples:**
+
+```python
+# Order by a column (ascending: small values behind, large on top)
+scatter.order(by='price')
+
+# Descending order with NaN behind everything
+scatter.order(by='price', direction='desc', na_values='first')
+
+# Custom category order: B drawn on top
+scatter.order(by='cluster', map=['A', 'C', 'B'])
+
+# Provide a custom draw order directly
+scatter.order(by=[2, 0, 1, 4, 3])
+
+# Reset to default input order
+scatter.order(by=None)
+
+# Get the current order settings
+scatter.order()
+# => {'by': 'price', 'map': None, 'direction': 'desc', 'na_values': 'first'}
 ```
 
 
@@ -742,6 +779,10 @@ You can define those property when creating a `Scatter` instance. For example,
 | `y`                        | str \| list[float] \| ndarray                                                            | `None`                                         |
 | `y_scale`                  | 'linear' \| 'log' \| 'pow' \| tuple[float] \| [LogNorm][lognorm] \| [PowerNorm][pownorm] | `linear`                                       |
 | `selection`                | list[int]                                                                                | `[]`                                           |
+| `order_by`                 | str \| list[int] \| None                                                                 | `None`                                         |
+| `order_map`                | list[str] \| None                                                                        | `None`                                         |
+| `order_direction`          | 'asc' \| 'desc'                                                                          | `'asc'`                                        |
+| `order_na_values`          | 'first' \| 'last' \| None                                                                | `'last'`                                       |
 | `width`                    | int \| 'auto'                                                                            | `'auto'`                                       |
 | `height`                   | int                                                                                      | `240`                                          |
 | `color`                    | str \| tuple[float] \| list[float]                                                       | `(0, 0, 0, 0.66)`                              |

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -26,7 +26,7 @@
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "regl": "~2.1.0",
-        "regl-scatterplot": "~1.14.1"
+        "regl-scatterplot": "~1.16.0"
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.14",
@@ -1735,9 +1735,9 @@
       }
     },
     "node_modules/earcut": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.1.tgz",
-      "integrity": "sha512-0l1/0gOjESMeQyYaK5IDiPNvFeu93Z/cO0TjZh9eZ1vyCtZnA7KMZ8rQggpsJHIbGSdrqYq9OhuveadOVHCshw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
+      "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
       "license": "ISC"
     },
     "node_modules/enhanced-resolve": {
@@ -2318,15 +2318,15 @@
       }
     },
     "node_modules/regl-scatterplot": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/regl-scatterplot/-/regl-scatterplot-1.14.1.tgz",
-      "integrity": "sha512-2WMrP6+pgoeckPpWrkHEqPpSJKjR3/QgNGBqctRCbzofsxDx3nDQh7541KnTH3LheGiZEofSJAoctdySgZG+tg==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/regl-scatterplot/-/regl-scatterplot-1.16.0.tgz",
+      "integrity": "sha512-LSNRzihkLgaSEALZv95+w02nX1c6slJJahqHqMNY0YOkE3L6Bk1e38GJaGatW2w8PlB1tOdvq3Cj0tPPrBhpsA==",
       "license": "MIT",
       "dependencies": {
-        "@flekschas/utils": "^0.32.2",
+        "@flekschas/utils": "^0.33.0",
         "dom-2d-camera": "^2.2.6",
-        "earcut": "^3.0.1",
-        "gl-matrix": "~3.4.3",
+        "earcut": "^3.0.2",
+        "gl-matrix": "~3.4.4",
         "pub-sub-es": "~3.0.0",
         "regl": "~2.1.1",
         "regl-line": "~1.1.1"
@@ -2340,10 +2340,17 @@
         "regl": "~2.1.1"
       }
     },
+    "node_modules/regl-scatterplot/node_modules/@flekschas/utils": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@flekschas/utils/-/utils-0.33.0.tgz",
+      "integrity": "sha512-THnZZqtQ5me5kgF9xzI0oYJ8D+524kKXKCUJErAmlT8pfw2iTwiyPDS8f3SqrY9Y7M8zNY2dGME+JBUpKypEqg==",
+      "license": "MIT"
+    },
     "node_modules/regl-scatterplot/node_modules/gl-matrix": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.3.tgz",
-      "integrity": "sha512-wcCp8vu8FT22BnvKVPjXa/ICBWRq/zjFfdofZy1WSpQZpphblv12/bOQLBC1rMM7SGOFS9ltVmKOHil5+Ml7gA=="
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.4.tgz",
+      "integrity": "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==",
+      "license": "MIT"
     },
     "node_modules/requires-port": {
       "version": "1.0.0",

--- a/js/package.json
+++ b/js/package.json
@@ -36,7 +36,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "regl": "~2.1.0",
-    "regl-scatterplot": "~1.14.1"
+    "regl-scatterplot": "~1.16.0"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.14",

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -109,6 +109,7 @@ const properties = {
   opacityBy: 'opacityBy',
   opacityUnselected: 'opacityInactiveScale',
   reglScatterplotOptions: 'reglScatterplotOptions',
+  pointOrder: 'pointOrder',
   points: 'points',
   reticle: 'showReticle',
   reticleColor: 'reticleColor',
@@ -2522,6 +2523,10 @@ class JupyterScatterView {
   }
 
   // Event handlers for Python-triggered events
+  pointOrderHandler(newPointOrder) {
+    this.scatterplot.set({ pointOrder: newPointOrder });
+  }
+
   pointsHandler(newPoints) {
     if (newPoints.length === this.scatterplot.get('points').length) {
       // We assume point correspondence

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -233,6 +233,7 @@ const reglScatterplotProperty = new Set([
   'pointConnectionOpacityBy',
   'pointConnectionSize',
   'pointConnectionSizeBy',
+  'pointOrder',
 ]);
 
 // Custom View. Renders the widget model.
@@ -3185,6 +3186,7 @@ async function render({ model, el }) {
     el: el,
     model: modelWithSerializers(model, {
       points: Numpy2D('float32'),
+      point_order: Numpy1D('uint32'),
       selection: Numpy1D('uint32'),
       filter: Numpy1D('uint32'),
       view_data: NumpyImage(),

--- a/jscatter/jscatter.py
+++ b/jscatter/jscatter.py
@@ -1338,9 +1338,7 @@ class Scatter:
                 na_position=na_position,
                 kind='mergesort',
             ).index
-            order = np.empty(len(sorted_idx), dtype=np.uint32)
-            order[sorted_idx] = np.arange(len(sorted_idx), dtype=np.uint32)
-            return order
+            return np.asarray(sorted_idx, dtype=np.uint32)
 
         return np.asarray(self._order_by, dtype=np.uint32)
 
@@ -1698,7 +1696,10 @@ class Scatter:
                         if self._background_color_luminance < 0.5
                         else gray_light
                     )
-                    self._color_map = [gray] + self._color_map
+                    # Clip to the number of non-NA categories so gray
+                    # lands exactly at the NA index
+                    n_cats = len(self._color_categories) - 1
+                    self._color_map = self._color_map[:n_cats] + [gray]
 
         if labeling is not UNDEF:
             if labeling is None:

--- a/jscatter/jscatter.py
+++ b/jscatter/jscatter.py
@@ -42,6 +42,8 @@ from .types import (
     LabelPositioning,
     LabelScaleFunction,
     MouseModes,
+    OrderDirection,
+    OrderNaValues,
     Position,
     Reverse,
     Scales,
@@ -500,6 +502,10 @@ class Scatter:
         self._zoom_padding = 0.33
         self._zoom_on_selection = False
         self._zoom_on_filter = False
+        self._point_order = None
+        self._order_by = None
+        self._order_direction = 'asc'
+        self._order_na_values = 'last'
         self._regl_scatterplot_options = {}
 
         self.x(x, kwargs.get('x_scale', UNDEF))
@@ -613,6 +619,11 @@ class Scatter:
             kwargs.get('tooltip_preview_audio_loop', UNDEF),
             kwargs.get('tooltip_preview_audio_controls', UNDEF),
             kwargs.get('tooltip_size', UNDEF),
+        )
+        self.order(
+            kwargs.get('order_by', UNDEF),
+            kwargs.get('order_direction', UNDEF),
+            kwargs.get('order_na_values', UNDEF),
         )
         self.zoom(
             kwargs.get('zoom_to', UNDEF),
@@ -1308,6 +1319,107 @@ class Scatter:
             return row_idxs
 
         return self._filtered_points_ids
+
+    def _compute_point_order(self):
+        if self._order_by is None:
+            return None
+
+        if isinstance(self._order_by, str):
+            if self._data is None:
+                raise ValueError(
+                    'Cannot order by column name without a DataFrame. '
+                    'Use `data` to set a DataFrame first.'
+                )
+            series = self._data[self._order_by]
+            na_position = self._order_na_values or 'last'
+            ascending = self._order_direction != 'desc'
+            sorted_idx = series.sort_values(
+                ascending=ascending,
+                na_position=na_position,
+                kind='mergesort',
+            ).index
+            order = np.empty(len(sorted_idx), dtype=np.uint32)
+            order[sorted_idx] = np.arange(len(sorted_idx), dtype=np.uint32)
+            return order
+
+        return np.asarray(self._order_by, dtype=np.uint32)
+
+    def order(
+        self,
+        by: Optional[Union[str, List[int], np.ndarray, None, Undefined]] = UNDEF,
+        direction: Optional[Union[OrderDirection, Undefined]] = UNDEF,
+        na_values: Optional[Union[OrderNaValues, None, Undefined]] = UNDEF,
+    ) -> Union[Scatter, dict]:
+        """
+        Set or get the draw order of points.
+
+        Points drawn later appear on top of earlier points. By default, points
+        are drawn in the order they appear in the data. This method allows you
+        to control the draw order without reordering the underlying data.
+
+        Parameters
+        ----------
+        by : str, array_like, or None, optional
+            When set to a string, points are ordered by the values of the
+            corresponding column in the DataFrame using lexicographic (natural)
+            ordering. When set to an integer array, it is used directly as the
+            draw order (must be a permutation of point indices). When set to
+            ``None``, the order is reset to the default input order.
+        direction : {'asc', 'desc'}, optional
+            The sort direction when ``by`` is a column name. ``'asc'`` means
+            points with smaller values are drawn first (behind). ``'desc'``
+            means points with larger values are drawn first. Defaults to
+            ``'asc'``.
+        na_values : {'first', 'last'} or None, optional
+            Where to place NaN/missing values in the sort order when ``by`` is
+            a column name. ``'first'`` draws them behind all other points,
+            ``'last'`` draws them on top. Defaults to ``'last'``.
+
+        Returns
+        -------
+        self or dict
+            If no arguments were provided, a dictionary with the current
+            settings is returned. Otherwise, ``self`` is returned.
+
+        Examples
+        --------
+        >>> scatter.order(by='price')
+        <jscatter.jscatter.Scatter>
+
+        >>> scatter.order(by='price', direction='desc', na_values='first')
+        <jscatter.jscatter.Scatter>
+
+        >>> scatter.order(by=[2, 0, 1, 4, 3])
+        <jscatter.jscatter.Scatter>
+
+        >>> scatter.order(by=None)
+        <jscatter.jscatter.Scatter>
+
+        >>> scatter.order()
+        {'by': 'price', 'direction': 'desc', 'na_values': 'first'}
+        """
+        if by is not UNDEF:
+            if by is None:
+                self._order_by = None
+            else:
+                self._order_by = by
+
+        if direction is not UNDEF:
+            self._order_direction = direction
+
+        if na_values is not UNDEF:
+            self._order_na_values = na_values
+
+        if any_not([by, direction, na_values], UNDEF):
+            self._point_order = self._compute_point_order()
+            self.update_widget('point_order', self._point_order)
+            return self
+
+        return dict(
+            by=self._order_by,
+            direction=self._order_direction,
+            na_values=self._order_na_values,
+        )
 
     @property
     def color_data(self):
@@ -5292,6 +5404,7 @@ class Scatter:
             opacity_scale=get_scale(self, 'opacity'),
             opacity_title=self._opacity_by,
             opacity_unselected=self._opacity_unselected,
+            point_order=self._point_order,
             points=self.get_point_list(),
             reticle=self._reticle,
             reticle_color=self.get_reticle_color(),

--- a/jscatter/jscatter.py
+++ b/jscatter/jscatter.py
@@ -504,6 +504,7 @@ class Scatter:
         self._zoom_on_filter = False
         self._point_order = None
         self._order_by = None
+        self._order_map = None
         self._order_direction = 'asc'
         self._order_na_values = 'last'
         self._regl_scatterplot_options = {}
@@ -622,6 +623,7 @@ class Scatter:
         )
         self.order(
             kwargs.get('order_by', UNDEF),
+            kwargs.get('order_map', UNDEF),
             kwargs.get('order_direction', UNDEF),
             kwargs.get('order_na_values', UNDEF),
         )
@@ -1332,7 +1334,20 @@ class Scatter:
                 )
             series = self._data[self._order_by]
             na_position = self._order_na_values or 'last'
-            ascending = self._order_direction != 'desc'
+
+            if self._order_map is not None:
+                # Custom category order: convert to an ordered categorical
+                # so sort_values respects the provided sequence.
+                # Use cat codes directly to avoid deprecation warnings
+                # when the series contains values not in the map.
+                cat_order = {v: i for i, v in enumerate(self._order_map)}
+                # Cast to object first so .map() returns a numeric series
+                # instead of a categorical (which would sort by category order)
+                series = series.astype(object).map(cat_order)
+                ascending = True
+            else:
+                ascending = self._order_direction != 'desc'
+
             sorted_idx = series.sort_values(
                 ascending=ascending,
                 na_position=na_position,
@@ -1345,6 +1360,7 @@ class Scatter:
     def order(
         self,
         by: Optional[Union[str, List[int], np.ndarray, None, Undefined]] = UNDEF,
+        map: Optional[Union[List[str], None, Undefined]] = UNDEF,
         direction: Optional[Union[OrderDirection, Undefined]] = UNDEF,
         na_values: Optional[Union[OrderNaValues, None, Undefined]] = UNDEF,
     ) -> Union[Scatter, dict]:
@@ -1363,11 +1379,16 @@ class Scatter:
             ordering. When set to an integer array, it is used directly as the
             draw order (must be a permutation of point indices). When set to
             ``None``, the order is reset to the default input order.
+        map : list of str or None, optional
+            A custom category order for the column specified by ``by``. Values
+            earlier in the list are drawn first (behind), values later are drawn
+            last (on top). When set, ``direction`` is ignored. Missing values
+            (NaN) are still controlled by ``na_values``.
         direction : {'asc', 'desc'}, optional
             The sort direction when ``by`` is a column name. ``'asc'`` means
             points with smaller values are drawn first (behind). ``'desc'``
-            means points with larger values are drawn first. Defaults to
-            ``'asc'``.
+            means points with larger values are drawn first. Ignored when
+            ``map`` is set. Defaults to ``'asc'``.
         na_values : {'first', 'last'} or None, optional
             Where to place NaN/missing values in the sort order when ``by`` is
             a column name. ``'first'`` draws them behind all other points,
@@ -1387,6 +1408,9 @@ class Scatter:
         >>> scatter.order(by='price', direction='desc', na_values='first')
         <jscatter.jscatter.Scatter>
 
+        >>> scatter.order(by='cluster', map=['A', 'C', 'B'])
+        <jscatter.jscatter.Scatter>
+
         >>> scatter.order(by=[2, 0, 1, 4, 3])
         <jscatter.jscatter.Scatter>
 
@@ -1394,7 +1418,7 @@ class Scatter:
         <jscatter.jscatter.Scatter>
 
         >>> scatter.order()
-        {'by': 'price', 'direction': 'desc', 'na_values': 'first'}
+        {'by': 'price', 'map': None, 'direction': 'desc', 'na_values': 'first'}
         """
         if by is not UNDEF:
             if by is None:
@@ -1402,19 +1426,23 @@ class Scatter:
             else:
                 self._order_by = by
 
+        if map is not UNDEF:
+            self._order_map = map
+
         if direction is not UNDEF:
             self._order_direction = direction
 
         if na_values is not UNDEF:
             self._order_na_values = na_values
 
-        if any_not([by, direction, na_values], UNDEF):
+        if any_not([by, map, direction, na_values], UNDEF):
             self._point_order = self._compute_point_order()
             self.update_widget('point_order', self._point_order)
             return self
 
         return dict(
             by=self._order_by,
+            map=self._order_map,
             direction=self._order_direction,
             na_values=self._order_na_values,
         )

--- a/jscatter/types.py
+++ b/jscatter/types.py
@@ -40,6 +40,8 @@ WidgetButtons = Literal[
     'pan_zoom', 'lasso', 'full_screen', 'screenshot', 'download', 'reset', 'divider'
 ]
 LogLevel = Literal['debug', 'info', 'warning', 'error', 'critical']
+OrderDirection = Literal['asc', 'desc']
+OrderNaValues = Literal['first', 'last']
 
 NumericType = TypeVar('NumericType', int, float, np.number)
 

--- a/jscatter/utils.py
+++ b/jscatter/utils.py
@@ -311,7 +311,7 @@ def get_categorical_data(data):
 
     if categorical_data is not None and categorical_data.hasnans:
         # Create categories with your value first
-        cats = ['NA'] + list(categorical_data.cat.categories)
+        cats = list(categorical_data.cat.categories) + ['NA']
 
         # Create Series with ordered categories
         categorical_data = pd.Series(data, dtype=pd.CategoricalDtype(categories=cats))

--- a/jscatter/widget.py
+++ b/jscatter/widget.py
@@ -91,6 +91,9 @@ class JupyterScatter(anywidget.AnyWidget):
         sync=True, **ndarray_serialization
     )
     hovering = Int(None, allow_none=True).tag(sync=True)
+    point_order = Array(default_value=None, allow_none=True).tag(
+        sync=True, **ndarray_serialization
+    )
 
     # Channel titles
     x_title = Unicode(None, allow_none=True).tag(sync=True)

--- a/notebooks/marimo.py
+++ b/notebooks/marimo.py
@@ -47,7 +47,7 @@ def _():
             'value': np.random.uniform(0, 100, n),
         }
     )
-    return df, duckdb, jscatter, np, pa, pl
+    return df, duckdb, jscatter, np, pa, pd, pl
 
 
 @app.cell
@@ -72,6 +72,85 @@ def _(df, jscatter):
         sync_view=False,
         rows=1,
         row_height=320,
+    )
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    # Point Ordering
+
+    Use `scatter.order()` to control the draw order of points without
+    reordering the underlying data. Points drawn later appear on top.
+    """)
+    return
+
+
+@app.cell
+def _(np, pd):
+    # Three overlapping gaussian blobs + a wide noise cluster with NaN category
+    rng = np.random.default_rng(42)
+    n_per_blob = 500
+
+    blob_a = rng.normal(loc=[-0.5, 0.5], scale=0.4, size=(n_per_blob, 2))
+    blob_b = rng.normal(loc=[0.5, 0.5], scale=0.4, size=(n_per_blob, 2))
+    blob_c = rng.normal(loc=[0.0, -0.4], scale=0.4, size=(n_per_blob, 2))
+    blob_noise = rng.normal(loc=[0.0, 0.2], scale=1.2, size=(n_per_blob, 2))
+
+    coords = np.vstack([blob_a, blob_b, blob_c, blob_noise])
+    categories = (
+        ['A'] * n_per_blob
+        + ['B'] * n_per_blob
+        + ['C'] * n_per_blob
+        + [None] * n_per_blob
+    )
+
+    df_blobs = pd.DataFrame(
+        {
+            'x': coords[:, 0],
+            'y': coords[:, 1],
+            'cluster': pd.Categorical(categories),
+        }
+    )
+    # Shuffle so the default order is a mix of all clusters
+    df_blobs = df_blobs.sample(frac=1, random_state=42).reset_index(drop=True)
+    return (df_blobs,)
+
+
+@app.cell
+def _(df_blobs, jscatter):
+    _kw = dict(
+        data=df_blobs,
+        x='x',
+        y='y',
+        color_by='cluster',
+        size=4,
+        height=280,
+        legend=True,
+        axes=False,
+    )
+
+    scatter_default = jscatter.Scatter(**_kw)
+    scatter_c_top = jscatter.Scatter(**_kw, order_by='cluster', order_na_values='first')
+    scatter_a_top = jscatter.Scatter(
+        **_kw, order_by='cluster', order_direction='desc', order_na_values='first'
+    )
+    scatter_na_behind = jscatter.Scatter(
+        **_kw, order_by='cluster', order_na_values='last'
+    )
+
+    jscatter.compose(
+        [
+            (scatter_default, 'Default Order'),
+            (scatter_c_top, 'Asc (C on top)'),
+            (scatter_a_top, 'Desc (A on top)'),
+            (scatter_na_behind, 'NaN Behind'),
+        ],
+        sync_selection=True,
+        sync_view=True,
+        rows=1,
+        row_height=280,
     )
     return
 

--- a/notebooks/marimo.py
+++ b/notebooks/marimo.py
@@ -136,16 +136,23 @@ def _(df_blobs, jscatter):
     scatter_a_top = jscatter.Scatter(
         **_kw, order_by='cluster', order_direction='desc', order_na_values='first'
     )
+    scatter_b_top = jscatter.Scatter(
+        **_kw,
+        order_by='cluster',
+        order_map=['A', 'C', 'B'],
+        order_na_values='first',
+    )
     scatter_na_behind = jscatter.Scatter(
         **_kw, order_by='cluster', order_na_values='last'
     )
 
     jscatter.compose(
         [
-            (scatter_default, 'Default Order'),
-            (scatter_c_top, 'Asc (C on top)'),
-            (scatter_a_top, 'Desc (A on top)'),
-            (scatter_na_behind, 'NaN Behind'),
+            (scatter_default, 'Default'),
+            (scatter_c_top, 'C on top'),
+            (scatter_a_top, 'A on top'),
+            (scatter_b_top, 'B on top'),
+            (scatter_na_behind, 'NaN on top'),
         ],
         sync_selection=True,
         sync_view=True,

--- a/tests/test_jscatter.py
+++ b/tests/test_jscatter.py
@@ -638,3 +638,112 @@ def test_toolbar_buttons(df: pd.DataFrame):
     # Test show() returns the widget
     result = scatter.show()
     assert result is scatter.widget
+
+
+def test_order_by_column(df: pd.DataFrame):
+    scatter = Scatter(data=df, x='a', y='b')
+
+    # Order by a numeric column ascending (default)
+    scatter.order(by='c')
+    point_order = scatter.widget.point_order
+    assert point_order is not None
+    assert len(point_order) == len(df)
+    # Verify it's a valid permutation
+    assert set(point_order) == set(range(len(df)))
+
+    # The order should correspond to sorting by column 'c'
+    sorted_idx = df['c'].sort_values(ascending=True, kind='mergesort').index
+    expected = np.empty(len(sorted_idx), dtype=np.uint32)
+    expected[sorted_idx] = np.arange(len(sorted_idx), dtype=np.uint32)
+    assert np.array_equal(point_order, expected)
+
+
+def test_order_by_column_desc(df: pd.DataFrame):
+    scatter = Scatter(data=df, x='a', y='b')
+
+    scatter.order(by='c', direction='desc')
+    point_order = scatter.widget.point_order
+    assert point_order is not None
+
+    sorted_idx = df['c'].sort_values(ascending=False, kind='mergesort').index
+    expected = np.empty(len(sorted_idx), dtype=np.uint32)
+    expected[sorted_idx] = np.arange(len(sorted_idx), dtype=np.uint32)
+    assert np.array_equal(point_order, expected)
+
+
+def test_order_by_custom_array(df: pd.DataFrame):
+    scatter = Scatter(data=df, x='a', y='b')
+
+    custom_order = np.arange(len(df), dtype=np.uint32)[::-1].copy()
+    scatter.order(by=custom_order)
+    assert np.array_equal(scatter.widget.point_order, custom_order)
+
+
+def test_order_reset(df: pd.DataFrame):
+    scatter = Scatter(data=df, x='a', y='b')
+
+    scatter.order(by='c')
+    assert scatter.widget.point_order is not None
+
+    scatter.order(by=None)
+    assert scatter.widget.point_order is None
+
+
+def test_order_getter(df: pd.DataFrame):
+    scatter = Scatter(data=df, x='a', y='b')
+
+    result = scatter.order()
+    assert result == {'by': None, 'direction': 'asc', 'na_values': 'last'}
+
+    scatter.order(by='c', direction='desc', na_values='first')
+    result = scatter.order()
+    assert result == {'by': 'c', 'direction': 'desc', 'na_values': 'first'}
+
+
+def test_order_fluent_api(df: pd.DataFrame):
+    scatter = Scatter(data=df, x='a', y='b')
+
+    # Should return self for chaining
+    result = scatter.order(by='c')
+    assert result is scatter
+
+
+def test_order_with_na_values():
+    df = pd.DataFrame(
+        {
+            'x': [0.0, 1.0, 2.0, 3.0, 4.0],
+            'y': [0.0, 1.0, 2.0, 3.0, 4.0],
+            'val': [3.0, np.nan, 1.0, np.nan, 2.0],
+        }
+    )
+    scatter = Scatter(data=df, x='x', y='y')
+
+    # na_values='last' (default): NaN points drawn on top (last)
+    scatter.order(by='val', na_values='last')
+    order_last = scatter.widget.point_order
+    # Points with NaN (indices 1, 3) should have the highest order values
+    assert order_last[1] > order_last[0]
+    assert order_last[1] > order_last[2]
+    assert order_last[1] > order_last[4]
+    assert order_last[3] > order_last[0]
+    assert order_last[3] > order_last[2]
+    assert order_last[3] > order_last[4]
+
+    # na_values='first': NaN points drawn first (behind)
+    scatter.order(by='val', na_values='first')
+    order_first = scatter.widget.point_order
+    # Points with NaN (indices 1, 3) should have the lowest order values
+    assert order_first[1] < order_first[0]
+    assert order_first[1] < order_first[2]
+    assert order_first[1] < order_first[4]
+    assert order_first[3] < order_first[0]
+    assert order_first[3] < order_first[2]
+    assert order_first[3] < order_first[4]
+
+
+def test_order_via_constructor(df: pd.DataFrame):
+    scatter = Scatter(data=df, x='a', y='b', order_by='c', order_direction='desc')
+    assert scatter.widget.point_order is not None
+    result = scatter.order()
+    assert result['by'] == 'c'
+    assert result['direction'] == 'desc'

--- a/tests/test_jscatter.py
+++ b/tests/test_jscatter.py
@@ -691,11 +691,11 @@ def test_order_getter(df: pd.DataFrame):
     scatter = Scatter(data=df, x='a', y='b')
 
     result = scatter.order()
-    assert result == {'by': None, 'direction': 'asc', 'na_values': 'last'}
+    assert result == {'by': None, 'map': None, 'direction': 'asc', 'na_values': 'last'}
 
     scatter.order(by='c', direction='desc', na_values='first')
     result = scatter.order()
-    assert result == {'by': 'c', 'direction': 'desc', 'na_values': 'first'}
+    assert result == {'by': 'c', 'map': None, 'direction': 'desc', 'na_values': 'first'}
 
 
 def test_order_fluent_api(df: pd.DataFrame):
@@ -728,6 +728,47 @@ def test_order_with_na_values():
     order_first = scatter.widget.point_order
     # The first two entries in the draw sequence should be the NaN points
     assert set(order_first[:2]) == nan_indices
+
+
+def test_order_map(df: pd.DataFrame):
+    scatter = Scatter(data=df, x='a', y='b')
+
+    # Custom category order: B drawn last (on top)
+    scatter.order(by='group', map=['A', 'C', 'B'])
+    point_order = scatter.widget.point_order
+    assert point_order is not None
+
+    # Points in the draw sequence should follow the map order:
+    # all A points, then all C points, then all B points
+    groups = df['group'].iloc[point_order].values
+    # Find the last position of each group in the draw sequence
+    last_a = max(i for i, g in enumerate(groups) if g == 'A')
+    first_c = min(i for i, g in enumerate(groups) if g == 'C')
+    last_c = max(i for i, g in enumerate(groups) if g == 'C')
+    first_b = min(i for i, g in enumerate(groups) if g == 'B')
+    assert last_a < first_c
+    assert last_c < first_b
+
+
+def test_order_map_with_na():
+    df = pd.DataFrame(
+        {
+            'x': [0.0, 1.0, 2.0, 3.0, 4.0],
+            'y': [0.0, 1.0, 2.0, 3.0, 4.0],
+            'cat': pd.Categorical(['A', None, 'B', None, 'A']),
+        }
+    )
+    scatter = Scatter(data=df, x='x', y='y')
+
+    # B on top, NaN behind everything
+    scatter.order(by='cat', map=['A', 'B'], na_values='first')
+    order = scatter.widget.point_order
+    # NaN indices (1, 3) should be drawn first
+    assert set(order[:2]) == {1, 3}
+    # Then A, then B
+    cats = df['cat'].iloc[order[2:]].values
+    assert all(c == 'A' for c in cats[: sum(df['cat'] == 'A')])
+    assert all(c == 'B' for c in cats[sum(df['cat'] == 'A') :])
 
 
 def test_order_via_constructor(df: pd.DataFrame):

--- a/tests/test_jscatter.py
+++ b/tests/test_jscatter.py
@@ -651,11 +651,10 @@ def test_order_by_column(df: pd.DataFrame):
     # Verify it's a valid permutation
     assert set(point_order) == set(range(len(df)))
 
-    # The order should correspond to sorting by column 'c'
-    sorted_idx = df['c'].sort_values(ascending=True, kind='mergesort').index
-    expected = np.empty(len(sorted_idx), dtype=np.uint32)
-    expected[sorted_idx] = np.arange(len(sorted_idx), dtype=np.uint32)
-    assert np.array_equal(point_order, expected)
+    # point_order is a draw sequence: point_order[draw_pos] = point_index
+    # So df['c'].iloc[point_order] should be non-decreasing (ascending sort)
+    ordered_values = df['c'].iloc[point_order].values
+    assert np.all(ordered_values[:-1] <= ordered_values[1:])
 
 
 def test_order_by_column_desc(df: pd.DataFrame):
@@ -665,10 +664,9 @@ def test_order_by_column_desc(df: pd.DataFrame):
     point_order = scatter.widget.point_order
     assert point_order is not None
 
-    sorted_idx = df['c'].sort_values(ascending=False, kind='mergesort').index
-    expected = np.empty(len(sorted_idx), dtype=np.uint32)
-    expected[sorted_idx] = np.arange(len(sorted_idx), dtype=np.uint32)
-    assert np.array_equal(point_order, expected)
+    # df['c'].iloc[point_order] should be non-increasing (descending sort)
+    ordered_values = df['c'].iloc[point_order].values
+    assert np.all(ordered_values[:-1] >= ordered_values[1:])
 
 
 def test_order_by_custom_array(df: pd.DataFrame):
@@ -717,28 +715,19 @@ def test_order_with_na_values():
         }
     )
     scatter = Scatter(data=df, x='x', y='y')
+    nan_indices = {1, 3}
 
-    # na_values='last' (default): NaN points drawn on top (last)
+    # na_values='last' (default): NaN points drawn last (on top)
     scatter.order(by='val', na_values='last')
     order_last = scatter.widget.point_order
-    # Points with NaN (indices 1, 3) should have the highest order values
-    assert order_last[1] > order_last[0]
-    assert order_last[1] > order_last[2]
-    assert order_last[1] > order_last[4]
-    assert order_last[3] > order_last[0]
-    assert order_last[3] > order_last[2]
-    assert order_last[3] > order_last[4]
+    # The last two entries in the draw sequence should be the NaN points
+    assert set(order_last[-2:]) == nan_indices
 
     # na_values='first': NaN points drawn first (behind)
     scatter.order(by='val', na_values='first')
     order_first = scatter.widget.point_order
-    # Points with NaN (indices 1, 3) should have the lowest order values
-    assert order_first[1] < order_first[0]
-    assert order_first[1] < order_first[2]
-    assert order_first[1] < order_first[4]
-    assert order_first[3] < order_first[0]
-    assert order_first[3] < order_first[2]
-    assert order_first[3] < order_first[4]
+    # The first two entries in the draw sequence should be the NaN points
+    assert set(order_first[:2]) == nan_indices
 
 
 def test_order_via_constructor(df: pd.DataFrame):


### PR DESCRIPTION
This PR adds the ability to adjust the draw order of points

## Description

### What was changed in this PR?

Added a new method `order()`:

```py
scatter.order(by='price')
scatter.order(by='price', direction='desc', na_values='first')
scatter.order(by='cluster', map=['A', 'C', 'B'])
scatter.order(by=[2, 0, 1, 4, 3])
scatter.order(by=None)
```

### Example

https://github.com/user-attachments/assets/f3b317cb-0f0f-424d-a86b-38f792722634

### Why is this PR necessary?

Fixes #190 

## Checklist

- [x] Provided a concise title as a [semantic commit message](https://www.conventionalcommits.org) (e.g. "fix: correctly handle undefined properties")
- [x] `CHANGELOG.md` updated
- [x] Tests added or updated
- [x] Documentation in `README.md` added or updated
- [x] Example(s) added or updated
- [x] Screenshot, gif, or video attached for visual changes
