### PR TITLE
chore: signal basic Python 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v6
@@ -41,10 +41,22 @@ jobs:
           version: "0.8.x"
 
       - name: Run tests with all dependencies
+        if: matrix.python-version != '3.14'
         run: |
           uv venv --clear
           source .venv/bin/activate
           uv pip install -e ".[all]"
+          uv pip install pytest pytest-cov polars
+          pytest . --color=yes
+        env:
+          UV_PYTHON: ${{ matrix.python-version }}
+
+      - name: Run tests without label placement (Python 3.14)
+        if: matrix.python-version == '3.14'
+        run: |
+          uv venv --clear
+          source .venv/bin/activate
+          uv pip install -e ".[annotation-extras]"
           uv pip install pytest pytest-cov polars
           pytest . --color=yes
         env:
@@ -61,6 +73,7 @@ jobs:
           UV_PYTHON: ${{ matrix.python-version }}
 
       - name: Run tests with default and label-extras dependencies only
+        if: matrix.python-version != '3.14'
         run: |
           uv venv --clear
           source .venv/bin/activate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 ## v1.0.0
 
+
 - Feat: add `order()` for determining the draw order of points ([#190](https://github.com/flekschas/jupyter-scatter/issues/190) via [#237](https://github.com/flekschas/jupyter-scatter/pull/237))
 - Feat: use categorical color encoding in histogram bars ([#97](https://github.com/flekschas/jupyter-scatter/issues/97))
 - Refactor: move toolbar UI from Python ipywidgets to TS React. This enables full Marimo support 🎉
 - Chore: add `straight` option to connect() for straight line connections ([#130](https://github.com/flekschas/jupyter-scatter/pull/130))
+- Chore: verify Python 3.14 support (label placement not yet available due to `geoindex-rs` lacking 3.14 wheels)
 - Fix: Unused categories cause wrong colors/legend ([#189](https://github.com/flekschas/jupyter-scatter/issues/189) via [#233](https://github.com/flekschas/jupyter-scatter/pull/233))
 - Fix: Wrong coloring when switching color_by between categorical/continuous ([#191](https://github.com/flekschas/jupyter-scatter/issues/191) via [#233](https://github.com/flekschas/jupyter-scatter/pull/233))
 - Fix: Exception when updating data with changed categories ([#197](https://github.com/flekschas/jupyter-scatter/issues/197) via [#233](https://github.com/flekschas/jupyter-scatter/pull/233))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 ## v1.0.0
 
-
 - Feat: add `order()` for determining the draw order of points ([#190](https://github.com/flekschas/jupyter-scatter/issues/190) via [#237](https://github.com/flekschas/jupyter-scatter/pull/237))
 - Feat: use categorical color encoding in histogram bars ([#97](https://github.com/flekschas/jupyter-scatter/issues/97))
 - Refactor: move toolbar UI from Python ipywidgets to TS React. This enables full Marimo support 🎉

--- a/jscatter/label_placement/label_placement.py
+++ b/jscatter/label_placement/label_placement.py
@@ -12,12 +12,20 @@ import pandas as pd
 try:
     from geoindex_rs import kdtree, rtree
 except ImportError:
-    from geoindex_rs import KDTree as kdtree, RTree as rtree
+    try:
+        from geoindex_rs import KDTree as kdtree, RTree as rtree
+    except ImportError:
+        kdtree = None
+        rtree = None
 from matplotlib.colors import to_hex
 from scipy.spatial import ConvexHull
 from scipy.spatial._qhull import QhullError
 
-from ..dependencies import check_label_extras_dependencies, MissingCallable
+from ..dependencies import (
+    check_label_extras_dependencies,
+    DependencyError,
+    MissingCallable,
+)
 from ..font import Font
 from ..types import (
     AggregationMethod,
@@ -1252,6 +1260,14 @@ class LabelPlacement:
         pandas.DataFrame
             Computed labels ready for rendering
         """
+        # Check for geoindex-rs (unavailable on some Python versions)
+        if kdtree is None or rtree is None:
+            raise DependencyError(
+                "Label placement requires the 'geoindex-rs' package, which is "
+                'not available for your Python version. '
+                'Please use Python 3.9 - 3.13 for label placement support.'
+            )
+
         # Check for extra dependencies
         if show_progress or self._positioning == 'largest_cluster':
             check_label_extras_dependencies()

--- a/jscatter/label_placement/resolve_zoom_in_collisions.py
+++ b/jscatter/label_placement/resolve_zoom_in_collisions.py
@@ -9,7 +9,10 @@ import numpy.typing as npt
 try:
     from geoindex_rs import rtree
 except ImportError:
-    from geoindex_rs import RTree as rtree
+    try:
+        from geoindex_rs import RTree as rtree
+    except ImportError:
+        rtree = None
 
 from .constants import (
     NUM_LABELS_SOLVE_ZOOM_LEVELS_APPROXIMATELY,

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -17,6 +17,6 @@ pre-push:
   parallel: true
   commands:
     pytest:
-      run: uv run pytest
+      run: uv run --extra all pytest
     js-test:
       run: cd js && npm run test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
 ]
 keywords = [
   "scatter",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ keywords = [
 ]
 dependencies = [
   "anywidget>=0.9.0",
-  "geoindex-rs",
+  "geoindex-rs; python_version < '3.14'",
   "ipywidgets>=7.6,<9",
   "ipython",
   "matplotlib>=3.9",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+import pytest
+from importlib.util import find_spec
+
+geoindex_available = find_spec('geoindex_rs') is not None
+
+
+def pytest_collection_modifyitems(config, items):
+    if geoindex_available:
+        return
+    skip = pytest.mark.skip(reason='geoindex-rs not available')
+    for item in items:
+        if 'test_label_placement' in item.nodeid:
+            item.add_marker(skip)

--- a/tests/test_composite_annotations.py
+++ b/tests/test_composite_annotations.py
@@ -3,15 +3,14 @@ import matplotlib
 matplotlib.use('Agg')
 
 import pytest
-import seaborn as sns
-import sys
+
+sns = pytest.importorskip('seaborn')
 
 from jscatter.annotations import Line
 from jscatter.composite_annotations import Contour
 from jscatter.jscatter import Scatter
 
 
-@pytest.mark.skipif(sys.version_info < (3, 9), reason='requires at least Python v3.9')
 def test_contour():
     c = Contour()
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.9"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",

--- a/uv.lock
+++ b/uv.lock
@@ -1341,7 +1341,7 @@ name = "geoindex-rs"
 version = "0.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "arro3-core" },
+    { name = "arro3-core", marker = "python_full_version < '3.14'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/45/8ca54eb995f3af4feaafb6e0438021cffe294ee18803f75be12e50243391/geoindex_rs-0.2.1-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:d8ffe1cb3a8c47ca20a49eb5b37f1b61a21bafc2ea07833095061c5380578695", size = 2321411, upload-time = "2025-09-05T22:51:14.427Z" },
@@ -2030,7 +2030,7 @@ name = "jupyter-scatter"
 source = { editable = "." }
 dependencies = [
     { name = "anywidget" },
-    { name = "geoindex-rs" },
+    { name = "geoindex-rs", marker = "python_full_version < '3.14'" },
     { name = "ipython", version = "8.18.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "ipython", version = "8.38.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
     { name = "ipython", version = "9.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
@@ -2083,7 +2083,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "anywidget", specifier = ">=0.9.0" },
-    { name = "geoindex-rs" },
+    { name = "geoindex-rs", marker = "python_full_version < '3.14'" },
     { name = "hdbscan", marker = "extra == 'all'" },
     { name = "hdbscan", marker = "extra == 'label-extras'" },
     { name = "ipython" },


### PR DESCRIPTION
Non-functional changes to signal that Python v3.14 is support except for labeling.

## Description

### What was changed in this PR?

Made `geoindex-rs` optional on Python 3.14, added graceful error handling for label placement, and updated CI to test against 3.14.

### Why is this PR necessary?

To signal that Python v3.14 is supported in 95%

## Checklist

- [x] Provided a concise title as a [semantic commit message](https://www.conventionalcommits.org) (e.g. "fix: correctly handle undefined properties")
- [x] `CHANGELOG.md` updated
- [x] Tests added or updated
- [ ] Documentation in `README.md` added or updated
- [ ] Example(s) added or updated
- [ ] Screenshot, gif, or video attached for visual changes
