### PR TITLE
chore: Arrow PyCapsule cleanup

### DIFF
--- a/jscatter/jscatter.py
+++ b/jscatter/jscatter.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import Dict, List, Mapping, Optional, Tuple, Union, cast
+from typing import Dict, List, Mapping, Optional, Protocol, Tuple, Union, cast
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -19,6 +19,12 @@ from matplotlib.colors import (
 from .dataframe_utils import ensure_pandas
 
 from .annotations import HLine, Line, Rect, VLine
+
+
+class ArrowStreamExportable(Protocol):
+    def __arrow_c_stream__(self, requested_schema: object | None = None) -> object: ...
+
+
 from .color_maps import glasbey_dark, glasbey_light, gray_dark, gray_light, okabe_ito
 from .composite_annotations import CompositeAnnotation, Contour
 from .dependencies import check_label_extras_dependencies
@@ -268,7 +274,7 @@ class Scatter:
         self,
         x: Union[str, List[float], np.ndarray],
         y: Union[str, List[float], np.ndarray],
-        data=None,
+        data: Optional[Union[pd.DataFrame, ArrowStreamExportable]] = None,
         **kwargs,
     ):
         """
@@ -5567,7 +5573,7 @@ class Scatter:
 def plot(
     x: Union[str, List[float], np.ndarray],
     y: Union[str, List[float], np.ndarray],
-    data=None,
+    data: Optional[Union[pd.DataFrame, ArrowStreamExportable]] = None,
     **kwargs,
 ):
     """

--- a/jscatter/serializers/dataframe.py
+++ b/jscatter/serializers/dataframe.py
@@ -10,10 +10,10 @@ def df_to_arrow_ipc_buffer(df, obj=None, force_contiguous=True):
         return None
 
     # Convert to Arrow Table, supporting PyCapsule Interface (Polars, etc.)
-    if hasattr(df, '__arrow_c_stream__') and not isinstance(df, pd.DataFrame):
-        table = pa.RecordBatchReader.from_stream(df).read_all()
-    else:
+    if isinstance(df, pd.DataFrame):
         table = pa.Table.from_pandas(df)
+    else:
+        table = pa.table(df)
 
     # Create an in-memory buffer
     buf = io.BytesIO()


### PR DESCRIPTION
Use `pa.table()` for PyCapsule Interface conversion and add type hints for the `data` parameter.

## Description

### What was changed in this PR?

- Added an `ArrowStreamExportable` Protocol type hint to the `data` parameter of `Scatter.__init__()` and `plot()`, making it explicit that any object implementing the Arrow PyCapsule Interface (e.g., Polars, DuckDB) is accepted alongside `pd.DataFrame`
- Simplified PyCapsule Interface conversion in the serializer by using `pa.table()`, which natively handles `__arrow_c_stream__`, instead of manually checking for the attribute and using `RecordBatchReader.from_stream()`

### Why is this PR necessary?

- https://github.com/flekschas/jupyter-scatter/pull/236#discussion_r3219506087
- https://github.com/flekschas/jupyter-scatter/pull/236#discussion_r3219523230

## Checklist

- [x] Provided a concise title as a [semantic commit message](https://www.conventionalcommits.org) (e.g. "fix: correctly handle undefined properties")
- [ ] `CHANGELOG.md` updated
- [ ] Tests added or updated
- [ ] Documentation in `README.md` added or updated
- [ ] Example(s) added or updated
- [ ] Screenshot, gif, or video attached for visual changes
