### PR TITLE
fix: correct docstrings that do not match the code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Fix: docstrings of `height()`, `mouse()` and `to_parquet()` did not match the code ([#265](https://github.com/flekschas/jupyter-scatter/issues/265))
+
 ## v1.0.1
 
 - Fix: add missing `bundle.css` to wheel

--- a/jscatter/jscatter.py
+++ b/jscatter/jscatter.py
@@ -3742,7 +3742,7 @@ class Scatter:
 
         Parameters
         ----------
-        width : int, optional
+        height : int, optional
             The height of the scatter plot in pixel.
 
         Returns
@@ -3875,7 +3875,7 @@ class Scatter:
 
         Parameters
         ----------
-        show : 'panZoom', 'lasso' or 'rotate', optional
+        mode : 'panZoom', 'lasso' or 'rotate', optional
             The mouse mode. Currently, three modes are supported: pan & zoom,
             lasso selection, or rotating the scatter plot.
 

--- a/jscatter/label_placement/persistence.py
+++ b/jscatter/label_placement/persistence.py
@@ -19,8 +19,8 @@ def _get_path_prefix(path: str) -> str:
     ----------
         path : str
         Path to save data. Can be either:
-        - A directory path where files 'labels.parquet' and 'tiles.parquet' will be stored
-        - A path prefix where files '{prefix}-labels.parquet' and '{prefix}-tiles.parquet' will be stored
+        - A directory path, giving the prefix '<path>/label'
+        - A path prefix, giving the prefix '<path>-label'
 
     Returns
     -------
@@ -76,14 +76,11 @@ def to_parquet(
         Label placement object to export
     path : str
         Path to save data. Can be either:
-        - A directory path where files 'labels.parquet' and 'tiles.parquet' will be stored
-        - A path prefix where files '{prefix}-labels.parquet' and '{prefix}-tiles.parquet' will be stored
-    format : PersistenceFormat, default=PersistenceFormat.PARQUET
-        Format to use for persistence
-    use_prefix : bool, optional
-        If True, treat path as a prefix for output files.
-        If False, treat path as a directory.
-        If None (default), automatically detect based on whether path exists as a directory.
+        - A directory path where files 'label-data.parquet' and 'label-tiles.parquet' will be stored
+        - A path prefix where files '{prefix}-label-data.parquet' and '{prefix}-label-tiles.parquet' will be stored
+    format : PersistenceFormat, default='parquet'
+        Format to use for persistence. With 'arrow_ipc' the files are written
+        with an '.arrow' extension instead.
     """
 
     import pyarrow as pa


### PR DESCRIPTION
Corrects three docstrings that describe something other than what the code does.

## Description

### What was changed in this PR?

**`Scatter.height()`** documented its parameter as `width` — a copy-paste from `width()` above it. The description was already right, only the name was wrong.

**`Scatter.mouse()`** documented `show` (the parameter name of `reticle()`) for an argument called `mode`. The Returns section eight lines below already said "If no mode is provided", so the block contradicted itself.

**`to_parquet()`** promised

```
- A directory path where files 'labels.parquet' and 'tiles.parquet' will be stored
- A path prefix where files '{prefix}-labels.parquet' and '{prefix}-tiles.parquet' will be stored
```

but `_get_path_prefix` returns `f'{path}/label'` or `f'{path}-label'`, and the writer appends `-data.{ext}` / `-tiles.{ext}`, so the files are actually `label-data.parquet` / `label-tiles.parquet` and `{prefix}-label-data.parquet` / `{prefix}-label-tiles.parquet`. `from_parquet` right below already documents those names correctly, so the two halves of the same round trip disagreed. This PR takes `from_parquet`'s wording.

The same block documented a `use_prefix : bool, optional` parameter that does not exist — the mode is detected inside `_get_path_prefix` — and gave the default of `format` as `PersistenceFormat.PARQUET`, although `PersistenceFormat` is `Literal['parquet', 'arrow_ipc']` and has no such attribute; the real default is `'parquet'`. Both are fixed, and the `'arrow_ipc'` extension is mentioned since it changes the file names too.

The identical wrong path description in `_get_path_prefix`'s own docstring is rewritten to describe what that helper actually returns, which is a prefix, not a pair of files.

Docstrings only — no behaviour change.

### Why is this PR necessary?

Fixes #265

## Checklist

- [x] Provided a concise title as a [semantic commit message](https://www.conventionalcommits.org)
- [x] `CHANGELOG.md` updated
