### PR TITLE
fix: correct docstring parameters in the label placement module

### DIFF
--- a/jscatter/label_placement/optimize_line_breaks.py
+++ b/jscatter/label_placement/optimize_line_breaks.py
@@ -21,14 +21,16 @@ def optimize_line_breaks(
     ----------
     text : str
         The label text
-    label_type : str
-        The type of the label (used to look up font info)
-    label_value : str
-        The value of the label (used to look up font info)
+    text_measurer : Text
+        Measurer used to determine the rendered width of the text
+    font_size : int
+        The font size the text is rendered at
     target_aspect_ratio : float
         The target aspect ratio to optimize for
     max_lines : Optional[int]
         The maximum number of lines
+    word_break_lookahead : int
+        How many following words to consider when deciding where to break
 
     Notes
     -----

--- a/jscatter/label_placement/resolve_zoom_in_collisions.py
+++ b/jscatter/label_placement/resolve_zoom_in_collisions.py
@@ -52,9 +52,18 @@ def resolve_static_zoom_in_collisions(
 
     Parameters
     ----------
-    labels : pandas.DataFrame
-        Label data with coordinates and dimensions
-    spatial_idx : Spatial index for collision detection
+    spatial_index : Any
+        Spatial index used for collision detection
+    center_xs, center_ys : numpy.ndarray
+        Label centers
+    half_widths, half_heights : numpy.ndarray
+        Half extents of each label
+    min_xs, min_ys, max_xs, max_ys : numpy.ndarray
+        Bounding box of each label
+    zoom_ins, zoom_outs : numpy.ndarray
+        Zoom levels at which each label appears and disappears
+    idxs : numpy.ndarray
+        Label indices in priority order
     progress_bar : tqdm.tqdm, optional
         Progress bar for tracking computation
 
@@ -164,9 +173,18 @@ def resolve_asinh_zoom_in_collisions(
 
     Parameters
     ----------
-    labels : pandas.DataFrame
-        Label data with coordinates and dimensions
-    spatial_idx : Spatial index for collision detection
+    spatial_index : Any
+        Spatial index used for collision detection
+    center_xs, center_ys : numpy.ndarray
+        Label centers
+    half_widths, half_heights : numpy.ndarray
+        Half extents of each label
+    min_xs, min_ys, max_xs, max_ys : numpy.ndarray
+        Bounding box of each label
+    zoom_ins, zoom_outs : numpy.ndarray
+        Zoom levels at which each label appears and disappears
+    idxs : numpy.ndarray
+        Label indices in priority order
     progress_bar : tqdm.tqdm, optional
         Progress bar for tracking computation
 

--- a/jscatter/label_placement/utils.py
+++ b/jscatter/label_placement/utils.py
@@ -222,9 +222,9 @@ def map_property(
         All unique labels
     value : T
         The value(s) to assign
-    default_values : T
-        Default values to use if not specified
-    current : Dict[str, T]
+    default_value : T
+        Default value to use if not specified
+    current_value : Dict[str, T]
         The current mapped property. If None, the return value will be
         initialized
 


### PR DESCRIPTION
Same kind of thing as #266, in `label_placement/`. Three docstrings describe an earlier version of their function, so `help()` and editor tooltips show arguments that raise `TypeError` if passed.

### `optimize_line_breaks`

Documents `label_type` and `label_value`, described as "used to look up font info". The function takes a `text_measurer` and a `font_size` instead, so the lookup moved out of it at some point. Those two, plus `word_break_lookahead`, were undocumented.

### `resolve_static_zoom_in_collisions` and `resolve_asinh_zoom_in_collisions`

Both document:

```
labels : pandas.DataFrame
    Label data with coordinates and dimensions
spatial_idx : Spatial index for collision detection
```

The signature has neither. The frame was split into thirteen arrays (`center_xs`, `half_widths`, `min_xs`, `zoom_ins`, `idxs` and so on) and the docstring stayed as it was. Rewrote the section to describe what is actually taken, grouping the coordinate arrays so it stays readable.

### `map_property`

`default_values` -> `default_value`, `current` -> `current_value`.

### Checks

Docstrings only. The sweep reported 8 before and 3 after, and those 3 are `height`, `mouse` and `to_parquet`, which are already fixed in #266 and waiting on that merge.

Branched off `main` rather than off #266, so the two do not overlap and either can go first.